### PR TITLE
Expose Shard Details

### DIFF
--- a/cluster-http/src/main/scala/akka/cluster/http/management/ClusterHttpManagement.scala
+++ b/cluster-http/src/main/scala/akka/cluster/http/management/ClusterHttpManagement.scala
@@ -136,7 +136,7 @@ object ClusterHttpManagementRoutes extends ClusterHttpManagementHelper {
     get {
       extractExecutionContext { implicit executor =>
         complete {
-          implicit val timeout = Timeout(1.second)
+          implicit val timeout = Timeout(5.seconds)
           try {
             ClusterSharding(cluster.system)
               .shardRegion(shardRegionName)
@@ -173,7 +173,7 @@ object ClusterHttpManagementRoutes extends ClusterHttpManagementHelper {
         } ~
         routesMember(cluster)
       } ~
-      pathPrefix("shard_regions" / Remaining) { shardRegionName =>
+      pathPrefix("shards" / Remaining) { shardRegionName =>
         pathEnd {
           routeGetShardInfo(cluster, shardRegionName)
         }

--- a/cluster-http/src/main/scala/akka/cluster/http/management/ClusterHttpManagement.scala
+++ b/cluster-http/src/main/scala/akka/cluster/http/management/ClusterHttpManagement.scala
@@ -129,7 +129,7 @@ object ClusterHttpManagementRoutes extends ClusterHttpManagementHelper {
    * [[akka.cluster.Cluster]] instance. This version does not provide Basic Authentication. It uses
    * the default path "members".
    */
-  def apply(cluster: Cluster): Route = apply(cluster, "members")
+  def apply(cluster: Cluster): Route = apply(cluster, "")
 
   /**
    * Creates an instance of [[akka.cluster.http.management.ClusterHttpManagementRoutes]] to manage the specified
@@ -137,11 +137,13 @@ object ClusterHttpManagementRoutes extends ClusterHttpManagementHelper {
    * the specified path `pathPrefixName`.
    */
   def apply(cluster: Cluster, pathPrefixName: String): Route =
-    pathPrefix(pathPrefixName) {
-      pathEndOrSingleSlash {
-        routeGetMembers(cluster) ~ routePostMembers(cluster)
-      } ~
-      routesMember(cluster)
+    rawPathPrefix(pathPrefixName) {
+      pathPrefix("members") {
+        pathEndOrSingleSlash {
+          routeGetMembers(cluster) ~ routePostMembers(cluster)
+        } ~
+        routesMember(cluster)
+      }
     }
 
   /**

--- a/cluster-http/src/main/scala/akka/cluster/http/management/ClusterHttpManagement.scala
+++ b/cluster-http/src/main/scala/akka/cluster/http/management/ClusterHttpManagement.scala
@@ -7,16 +7,20 @@ import java.util.concurrent.atomic.AtomicReference
 
 import akka.Done
 import akka.actor.AddressFromURIString
+import akka.cluster.sharding.{ ClusterSharding, ShardRegion }
 import akka.cluster.{ Cluster, Member, MemberStatus }
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.{ Route, RouteResult }
 import akka.http.scaladsl.{ ConnectionContext, Http }
+import akka.pattern.ask
 import akka.stream.ActorMaterializer
+import akka.util.Timeout
 import spray.json.DefaultJsonProtocol
 
 import scala.concurrent.{ Future, Promise }
+import scala.concurrent.duration._
 
 final case class ClusterUnreachableMember(node: String, observedBy: Seq[String])
 final case class ClusterMember(node: String, nodeUid: String, status: String, roles: Set[String])
@@ -26,6 +30,8 @@ final case class ClusterMembers(selfNode: String,
                                 leader: Option[String],
                                 oldest: Option[String])
 final case class ClusterHttpManagementMessage(message: String)
+final case class ShardRegionInfo(shardId: String, numEntities: Int)
+final case class ShardDetails(regions: Seq[ShardRegionInfo])
 
 private[akka] sealed trait ClusterHttpManagementOperation
 private[akka] case object Down extends ClusterHttpManagementOperation
@@ -42,6 +48,8 @@ trait ClusterHttpManagementJsonProtocol extends SprayJsonSupport with DefaultJso
   implicit val clusterMemberFormat = jsonFormat4(ClusterMember)
   implicit val clusterMembersFormat = jsonFormat5(ClusterMembers)
   implicit val clusterMemberMessageFormat = jsonFormat1(ClusterHttpManagementMessage)
+  implicit val shardRegionInfoFormat = jsonFormat2(ShardRegionInfo)
+  implicit val shardDetailsFormat = jsonFormat1(ShardDetails)
 }
 
 trait ClusterHttpManagementHelper extends ClusterHttpManagementJsonProtocol {
@@ -124,6 +132,27 @@ object ClusterHttpManagementRoutes extends ClusterHttpManagementHelper {
       }
     }
 
+  private def routeGetShardInfo(cluster: Cluster, shardRegionName: String) =
+    get {
+      extractExecutionContext { implicit executor =>
+        complete {
+          implicit val timeout = Timeout(1.second)
+          try {
+            ClusterSharding(cluster.system)
+              .shardRegion(shardRegionName)
+              .ask(ShardRegion.GetShardRegionStats)
+              .mapTo[ShardRegion.ShardRegionStats]
+              .map { shardRegionStats =>
+                ShardDetails(shardRegionStats.stats.map(s => ShardRegionInfo(s._1, s._2)).toSeq)
+              }
+          } catch {
+            case _: IllegalArgumentException =>
+              StatusCodes.NotFound → ClusterHttpManagementMessage(s"Shard Region $shardRegionName is not started")
+          }
+        }
+      }
+    }
+
   /**
    * Creates an instance of [[akka.cluster.http.management.ClusterHttpManagementRoutes]] to manage the specified
    * [[akka.cluster.Cluster]] instance. This version does not provide Basic Authentication. It uses
@@ -143,6 +172,11 @@ object ClusterHttpManagementRoutes extends ClusterHttpManagementHelper {
           routeGetMembers(cluster) ~ routePostMembers(cluster)
         } ~
         routesMember(cluster)
+      } ~
+      pathPrefix("shard_regions" / Remaining) { shardRegionName =>
+        pathEnd {
+          routeGetShardInfo(cluster, shardRegionName)
+        }
       }
     }
 

--- a/cluster-http/src/test/scala/akka/cluster/http/management/ClusterHttpManagementRoutesSpec.scala
+++ b/cluster-http/src/test/scala/akka/cluster/http/management/ClusterHttpManagementRoutesSpec.scala
@@ -332,7 +332,7 @@ class ClusterHttpManagementRoutesSpec
         clusterHttpManagement.start()
 
         val responseGetShardDetailsFuture = Http().singleRequest(
-          HttpRequest(uri = s"http://127.0.0.1:20100/shard_regions/$name")
+          HttpRequest(uri = s"http://127.0.0.1:20100/shards/$name")
         )
         val responseGetShardDetails = Await.result(responseGetShardDetailsFuture, 1.second)
         responseGetShardDetails.entity.getContentType shouldEqual ContentTypes.`application/json`
@@ -344,7 +344,7 @@ class ClusterHttpManagementRoutesSpec
         unmarshaledGetShardDetails shouldEqual ShardDetails(Seq(ShardRegionInfo("ShardId", 1)))
 
         val responseInvalidGetShardDetailsFuture = Http().singleRequest(
-          HttpRequest(uri = s"http://127.0.0.1:20100/shard_regions/ThisShardRegionDoesNotExist")
+          HttpRequest(uri = s"http://127.0.0.1:20100/shards/ThisShardRegionDoesNotExist")
         )
         val responseInvalidGetShardDetails = Await.result(responseInvalidGetShardDetailsFuture, 1.second)
         responseInvalidGetShardDetails.entity.getContentType shouldEqual ContentTypes.`application/json`

--- a/cluster-http/src/test/scala/akka/cluster/http/management/ClusterHttpManagementRoutesSpec.scala
+++ b/cluster-http/src/test/scala/akka/cluster/http/management/ClusterHttpManagementRoutesSpec.scala
@@ -3,18 +3,29 @@
  */
 package akka.cluster.http.management
 
-import akka.actor.Address
+import akka.actor.{ Actor, ActorSystem, Address, ExtendedActorSystem, Props }
 import akka.cluster.ClusterEvent.CurrentClusterState
 import akka.cluster.MemberStatus.Joining
 import akka.cluster.MemberStatus.Up
 import akka.cluster._
-import akka.http.scaladsl.model.{ FormData, StatusCodes }
+import akka.cluster.sharding.{ ClusterSharding, ClusterShardingSettings, ShardRegion }
+import akka.http.scaladsl.model.{ ContentTypes, FormData, HttpRequest, StatusCodes }
 import akka.http.scaladsl.testkit.ScalatestRouteTest
+import akka.pattern.ask
+import akka.util.Timeout
+import com.typesafe.config.ConfigFactory
 import org.mockito.Mockito._
 import org.mockito.Matchers._
 import org.scalatest.{ Matchers, WordSpecLike }
 
+import scala.concurrent.duration._
 import scala.collection.immutable._
+import ClusterHttpManagementRoutesSpec._
+import akka.cluster.InternalClusterAction.LeaderActionsTick
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.unmarshalling.Unmarshal
+
+import scala.concurrent.Await
 
 class ClusterHttpManagementRoutesSpec
     extends WordSpecLike
@@ -275,5 +286,91 @@ class ClusterHttpManagementRoutesSpec
         }
       }
     }
+
+    "return shard region details" when {
+
+      "calling GET /shard_regions/{name}" in {
+        val config = ConfigFactory.parseString(
+          """
+            |akka.cluster {
+            |  auto-down-unreachable-after = 0s
+            |  periodic-tasks-initial-delay = 120 seconds // turn off scheduled tasks
+            |  publish-stats-interval = 0 s # always, when it happens
+            |  failure-detector.implementation-class = akka.cluster.FailureDetectorPuppet
+            |  sharding.state-store-mode = ddata
+            |}
+            |akka.actor.provider = "cluster"
+            |akka.remote.log-remote-lifecycle-events = off
+            |akka.remote.netty.tcp.port = 0
+          """.stripMargin
+        )
+        val configClusterHttpManager = ConfigFactory.parseString(
+          """
+            |akka.cluster.http.management.hostname = "127.0.0.1"
+            |akka.cluster.http.management.port = 20100
+          """.stripMargin
+        )
+
+        implicit val system = ActorSystem("test", config.withFallback(configClusterHttpManager))
+        val cluster = Cluster(system)
+        val selfAddress = system.asInstanceOf[ExtendedActorSystem].provider.getDefaultAddress
+        cluster.join(selfAddress)
+        cluster.clusterCore ! LeaderActionsTick
+
+        val name = "TestShardRegion"
+        val shardRegion = ClusterSharding(system).start(
+          name,
+          TestShardedActor.props,
+          ClusterShardingSettings(system),
+          TestShardedActor.extractEntityId,
+          TestShardedActor.extractShardId
+        )
+        val initializeEntityActorAsk = shardRegion.ask("hello")(Timeout(3.seconds)).mapTo[String]
+        Await.result(initializeEntityActorAsk, 3.seconds)
+
+        val clusterHttpManagement = ClusterHttpManagement(cluster)
+        clusterHttpManagement.start()
+
+        val responseGetShardDetailsFuture = Http().singleRequest(
+          HttpRequest(uri = s"http://127.0.0.1:20100/shard_regions/$name")
+        )
+        val responseGetShardDetails = Await.result(responseGetShardDetailsFuture, 1.second)
+        responseGetShardDetails.entity.getContentType shouldEqual ContentTypes.`application/json`
+        responseGetShardDetails.status shouldEqual StatusCodes.OK
+        val unmarshaledGetShardDetails = Await.result(
+          Unmarshal(responseGetShardDetails.entity).to[ShardDetails],
+          1.second
+        )
+        unmarshaledGetShardDetails shouldEqual ShardDetails(Seq(ShardRegionInfo("ShardId", 1)))
+
+        val responseInvalidGetShardDetailsFuture = Http().singleRequest(
+          HttpRequest(uri = s"http://127.0.0.1:20100/shard_regions/ThisShardRegionDoesNotExist")
+        )
+        val responseInvalidGetShardDetails = Await.result(responseInvalidGetShardDetailsFuture, 1.second)
+        responseInvalidGetShardDetails.entity.getContentType shouldEqual ContentTypes.`application/json`
+        responseInvalidGetShardDetails.status shouldEqual StatusCodes.NotFound
+
+        val bindingFuture = clusterHttpManagement.stop()
+        Await.ready(bindingFuture, 5.seconds)
+        system.terminate()
+      }
+    }
   }
+}
+
+object ClusterHttpManagementRoutesSpec {
+
+  object TestShardedActor {
+    def props: Props = Props(classOf[TestShardedActor])
+    def extractShardId: ShardRegion.ExtractShardId = _ => "ShardId"
+    def extractEntityId: ShardRegion.ExtractEntityId = {
+      case m: Any => ("1", m)
+    }
+  }
+  class TestShardedActor() extends Actor {
+    def receive: Receive = {
+      case "hello" => sender() ! "world"
+    }
+  }
+
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,7 @@ object Dependencies {
   val ClusterHttp = Seq(
     libraryDependencies ++= Seq(
       "com.typesafe.akka" %% "akka-cluster"                       % AkkaVersion,
-      "com.typesafe.akka" %% "akka-cluster-sharding"              % AkkaVersion    % "provided",
+      "com.typesafe.akka" %% "akka-cluster-sharding"              % AkkaVersion,
       "com.typesafe.akka" %% "akka-http"                          % AkkaHttpVersion,
       "com.typesafe.akka" %% "akka-http-spray-json"               % AkkaHttpVersion,
       "io.spray"          %% "spray-json"                         % "1.3.2",                  // ApacheV2

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,14 +14,15 @@ object Dependencies {
 
   val ClusterHttp = Seq(
     libraryDependencies ++= Seq(
-      "com.typesafe.akka" %% "akka-cluster"                      % AkkaVersion,
-      "com.typesafe.akka" %% "akka-cluster-sharding"             % AkkaVersion    % "provided",
-      "com.typesafe.akka" %% "akka-http"                         % AkkaHttpVersion,
-      "com.typesafe.akka" %% "akka-http-spray-json"              % AkkaHttpVersion,
-      "io.spray"          %% "spray-json"                        % "1.3.2",                  // ApacheV2
-      "com.typesafe.akka" %% "akka-http-testkit"                 % AkkaHttpVersion % "test",
-      "junit"             % "junit"                              % junitVersion    % "test",
-      "org.mockito"       % "mockito-all"                        % "1.10.19"       % "test"  // Common Public License 1.0
+      "com.typesafe.akka" %% "akka-cluster"                       % AkkaVersion,
+      "com.typesafe.akka" %% "akka-cluster-sharding"              % AkkaVersion    % "provided",
+      "com.typesafe.akka" %% "akka-http"                          % AkkaHttpVersion,
+      "com.typesafe.akka" %% "akka-http-spray-json"               % AkkaHttpVersion,
+      "io.spray"          %% "spray-json"                         % "1.3.2",                  // ApacheV2
+      "com.typesafe.akka" %% "akka-distributed-data-experimental" % AkkaVersion     % "test",
+      "com.typesafe.akka" %% "akka-http-testkit"                  % AkkaHttpVersion % "test",
+      "junit"             % "junit"                               % junitVersion    % "test",
+      "org.mockito"       % "mockito-all"                         % "1.10.19"       % "test"  // Common Public License 1.0
     )
   )
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,6 +15,7 @@ object Dependencies {
   val ClusterHttp = Seq(
     libraryDependencies ++= Seq(
       "com.typesafe.akka" %% "akka-cluster"                      % AkkaVersion,
+      "com.typesafe.akka" %% "akka-cluster-sharding"             % AkkaVersion    % "provided",
       "com.typesafe.akka" %% "akka-http"                         % AkkaHttpVersion,
       "com.typesafe.akka" %% "akka-http-spray-json"              % AkkaHttpVersion,
       "io.spray"          %% "spray-json"                        % "1.3.2",                  // ApacheV2


### PR DESCRIPTION
Fixes https://github.com/akka/akka-management/issues/14

This PR exposes the `GET /shards/{name}` path, which returns the following data:
```
{
  regions: [
    {
      "shardId": // shard id [string]
      "numEntities": // number of entities in the shard [int]
    },
    ...
  ]
]
```

At eero, we use this information in the following ways
* monitoring: check the health of an akka cluster instance (example: did it lose shards all of a sudden?)
* deploys: after deploying new code to an akka cluster instance, we wait for it to attain shards before deploying the next instance

One change to note is that commit e7ff9c7 changes how the `prefix` works. Before, `prefix` would override the `members` path. Now, if `prefix` is set, it will be a prefix to `members` and `shard_regions`