### PR TITLE
Updated spray-json library dependency from 1.3.2 to 1.3.3

### DIFF
--- a/cluster-http/src/test/scala/akka/cluster/http/management/ClusterHttpManagementSpec.scala
+++ b/cluster-http/src/test/scala/akka/cluster/http/management/ClusterHttpManagementSpec.scala
@@ -67,7 +67,7 @@ class ClusterHttpManagementSpec
         implicit val materializer = ActorMaterializer()
 
         val responseGetMembersFuture = Http().singleRequest(HttpRequest(uri = "http://127.0.0.1:19999/members"))
-        val responseGetMembers = Await.result(responseGetMembersFuture, 5 seconds)
+        val responseGetMembers = Await.result(responseGetMembersFuture, 5.seconds)
 
         Unmarshal(responseGetMembers.entity).to[ClusterMembers].onSuccess {
           case clusterMembers: ClusterMembers ⇒
@@ -78,7 +78,7 @@ class ClusterHttpManagementSpec
         responseGetMembers.status shouldEqual StatusCodes.OK
 
         val bindingFuture = clusterHttpManagement.stop()
-        Await.ready(bindingFuture, 5 seconds)
+        Await.ready(bindingFuture, 5.seconds)
         system.terminate()
       }
 
@@ -117,7 +117,7 @@ class ClusterHttpManagementSpec
         val httpRequest = HttpRequest(uri = "http://127.0.0.1:20000/members").addHeader(
             Authorization(BasicHttpCredentials("user", "p4ssw0rd")))
         val responseGetMembersFuture = Http().singleRequest(httpRequest)
-        val responseGetMembers = Await.result(responseGetMembersFuture, 5 seconds)
+        val responseGetMembers = Await.result(responseGetMembersFuture, 5.seconds)
 
         Unmarshal(responseGetMembers.entity).to[ClusterMembers].onSuccess {
           case clusterMembers: ClusterMembers ⇒
@@ -127,7 +127,7 @@ class ClusterHttpManagementSpec
         responseGetMembers.status shouldEqual StatusCodes.OK
 
         val bindingFuture = clusterHttpManagement.stop()
-        Await.ready(bindingFuture, 5 seconds)
+        Await.ready(bindingFuture, 5.seconds)
         system.terminate()
       }
 
@@ -179,7 +179,7 @@ class ClusterHttpManagementSpec
 
         val httpRequest = HttpRequest(uri = "https://127.0.0.1:20001/members")
         val responseGetMembersFuture = Http().singleRequest(httpRequest, connectionContext = https)
-        val responseGetMembers = Await.result(responseGetMembersFuture, 5 seconds)
+        val responseGetMembers = Await.result(responseGetMembersFuture, 5.seconds)
 
         Unmarshal(responseGetMembers.entity).to[ClusterMembers].onSuccess {
           case clusterMembers: ClusterMembers ⇒
@@ -189,7 +189,7 @@ class ClusterHttpManagementSpec
         responseGetMembers.status shouldEqual StatusCodes.OK
 
         val bindingFuture = clusterHttpManagement.stop()
-        Await.ready(bindingFuture, 5 seconds)
+        Await.ready(bindingFuture, 5.seconds)
         system.terminate()
       }
     }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
       "com.typesafe.akka" %% "akka-cluster-sharding"              % AkkaVersion,
       "com.typesafe.akka" %% "akka-http"                          % AkkaHttpVersion,
       "com.typesafe.akka" %% "akka-http-spray-json"               % AkkaHttpVersion,
-      "io.spray"          %% "spray-json"                         % "1.3.2",                  // ApacheV2
+      "io.spray"          %% "spray-json"                         % "1.3.3",                  // ApacheV2
       "com.typesafe.akka" %% "akka-distributed-data-experimental" % AkkaVersion     % "test",
       "com.typesafe.akka" %% "akka-http-testkit"                  % AkkaHttpVersion % "test",
       "junit"             % "junit"                               % junitVersion    % "test",


### PR DESCRIPTION
Also removed warnings generated while compiling **ClusterHttpManagementSpec.scala**

**Here's an example:**
Warning:(192, 38) postfix operator seconds should be enabled
by making the implicit value scala.language.postfixOps visible.
This can be achieved by adding the import clause 'import scala.language.postfixOps'
or by setting the compiler option -language:postfixOps.
See the Scaladoc for value scala.language.postfixOps for a discussion
why the feature should be explicitly enabled.
        Await.ready(bindingFuture, 5 seconds)