### PR TITLE
Bug fixes

### DIFF
--- a/cluster-http/src/main/resources/reference.conf
+++ b/cluster-http/src/main/resources/reference.conf
@@ -78,6 +78,9 @@ akka.cluster.bootstrap {
     # coordinating process may decide to join itself, or keep waiting for discovering of a seed node.
     no-seeds-stable-margin = 10 seconds
 
+    # Probe will be failed if it doesn't return in this amount of time
+    probe-timeout = 1 second
+
     # Interval at which contact points should be polled
     # the effective interval used is this value plus the same value multiplied by the jitter value
     probe-interval = 1 second

--- a/cluster-http/src/main/scala/akka/cluster/bootstrap/ClusterBootstrapSettings.scala
+++ b/cluster-http/src/main/scala/akka/cluster/bootstrap/ClusterBootstrapSettings.scala
@@ -73,6 +73,9 @@ final class ClusterBootstrapSettings(config: Config) {
     val probeIntervalJitter: Double =
       contactPointConfig.getDouble("probe-interval-jitter")
 
+    val probeTimeout: FiniteDuration =
+      contactPointConfig.getDuration("probe-timeout", TimeUnit.MILLISECONDS).millis
+
     val httpMaxSeedNodesToExpose: Int = 5
   }
 

--- a/cluster-http/src/main/scala/akka/cluster/bootstrap/dns/HeadlessServiceDnsBootstrap.scala
+++ b/cluster-http/src/main/scala/akka/cluster/bootstrap/dns/HeadlessServiceDnsBootstrap.scala
@@ -54,7 +54,8 @@ private[bootstrap] object HeadlessServiceDnsBootstrap {
     def selfAddressIfAbleToJoinItself(system: ActorSystem): Option[Address] = {
       val cluster = Cluster(system)
       val selfHost = cluster.selfAddress.host
-      if (lowestAddressContactPoint.contains(selfHost.get)) {
+
+      if (lowestAddressContactPoint.exists(p => selfHost.contains(p.host))) {
         // we are the "lowest address" and should join ourselves to initiate a new cluster
         Some(cluster.selfAddress)
       } else None

--- a/cluster-http/src/main/scala/akka/cluster/http/management/ClusterHttpManagement.scala
+++ b/cluster-http/src/main/scala/akka/cluster/http/management/ClusterHttpManagement.scala
@@ -390,6 +390,7 @@ class ClusterHttpManagement(
       // TODO instead of binding to hardcoded things here, discovery can also be used for this binding!
       val hostname = settings.ClusterHttpManagementHostname
       val port = settings.ClusterHttpManagementPort
+
       // Basically: "give me the SRV host/port for the port called `akka-bootstrap`"
       // discovery.lookup("_akka-bootstrap" + ".effective-name.default").find(myaddress)
       // ----


### PR DESCRIPTION
Thanks again for getting this done, we really appreciate it. I've begun integration with `reactive-lib` and was able to get a working implementation with the changes in this PR.

1) Fix bug `selfAddressIfAbleToJoinItself` would always return `None` since it was comparing unrelated types
2) Ensure that probe is retried when HTTP request fails

Also, just to note, we're not using the supplied `DnsSrvServiceDiscovery` but instead are providing our own implementation, but I did notice that `DnsSrvServiceDiscovery` cannot be instantiated because it takes an `effectiveConfig` and the reflection code is only passing it a single argument (`system`)