### PR TITLE
Fix mispelled effective-name key

### DIFF
--- a/cluster-http/src/main/resources/reference.conf
+++ b/cluster-http/src/main/resources/reference.conf
@@ -42,7 +42,7 @@ akka.cluster.bootstrap {
 
     # The effective service name is the exact string that will be used to perform service discovery
     # usually, this means the service-name being suffixed with an additional namespace (e.g. "name.default"
-    effective-service-name = null
+    effective-name = null
 
     # Config path of discovery method to be used to locate the initial contact points.
     # It must be a fully qualified config path to the discovery's config section.


### PR DESCRIPTION
Per https://github.com/akka/akka-management/blob/master/cluster-http/src/main/scala/akka/cluster/bootstrap/ClusterBootstrapSettings.scala#L35

should be `effective-name`, not `effective-service-name`