### PR TITLE
Update sbt-dynver

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.1")
 
 addSbtPlugin("de.heikoseeberger"                 % "sbt-header"       % "1.6.0")
 addSbtPlugin("com.geirsson"                      % "sbt-scalafmt"     % "0.4.10")
-addSbtPlugin("com.dwijnand"                      % "sbt-dynver"       % "1.1.1")
+addSbtPlugin("com.dwijnand"                      % "sbt-dynver"       % "2.0.0")
 addSbtPlugin("com.dwijnand"                      % "sbt-travisci"     % "1.0.0-M4")
 addSbtPlugin("com.lightbend.paradox"             % "sbt-paradox"      % "0.2.7")
 addSbtPlugin("com.eed3si9n"                      % "sbt-unidoc"       % "0.3.3")


### PR DESCRIPTION
To correctly populate `isSnapshot`, to make sure the proper whitesource
project name is generated