### PR TITLE
Adding client project and implementation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,13 +5,23 @@ lazy val `akka-management` = project
   .settings(unidocSettings)
   .enablePlugins(NoPublish)
   .disablePlugins(BintrayPlugin)
-  .aggregate(`cluster-http`, docs)
+  .aggregate(`cluster-http`, `cluster-http-client`, docs)
 
 lazy val `cluster-http` = project
   .in(file("cluster-http"))
   .enablePlugins(AutomateHeaderPlugin)
   .settings(
     name := "akka-management-cluster-http",
+    Dependencies.ClusterHttp,
+    resolvers += Resolver.bintrayRepo("hajile", "maven")
+  )
+
+lazy val `cluster-http-client` = project
+  .in(file("cluster-http-client"))
+  .enablePlugins(AutomateHeaderPlugin)
+    .dependsOn(`cluster-http`)
+  .settings(
+    name := "akka-management-cluster-http-client",
     Dependencies.ClusterHttp,
     resolvers += Resolver.bintrayRepo("hajile", "maven")
   )

--- a/cluster-http-client/src/main/scala/akka/cluster/http/management/client/ClusterManagementClient.scala
+++ b/cluster-http-client/src/main/scala/akka/cluster/http/management/client/ClusterManagementClient.scala
@@ -1,0 +1,40 @@
+package akka.cluster.http.management.client
+
+import akka.actor.ActorSystem
+import akka.cluster.http.management.{ClusterHttpManagementJsonProtocol, ClusterMember, ClusterMembers}
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.Uri.Path
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse, Uri}
+import akka.http.scaladsl.unmarshalling.Unmarshal
+import akka.stream.{ActorMaterializer, Materializer}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait ClusterManagementClient extends ClusterHttpManagementJsonProtocol {
+
+  type HttpResponder = HttpRequest => Future[HttpResponse]
+
+  def responder: HttpResponder
+
+  def baseUri: Uri
+
+  private[akka] implicit def system: ActorSystem
+
+  private[akka] implicit def materializer: Materializer
+
+  private[akka] implicit def ec: ExecutionContext
+
+  def getMembers(roles: String*): Future[Set[ClusterMember]] = {
+    val roleFilter: ClusterMember => Boolean = (m) => roles.isEmpty || roles.exists(m.roles.contains(_))
+    responder(HttpRequest(uri = baseUri.withPath(Path("/members"))))
+      .flatMap(r => Unmarshal(r.entity).to[ClusterMembers])
+      .map(c => c.members.filter(roleFilter))
+  }
+}
+
+class AkkaClusterManagementClient(val baseUri: Uri)(implicit val system: ActorSystem, val ec: ExecutionContext)
+  extends ClusterManagementClient {
+  override private[akka] implicit val materializer = ActorMaterializer()
+
+  override def responder = Http().singleRequest(_)
+}

--- a/cluster-http-client/src/main/scala/akka/cluster/http/management/client/ClusterManagementClient.scala
+++ b/cluster-http-client/src/main/scala/akka/cluster/http/management/client/ClusterManagementClient.scala
@@ -1,14 +1,17 @@
+/*
+ * Copyright (C) 2017 Lightbend Inc. <http://www.lightbend.com>
+ */
 package akka.cluster.http.management.client
 
 import akka.actor.ActorSystem
-import akka.cluster.http.management.{ClusterHttpManagementJsonProtocol, ClusterMember, ClusterMembers}
+import akka.cluster.http.management.{ ClusterHttpManagementJsonProtocol, ClusterMember, ClusterMembers }
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.Uri.Path
-import akka.http.scaladsl.model.{HttpRequest, HttpResponse, Uri}
+import akka.http.scaladsl.model.{ HttpRequest, HttpResponse, Uri }
 import akka.http.scaladsl.unmarshalling.Unmarshal
-import akka.stream.{ActorMaterializer, Materializer}
+import akka.stream.{ ActorMaterializer, Materializer }
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{ ExecutionContext, Future }
 
 trait ClusterManagementClient extends ClusterHttpManagementJsonProtocol {
 
@@ -33,7 +36,7 @@ trait ClusterManagementClient extends ClusterHttpManagementJsonProtocol {
 }
 
 class AkkaClusterManagementClient(val baseUri: Uri)(implicit val system: ActorSystem, val ec: ExecutionContext)
-  extends ClusterManagementClient {
+    extends ClusterManagementClient {
   override private[akka] implicit val materializer = ActorMaterializer()
 
   override def responder = Http().singleRequest(_)

--- a/cluster-http-client/src/test/scala/akka/cluster/http/management/client/ClusterManagementClientSpec.scala
+++ b/cluster-http-client/src/test/scala/akka/cluster/http/management/client/ClusterManagementClientSpec.scala
@@ -1,0 +1,84 @@
+package akka.cluster.http.management.client
+
+import akka.actor.ActorSystem
+import akka.cluster.http.management.ClusterMember
+import akka.http.scaladsl.model._
+import akka.stream.ActorMaterializer
+import akka.testkit.TestKit
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{FlatSpecLike, Matchers}
+
+import scala.concurrent.Future
+
+class ClusterManagementClientSpec extends TestKit(ActorSystem("akka-management"))
+  with Matchers with FlatSpecLike with ScalaFutures {
+
+  val response =
+    """
+      | {
+      | 	"selfNode": "akka.tcp://test@10.10.10.10:1111",
+      | 	"members": [{
+      | 		"node": "akka.tcp://test@10.10.10.10:1111",
+      | 		"nodeUid": "1116964444",
+      | 		"status": "Up",
+      | 		"roles": ["test","super"]
+      | 	},
+      |  {
+      | 		"node": "akka.tcp://test@10.10.10.10:1112",
+      | 		"nodeUid": "1116964443",
+      | 		"status": "Up",
+      | 		"roles": ["minion"]
+      | 	}],
+      | 	"unreachable": [],
+      | 	"leader": "akka.tcp://test@10.10.10.10:1111",
+      | 	"oldest": "akka.tcp://test@10.10.10.10:1111"
+      | }
+    """.stripMargin
+
+
+  "The ClusterManagementClient trait" should "look up members by role" in {
+    val client = new MockManagementClient(system, Seq(Uri("/members") -> response,
+      Uri("/members") -> response, Uri("/members") -> response, Uri("/members") -> response,
+      Uri("/members") -> response)) //one for each assertion
+
+    val member1 = ClusterMember("akka.tcp://test@10.10.10.10:1111", "1116964444", "Up", Set("test", "super"))
+    val member2 = ClusterMember("akka.tcp://test@10.10.10.10:1112", "1116964443", "Up", Set("minion"))
+
+    whenReady(client.getMembers())(r => r shouldBe Set(member1, member2))
+    whenReady(client.getMembers("test"))(r => r shouldBe Set(member1))
+    whenReady(client.getMembers("super"))(r => r shouldBe Set(member1))
+    whenReady(client.getMembers("minion"))(r => r shouldBe Set(member2))
+    whenReady(client.getMembers("test", "minion"))(r => r shouldBe Set(member1, member2))
+  }
+
+
+  "The AkkaClusterManagementClient" should "be properly configured" in {
+    val client = new AkkaClusterManagementClient("http://localhost:19999")(system, system.dispatcher)
+    client.materializer shouldBe an[ActorMaterializer]
+    client.responder shouldBe a[HttpRequest => Future[_]]
+  }
+
+}
+
+
+class MockManagementClient(val system: ActorSystem, reqRespPairs: Seq[(Uri, String)])
+  extends ClusterManagementClient with MockFactory {
+
+  val mock = mockFunction[HttpRequest, Future[HttpResponse]]
+
+  override val baseUri = Uri("")
+
+  override implicit val ec = system.dispatcher
+
+  override implicit val materializer = ActorMaterializer()(system)
+
+  override val responder: HttpResponder = mock
+
+  reqRespPairs.foreach {
+    case (uri, respString) =>
+      val req = HttpRequest(HttpMethods.GET, uri)
+      val resp = HttpResponse(status = StatusCodes.OK, entity = HttpEntity(ContentTypes.`application/json`, string = respString))
+      mock.expects(req).returning(Future.successful(resp))
+  }
+}

--- a/cluster-http-client/src/test/scala/akka/cluster/http/management/client/ClusterManagementClientSpec.scala
+++ b/cluster-http-client/src/test/scala/akka/cluster/http/management/client/ClusterManagementClientSpec.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2017 Lightbend Inc. <http://www.lightbend.com>
+ */
 package akka.cluster.http.management.client
 
 import akka.actor.ActorSystem
@@ -7,12 +10,15 @@ import akka.stream.ActorMaterializer
 import akka.testkit.TestKit
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{FlatSpecLike, Matchers}
+import org.scalatest.{ FlatSpecLike, Matchers }
 
 import scala.concurrent.Future
 
-class ClusterManagementClientSpec extends TestKit(ActorSystem("akka-management"))
-  with Matchers with FlatSpecLike with ScalaFutures {
+class ClusterManagementClientSpec
+    extends TestKit(ActorSystem("akka-management"))
+    with Matchers
+    with FlatSpecLike
+    with ScalaFutures {
 
   val response =
     """
@@ -36,11 +42,10 @@ class ClusterManagementClientSpec extends TestKit(ActorSystem("akka-management")
       | }
     """.stripMargin
 
-
   "The ClusterManagementClient trait" should "look up members by role" in {
-    val client = new MockManagementClient(system, Seq(Uri("/members") -> response,
-      Uri("/members") -> response, Uri("/members") -> response, Uri("/members") -> response,
-      Uri("/members") -> response)) //one for each assertion
+    val client = new MockManagementClient(system,
+      Seq(Uri("/members") -> response, Uri("/members") -> response, Uri("/members") -> response,
+        Uri("/members") -> response, Uri("/members") -> response)) //one for each assertion
 
     val member1 = ClusterMember("akka.tcp://test@10.10.10.10:1111", "1116964444", "Up", Set("test", "super"))
     val member2 = ClusterMember("akka.tcp://test@10.10.10.10:1112", "1116964443", "Up", Set("minion"))
@@ -52,7 +57,6 @@ class ClusterManagementClientSpec extends TestKit(ActorSystem("akka-management")
     whenReady(client.getMembers("test", "minion"))(r => r shouldBe Set(member1, member2))
   }
 
-
   "The AkkaClusterManagementClient" should "be properly configured" in {
     val client = new AkkaClusterManagementClient("http://localhost:19999")(system, system.dispatcher)
     client.materializer shouldBe an[ActorMaterializer]
@@ -61,9 +65,9 @@ class ClusterManagementClientSpec extends TestKit(ActorSystem("akka-management")
 
 }
 
-
 class MockManagementClient(val system: ActorSystem, reqRespPairs: Seq[(Uri, String)])
-  extends ClusterManagementClient with MockFactory {
+    extends ClusterManagementClient
+    with MockFactory {
 
   val mock = mockFunction[HttpRequest, Future[HttpResponse]]
 
@@ -78,7 +82,8 @@ class MockManagementClient(val system: ActorSystem, reqRespPairs: Seq[(Uri, Stri
   reqRespPairs.foreach {
     case (uri, respString) =>
       val req = HttpRequest(HttpMethods.GET, uri)
-      val resp = HttpResponse(status = StatusCodes.OK, entity = HttpEntity(ContentTypes.`application/json`, string = respString))
+      val resp = HttpResponse(status = StatusCodes.OK,
+        entity = HttpEntity(ContentTypes.`application/json`, string = respString))
       mock.expects(req).returning(Future.successful(resp))
   }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -27,7 +27,8 @@ object Dependencies {
       "com.typesafe.akka" %% "akka-distributed-data"              % AkkaVersion     % "test",
       "com.typesafe.akka" %% "akka-http-testkit"                  % AkkaHttpVersion % "test",
       "junit"             % "junit"                               % JUnitVersion    % "test",
-      "org.mockito"       % "mockito-all"                         % "1.10.19"       % "test"  // Common Public License 1.0
+      "org.mockito"       % "mockito-all"                         % "1.10.19"       % "test",  // Common Public License 1.0
+      "org.scalamock"     %% "scalamock"                          % "4.0.0"         % "test"
     )
   )
 


### PR DESCRIPTION
This PR adds a client module with Akka HTTP bindings to interface with the HTTP management service programmatically using a Scala API.