### PR TITLE
Discovery implementation based on Kubernetes API

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,7 @@ lazy val `akka-management-root` = project
   .aggregate(
     `akka-discovery`,
     `akka-discovery-dns`,
+    `akka-discovery-kubernetes-api`,
     `akka-management`,
     `cluster-http`,
     `cluster-bootstrap`,
@@ -34,6 +35,18 @@ lazy val `akka-discovery-dns` = project
     name := "akka-discovery-dns",
     organization := "com.lightbend.akka",
     Dependencies.DiscoveryDns
+  )
+  .dependsOn(`akka-discovery`)
+
+// K8s API implementation of discovery, allows formation to work even when readiness/health checks are failing
+lazy val `akka-discovery-kubernetes-api` = project
+  .in(file("discovery-kubernetes-api"))
+  .enablePlugins(AutomateHeaderPlugin)
+  .settings(unidocSettings)
+  .settings(
+    name := "akka-discovery-kubernetes-api",
+    organization := "com.lightbend.akka",
+    Dependencies.DiscoveryKubernetesApi
   )
   .dependsOn(`akka-discovery`)
 

--- a/discovery-kubernetes-api/src/main/resources/reference.conf
+++ b/discovery-kubernetes-api/src/main/resources/reference.conf
@@ -18,8 +18,8 @@ akka.discovery {
     # Namespace to query for pods
     pod-namespace = "default"
 
-    # selector value to query pod API with. %s will be replaced with the configured effective name, which defaults to
-    # the actor system name
+    # Selector value to query pod API with.
+    # `%s` will be replaced with the configured effective name, which defaults to the actor system name
     pod-label-selector = "app=%s"
 
     # The name of the akka management port

--- a/discovery-kubernetes-api/src/main/resources/reference.conf
+++ b/discovery-kubernetes-api/src/main/resources/reference.conf
@@ -1,0 +1,28 @@
+######################################################
+# Akka Service Discovery Kubernetes API Config       #
+######################################################
+
+akka.discovery {
+  # Set the following in your application.conf if you want to use this discovery mechanism:
+  # impl = kubernetes-api
+
+  kubernetes-api {
+    class = akka.discovery.kubernetes.KubernetesApiSimpleServiceDiscovery
+
+    # API server, cert and token information. Currently these are present on K8s versions: 1.6, 1.7, 1.8, and perhaps more
+    api-ca-path = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+    api-token-path = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+    api-service-host-env-name = "KUBERNETES_SERVICE_HOST"
+    api-service-port-env-name = "KUBERNETES_SERVICE_PORT"
+
+    # Namespace to query for pods
+    pod-namespace = "default"
+
+    # selector value to query pod API with. %s will be replaced with the configured effective name, which defaults to
+    # the actor system name
+    pod-label-selector = "app=%s"
+
+    # The name of the akka management port
+    pod-port-name = "akka-mgmt-http"
+  }
+}

--- a/discovery-kubernetes-api/src/main/resources/reference.conf
+++ b/discovery-kubernetes-api/src/main/resources/reference.conf
@@ -4,7 +4,7 @@
 
 akka.discovery {
   # Set the following in your application.conf if you want to use this discovery mechanism:
-  # impl = kubernetes-api
+  # method = kubernetes-api
 
   kubernetes-api {
     class = akka.discovery.kubernetes.KubernetesApiSimpleServiceDiscovery

--- a/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/JsonFormat.scala
+++ b/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/JsonFormat.scala
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.discovery.kubernetes
+
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import spray.json._
+
+import PodList._
+
+object JsonFormat extends SprayJsonSupport with DefaultJsonProtocol {
+  implicit val portFormat: JsonFormat[Port] = jsonFormat2(Port)
+  implicit val containerFormat: JsonFormat[Container] = jsonFormat2(Container)
+  implicit val specFormat: JsonFormat[Spec] = jsonFormat1(Spec)
+  implicit val statusFormat: JsonFormat[Status] = jsonFormat1(Status)
+  implicit val itemFormat: JsonFormat[Item] = jsonFormat2(Item)
+  implicit val podListFormat: RootJsonFormat[PodList] = jsonFormat1(PodList.apply)
+}

--- a/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/KubernetesApiSimpleServiceDiscovery.scala
+++ b/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/KubernetesApiSimpleServiceDiscovery.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.discovery.kubernetes
+
+import akka.actor.ActorSystem
+import akka.discovery._
+import akka.http.scaladsl._
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.headers.{ Authorization, OAuth2BearerToken }
+import akka.http.scaladsl.unmarshalling.Unmarshal
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.FileIO
+import com.typesafe.sslconfig.akka.AkkaSSLConfig
+import com.typesafe.sslconfig.ssl.TrustStoreConfig
+import java.nio.file.Paths
+import scala.collection.immutable.Seq
+import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
+import scala.util.Try
+
+import JsonFormat._
+import SimpleServiceDiscovery.{ Resolved, ResolvedTarget }
+
+object KubernetesApiSimpleServiceDiscovery {
+  private[kubernetes] def targets(podList: PodList, name: String, portName: String): Seq[ResolvedTarget] =
+    for {
+      item <- podList.items
+      container <- item.spec.containers.find(_.name == name)
+      port <- container.ports.find(_.name == portName)
+      ip <- item.status.podIP
+    } yield ResolvedTarget(ip, Some(port.containerPort))
+}
+
+/**
+ * An alternative implementation that uses the Kubernetes API. The main advantage of this method is that it allows
+ * you to define readiness/health checks that don't affect the bootstrap mechanism.
+ */
+class KubernetesApiSimpleServiceDiscovery(system: ActorSystem) extends SimpleServiceDiscovery {
+  import KubernetesApiSimpleServiceDiscovery._
+  import system.dispatcher
+
+  private val http = Http()(system)
+
+  private val settings = Settings(system)
+
+  private implicit val mat: ActorMaterializer = ActorMaterializer()(system)
+
+  private val httpsTrustStoreConfig =
+    TrustStoreConfig(data = None, filePath = Some(settings.apiCaPath)).withStoreType("PEM")
+
+  private val httpsConfig =
+    AkkaSSLConfig()(system).mapSettings(
+        s => s.withTrustManagerConfig(s.trustManagerConfig.withTrustStoreConfigs(Seq(httpsTrustStoreConfig))))
+
+  private val httpsContext = http.createClientHttpsContext(httpsConfig)
+
+  def lookup(name: String, resolveTimeout: FiniteDuration): Future[Resolved] =
+    for {
+      token <- apiToken()
+
+      request <- optionToFuture(podRequest(token, settings.podNamespace, name),
+        s"Unable to form request; check Kubernetes environment (expecting env vars ${settings.apiServiceHostEnvName}, ${settings.apiServicePortEnvName})")
+
+      response <- http.singleRequest(request, httpsContext)
+
+      entity <- response.entity.toStrict(resolveTimeout)
+
+      podList <- Unmarshal(entity).to[PodList]
+
+    } yield Resolved(name, targets(podList, name, settings.podPortName))
+
+  private def apiToken() =
+    FileIO.fromPath(Paths.get(settings.apiTokenPath)).runFold("")(_ + _.utf8String).recover { case _: Throwable => "" }
+
+  private def optionToFuture[T](option: Option[T], failMsg: String): Future[T] =
+    option.fold(Future.failed[T](new NoSuchElementException(failMsg)))(Future.successful)
+
+  private def podRequest(token: String, namespace: String, name: String) =
+    for {
+      host <- sys.env.get(settings.apiServiceHostEnvName)
+      portStr <- sys.env.get(settings.apiServicePortEnvName)
+      port <- Try(portStr.toInt).toOption
+    } yield {
+      val path = Uri.Path.Empty / "api" / "v1" / "namespaces" / namespace / "pods"
+      val query = Uri.Query("labelSelector" -> settings.podLabelSelector(name))
+      val uri = Uri.from(scheme = "https", host = host, port = port).withPath(path).withQuery(query)
+
+      HttpRequest(uri = uri, headers = Seq(Authorization(OAuth2BearerToken(token))))
+    }
+}

--- a/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/PodList.scala
+++ b/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/PodList.scala
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.discovery.kubernetes
+
+import scala.collection.immutable.Seq
+
+object PodList {
+  case class Port(name: String, containerPort: Int)
+  case class Container(name: String, ports: Seq[Port])
+  case class Spec(containers: Seq[Container])
+  case class Status(podIP: Option[String])
+  case class Item(spec: Spec, status: Status)
+}
+
+import PodList._
+
+case class PodList(items: Seq[Item])

--- a/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/Settings.scala
+++ b/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/Settings.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.discovery.kubernetes
+
+import akka.actor._
+
+final class Settings(system: ExtendedActorSystem) extends Extension {
+  private val kubernetesApi = system.settings.config.getConfig("akka.discovery.kubernetes-api")
+
+  val apiCaPath: String =
+    kubernetesApi.getString("api-ca-path")
+
+  val apiTokenPath: String =
+    kubernetesApi.getString("api-token-path")
+
+  val apiServiceHostEnvName: String =
+    kubernetesApi.getString("api-service-host-env-name")
+
+  val apiServicePortEnvName: String =
+    kubernetesApi.getString("api-service-port-env-name")
+
+  val podNamespace: String =
+    kubernetesApi.getString("pod-namespace")
+
+  def podLabelSelector(name: String): String =
+    kubernetesApi.getString("pod-label-selector").format(name)
+
+  val podPortName: String =
+    kubernetesApi.getString("pod-port-name")
+}
+
+object Settings extends ExtensionId[Settings] with ExtensionIdProvider {
+  override def get(system: ActorSystem): Settings = super.get(system)
+
+  override def lookup: Settings.type = Settings
+
+  override def createExtension(system: ExtendedActorSystem): Settings = new Settings(system)
+}

--- a/discovery-kubernetes-api/src/test/resources/pods.json
+++ b/discovery-kubernetes-api/src/test/resources/pods.json
@@ -1,0 +1,1057 @@
+{
+  "kind": "PodList",
+  "apiVersion": "v1",
+  "metadata": {
+    "selfLink": "/api/v1/namespaces/default/pods",
+    "resourceVersion": "16042"
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "akka-cluster-tooling-example-v0-1-0-7f854bcc78-dvm9q",
+        "generateName": "akka-cluster-tooling-example-v0-1-0-7f854bcc78-",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/pods/akka-cluster-tooling-example-v0-1-0-7f854bcc78-dvm9q",
+        "uid": "5fe7a41b-da9a-11e7-b064-0800270d668b",
+        "resourceVersion": "6523",
+        "creationTimestamp": "2017-12-06T15:30:22Z",
+        "labels": {
+          "appName": "akka-cluster-tooling-example",
+          "appNameVersion": "akka-cluster-tooling-example-v0-1-0",
+          "pod-template-hash": "3941067734"
+        },
+        "annotations": {
+          "kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"ReplicaSet\",\"namespace\":\"default\",\"name\":\"akka-cluster-tooling-example-v0-1-0-7f854bcc78\",\"uid\":\"5fdc6a1c-da9a-11e7-b064-0800270d668b\",\"apiVersion\":\"extensions\",\"resourceVersion\":\"3173\"}}\n"
+        },
+        "ownerReferences": [
+          {
+            "apiVersion": "extensions/v1beta1",
+            "kind": "ReplicaSet",
+            "name": "akka-cluster-tooling-example-v0-1-0-7f854bcc78",
+            "uid": "5fdc6a1c-da9a-11e7-b064-0800270d668b",
+            "controller": true,
+            "blockOwnerDeletion": true
+          }
+        ]
+      },
+      "spec": {
+        "volumes": [
+          {
+            "name": "default-token-zkgn4",
+            "secret": {
+              "secretName": "default-token-zkgn4",
+              "defaultMode": 420
+            }
+          }
+        ],
+        "containers": [
+          {
+            "name": "akka-cluster-tooling-example",
+            "image": "akka-cluster-tooling-example/akka-cluster-tooling-example:0.1.0",
+            "ports": [
+              {
+                "name": "akka-remote",
+                "containerPort": 10000,
+                "protocol": "TCP"
+              },
+              {
+                "name": "akka-mgmt-http",
+                "containerPort": 10001,
+                "protocol": "TCP"
+              },
+              {
+                "name": "http",
+                "containerPort": 10002,
+                "protocol": "TCP"
+              }
+            ],
+            "env": [
+              {
+                "name": "JAVA_OPTS",
+                "value": "-Drp.service-discovery.ask-timeout=1ms"
+              },
+              {
+                "name": "RP_APP_NAME",
+                "value": "akka-cluster-tooling-example"
+              },
+              {
+                "name": "RP_APP_TYPE",
+                "value": "basic"
+              },
+              {
+                "name": "RP_APP_VERSION",
+                "value": "0.1.0"
+              },
+              {
+                "name": "RP_ENDPOINTS",
+                "value": "AKKA_REMOTE,AKKA_MGMT_HTTP,HTTP"
+              },
+              {
+                "name": "RP_ENDPOINTS_COUNT",
+                "value": "3"
+              },
+              {
+                "name": "RP_ENDPOINT_0_BIND_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_0_BIND_PORT",
+                "value": "10000"
+              },
+              {
+                "name": "RP_ENDPOINT_0_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_0_PORT",
+                "value": "10000"
+              },
+              {
+                "name": "RP_ENDPOINT_1_BIND_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_1_BIND_PORT",
+                "value": "10001"
+              },
+              {
+                "name": "RP_ENDPOINT_1_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_1_PORT",
+                "value": "10001"
+              },
+              {
+                "name": "RP_ENDPOINT_2_BIND_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_2_BIND_PORT",
+                "value": "10002"
+              },
+              {
+                "name": "RP_ENDPOINT_2_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_2_PORT",
+                "value": "10002"
+              },
+              {
+                "name": "RP_ENDPOINT_AKKA_MGMT_HTTP_BIND_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_AKKA_MGMT_HTTP_BIND_PORT",
+                "value": "10001"
+              },
+              {
+                "name": "RP_ENDPOINT_AKKA_MGMT_HTTP_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_AKKA_MGMT_HTTP_PORT",
+                "value": "10001"
+              },
+              {
+                "name": "RP_ENDPOINT_AKKA_REMOTE_BIND_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_AKKA_REMOTE_BIND_PORT",
+                "value": "10000"
+              },
+              {
+                "name": "RP_ENDPOINT_AKKA_REMOTE_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_AKKA_REMOTE_PORT",
+                "value": "10000"
+              },
+              {
+                "name": "RP_ENDPOINT_HTTP_BIND_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_HTTP_BIND_PORT",
+                "value": "10002"
+              },
+              {
+                "name": "RP_ENDPOINT_HTTP_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_HTTP_PORT",
+                "value": "10002"
+              },
+              {
+                "name": "RP_JAVA_OPTS",
+                "value": "-Dconfig.resource=rp-application.conf -Dakka.cluster.bootstrap.contact-point-discovery.effective-name=akka-cluster-tooling-example -Dakka.cluster.bootstrap.contact-point-discovery.required-contact-point-nr=3"
+              },
+              {
+                "name": "RP_KUBERNETES_POD_IP",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_KUBERNETES_POD_NAME",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "metadata.name"
+                  }
+                }
+              },
+              {
+                "name": "RP_MODULES",
+                "value": "akka-cluster-bootstrapping,common,service-discovery"
+              },
+              {
+                "name": "RP_PLATFORM",
+                "value": "kubernetes"
+              }
+            ],
+            "resources": {
+
+            },
+            "volumeMounts": [
+              {
+                "name": "default-token-zkgn4",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+              }
+            ],
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "imagePullPolicy": "IfNotPresent"
+          }
+        ],
+        "restartPolicy": "Always",
+        "terminationGracePeriodSeconds": 30,
+        "dnsPolicy": "ClusterFirst",
+        "serviceAccountName": "default",
+        "serviceAccount": "default",
+        "nodeName": "minikube",
+        "securityContext": {
+
+        },
+        "schedulerName": "default-scheduler"
+      },
+      "status": {
+        "phase": "Running",
+        "conditions": [
+          {
+            "type": "Initialized",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2017-12-06T15:30:22Z"
+          },
+          {
+            "type": "Ready",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2017-12-06T17:36:57Z"
+          },
+          {
+            "type": "PodScheduled",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2017-12-06T15:30:22Z"
+          }
+        ],
+        "hostIP": "192.168.99.109",
+        "podIP": "172.17.0.4",
+        "startTime": "2017-12-06T15:30:22Z",
+        "containerStatuses": [
+          {
+            "name": "akka-cluster-tooling-example",
+            "state": {
+              "running": {
+                "startedAt": "2017-12-06T17:36:57Z"
+              }
+            },
+            "lastState": {
+              "terminated": {
+                "exitCode": 137,
+                "reason": "Error",
+                "startedAt": "2017-12-06T15:30:24Z",
+                "finishedAt": "2017-12-06T17:36:50Z",
+                "containerID": "docker://294b22a68ac2d91f64586ad349f5c4012bce5e3d0a51197ee21451b7eada0617"
+              }
+            },
+            "ready": true,
+            "restartCount": 1,
+            "image": "akka-cluster-tooling-example/akka-cluster-tooling-example:0.1.0",
+            "imageID": "docker://sha256:db3827171cfd7cea96f35e75e9df30e198f25b66a8e75e8167b09ad9e1a18c10",
+            "containerID": "docker://d805076f4737166117229aaa4eaf5e7eb974da0b4c781b2f6ec126d5046a4c3f"
+          }
+        ],
+        "qosClass": "BestEffort"
+      }
+    },
+    {
+      "metadata": {
+        "name": "akka-cluster-tooling-example-v0-1-0-7f854bcc78-m8dqb",
+        "generateName": "akka-cluster-tooling-example-v0-1-0-7f854bcc78-",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/pods/akka-cluster-tooling-example-v0-1-0-7f854bcc78-m8dqb",
+        "uid": "5fe22476-da9a-11e7-b064-0800270d668b",
+        "resourceVersion": "6520",
+        "creationTimestamp": "2017-12-06T15:30:22Z",
+        "labels": {
+          "appNameVersion": "akka-cluster-tooling-example-v0-1-0",
+          "pod-template-hash": "3941067734",
+          "appName": "akka-cluster-tooling-example"
+        },
+        "annotations": {
+          "kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"ReplicaSet\",\"namespace\":\"default\",\"name\":\"akka-cluster-tooling-example-v0-1-0-7f854bcc78\",\"uid\":\"5fdc6a1c-da9a-11e7-b064-0800270d668b\",\"apiVersion\":\"extensions\",\"resourceVersion\":\"3173\"}}\n"
+        },
+        "ownerReferences": [
+          {
+            "apiVersion": "extensions/v1beta1",
+            "kind": "ReplicaSet",
+            "name": "akka-cluster-tooling-example-v0-1-0-7f854bcc78",
+            "uid": "5fdc6a1c-da9a-11e7-b064-0800270d668b",
+            "controller": true,
+            "blockOwnerDeletion": true
+          }
+        ]
+      },
+      "spec": {
+        "volumes": [
+          {
+            "name": "default-token-zkgn4",
+            "secret": {
+              "secretName": "default-token-zkgn4",
+              "defaultMode": 420
+            }
+          }
+        ],
+        "containers": [
+          {
+            "name": "akka-cluster-tooling-example",
+            "image": "akka-cluster-tooling-example/akka-cluster-tooling-example:0.1.0",
+            "ports": [
+              {
+                "name": "akka-remote",
+                "containerPort": 10000,
+                "protocol": "TCP"
+              },
+              {
+                "name": "akka-mgmt-http",
+                "containerPort": 10001,
+                "protocol": "TCP"
+              },
+              {
+                "name": "http",
+                "containerPort": 10002,
+                "protocol": "TCP"
+              }
+            ],
+            "env": [
+              {
+                "name": "JAVA_OPTS",
+                "value": "-Drp.service-discovery.ask-timeout=1ms"
+              },
+              {
+                "name": "RP_APP_NAME",
+                "value": "akka-cluster-tooling-example"
+              },
+              {
+                "name": "RP_APP_TYPE",
+                "value": "basic"
+              },
+              {
+                "name": "RP_APP_VERSION",
+                "value": "0.1.0"
+              },
+              {
+                "name": "RP_ENDPOINTS",
+                "value": "AKKA_REMOTE,AKKA_MGMT_HTTP,HTTP"
+              },
+              {
+                "name": "RP_ENDPOINTS_COUNT",
+                "value": "3"
+              },
+              {
+                "name": "RP_ENDPOINT_0_BIND_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_0_BIND_PORT",
+                "value": "10000"
+              },
+              {
+                "name": "RP_ENDPOINT_0_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_0_PORT",
+                "value": "10000"
+              },
+              {
+                "name": "RP_ENDPOINT_1_BIND_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_1_BIND_PORT",
+                "value": "10001"
+              },
+              {
+                "name": "RP_ENDPOINT_1_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_1_PORT",
+                "value": "10001"
+              },
+              {
+                "name": "RP_ENDPOINT_2_BIND_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_2_BIND_PORT",
+                "value": "10002"
+              },
+              {
+                "name": "RP_ENDPOINT_2_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_2_PORT",
+                "value": "10002"
+              },
+              {
+                "name": "RP_ENDPOINT_AKKA_MGMT_HTTP_BIND_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_AKKA_MGMT_HTTP_BIND_PORT",
+                "value": "10001"
+              },
+              {
+                "name": "RP_ENDPOINT_AKKA_MGMT_HTTP_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_AKKA_MGMT_HTTP_PORT",
+                "value": "10001"
+              },
+              {
+                "name": "RP_ENDPOINT_AKKA_REMOTE_BIND_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_AKKA_REMOTE_BIND_PORT",
+                "value": "10000"
+              },
+              {
+                "name": "RP_ENDPOINT_AKKA_REMOTE_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_AKKA_REMOTE_PORT",
+                "value": "10000"
+              },
+              {
+                "name": "RP_ENDPOINT_HTTP_BIND_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_HTTP_BIND_PORT",
+                "value": "10002"
+              },
+              {
+                "name": "RP_ENDPOINT_HTTP_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_HTTP_PORT",
+                "value": "10002"
+              },
+              {
+                "name": "RP_JAVA_OPTS",
+                "value": "-Dconfig.resource=rp-application.conf -Dakka.cluster.bootstrap.contact-point-discovery.effective-name=akka-cluster-tooling-example -Dakka.cluster.bootstrap.contact-point-discovery.required-contact-point-nr=3"
+              },
+              {
+                "name": "RP_KUBERNETES_POD_IP",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_KUBERNETES_POD_NAME",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "metadata.name"
+                  }
+                }
+              },
+              {
+                "name": "RP_MODULES",
+                "value": "akka-cluster-bootstrapping,common,service-discovery"
+              },
+              {
+                "name": "RP_PLATFORM",
+                "value": "kubernetes"
+              }
+            ],
+            "resources": {
+
+            },
+            "volumeMounts": [
+              {
+                "name": "default-token-zkgn4",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+              }
+            ],
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "imagePullPolicy": "IfNotPresent"
+          }
+        ],
+        "restartPolicy": "Always",
+        "terminationGracePeriodSeconds": 30,
+        "dnsPolicy": "ClusterFirst",
+        "serviceAccountName": "default",
+        "serviceAccount": "default",
+        "nodeName": "minikube",
+        "securityContext": {
+
+        },
+        "schedulerName": "default-scheduler"
+      },
+      "status": {
+        "phase": "Running",
+        "conditions": [
+          {
+            "type": "Initialized",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2017-12-06T15:30:22Z"
+          },
+          {
+            "type": "Ready",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2017-12-06T17:36:57Z"
+          },
+          {
+            "type": "PodScheduled",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2017-12-06T15:30:22Z"
+          }
+        ],
+        "hostIP": "192.168.99.109",
+        "podIP": "172.17.0.6",
+        "startTime": "2017-12-06T15:30:22Z",
+        "containerStatuses": [
+          {
+            "name": "akka-cluster-tooling-example",
+            "state": {
+              "running": {
+                "startedAt": "2017-12-06T17:36:57Z"
+              }
+            },
+            "lastState": {
+              "terminated": {
+                "exitCode": 137,
+                "reason": "Error",
+                "startedAt": "2017-12-06T15:30:24Z",
+                "finishedAt": "2017-12-06T17:36:50Z",
+                "containerID": "docker://b5880747113029524ba902c561df5637f45b73a225bab52e8ed0395588432101"
+              }
+            },
+            "ready": true,
+            "restartCount": 1,
+            "image": "akka-cluster-tooling-example/akka-cluster-tooling-example:0.1.0",
+            "imageID": "docker://sha256:db3827171cfd7cea96f35e75e9df30e198f25b66a8e75e8167b09ad9e1a18c10",
+            "containerID": "docker://ba80f96ce994517bc2d49d2930923c54b818bdd3a1aa8e60e42944e8ac4bf730"
+          }
+        ],
+        "qosClass": "BestEffort"
+      }
+    },
+    {
+      "metadata": {
+        "name": "akka-cluster-tooling-example-v0-1-0-7f854bcc78-xncvj",
+        "generateName": "akka-cluster-tooling-example-v0-1-0-7f854bcc78-",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/pods/akka-cluster-tooling-example-v0-1-0-7f854bcc78-xncvj",
+        "uid": "5fe6b0c7-da9a-11e7-b064-0800270d668b",
+        "resourceVersion": "6593",
+        "creationTimestamp": "2017-12-06T15:30:22Z",
+        "labels": {
+          "pod-template-hash": "3941067734",
+          "appName": "akka-cluster-tooling-example",
+          "appNameVersion": "akka-cluster-tooling-example-v0-1-0"
+        },
+        "annotations": {
+          "kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"ReplicaSet\",\"namespace\":\"default\",\"name\":\"akka-cluster-tooling-example-v0-1-0-7f854bcc78\",\"uid\":\"5fdc6a1c-da9a-11e7-b064-0800270d668b\",\"apiVersion\":\"extensions\",\"resourceVersion\":\"3173\"}}\n"
+        },
+        "ownerReferences": [
+          {
+            "apiVersion": "extensions/v1beta1",
+            "kind": "ReplicaSet",
+            "name": "akka-cluster-tooling-example-v0-1-0-7f854bcc78",
+            "uid": "5fdc6a1c-da9a-11e7-b064-0800270d668b",
+            "controller": true,
+            "blockOwnerDeletion": true
+          }
+        ]
+      },
+      "spec": {
+        "volumes": [
+          {
+            "name": "default-token-zkgn4",
+            "secret": {
+              "secretName": "default-token-zkgn4",
+              "defaultMode": 420
+            }
+          }
+        ],
+        "containers": [
+          {
+            "name": "akka-cluster-tooling-example",
+            "image": "akka-cluster-tooling-example/akka-cluster-tooling-example:0.1.0",
+            "ports": [
+              {
+                "name": "akka-remote",
+                "containerPort": 10000,
+                "protocol": "TCP"
+              },
+              {
+                "name": "akka-mgmt-http",
+                "containerPort": 10001,
+                "protocol": "TCP"
+              },
+              {
+                "name": "http",
+                "containerPort": 10002,
+                "protocol": "TCP"
+              }
+            ],
+            "env": [
+              {
+                "name": "JAVA_OPTS",
+                "value": "-Drp.service-discovery.ask-timeout=1ms"
+              },
+              {
+                "name": "RP_APP_NAME",
+                "value": "akka-cluster-tooling-example"
+              },
+              {
+                "name": "RP_APP_TYPE",
+                "value": "basic"
+              },
+              {
+                "name": "RP_APP_VERSION",
+                "value": "0.1.0"
+              },
+              {
+                "name": "RP_ENDPOINTS",
+                "value": "AKKA_REMOTE,AKKA_MGMT_HTTP,HTTP"
+              },
+              {
+                "name": "RP_ENDPOINTS_COUNT",
+                "value": "3"
+              },
+              {
+                "name": "RP_ENDPOINT_0_BIND_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_0_BIND_PORT",
+                "value": "10000"
+              },
+              {
+                "name": "RP_ENDPOINT_0_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_0_PORT",
+                "value": "10000"
+              },
+              {
+                "name": "RP_ENDPOINT_1_BIND_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_1_BIND_PORT",
+                "value": "10001"
+              },
+              {
+                "name": "RP_ENDPOINT_1_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_1_PORT",
+                "value": "10001"
+              },
+              {
+                "name": "RP_ENDPOINT_2_BIND_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_2_BIND_PORT",
+                "value": "10002"
+              },
+              {
+                "name": "RP_ENDPOINT_2_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_2_PORT",
+                "value": "10002"
+              },
+              {
+                "name": "RP_ENDPOINT_AKKA_MGMT_HTTP_BIND_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_AKKA_MGMT_HTTP_BIND_PORT",
+                "value": "10001"
+              },
+              {
+                "name": "RP_ENDPOINT_AKKA_MGMT_HTTP_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_AKKA_MGMT_HTTP_PORT",
+                "value": "10001"
+              },
+              {
+                "name": "RP_ENDPOINT_AKKA_REMOTE_BIND_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_AKKA_REMOTE_BIND_PORT",
+                "value": "10000"
+              },
+              {
+                "name": "RP_ENDPOINT_AKKA_REMOTE_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_AKKA_REMOTE_PORT",
+                "value": "10000"
+              },
+              {
+                "name": "RP_ENDPOINT_HTTP_BIND_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_HTTP_BIND_PORT",
+                "value": "10002"
+              },
+              {
+                "name": "RP_ENDPOINT_HTTP_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_HTTP_PORT",
+                "value": "10002"
+              },
+              {
+                "name": "RP_JAVA_OPTS",
+                "value": "-Dconfig.resource=rp-application.conf -Dakka.cluster.bootstrap.contact-point-discovery.effective-name=akka-cluster-tooling-example -Dakka.cluster.bootstrap.contact-point-discovery.required-contact-point-nr=3"
+              },
+              {
+                "name": "RP_KUBERNETES_POD_IP",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_KUBERNETES_POD_NAME",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "metadata.name"
+                  }
+                }
+              },
+              {
+                "name": "RP_MODULES",
+                "value": "akka-cluster-bootstrapping,common,service-discovery"
+              },
+              {
+                "name": "RP_PLATFORM",
+                "value": "kubernetes"
+              }
+            ],
+            "resources": {
+
+            },
+            "volumeMounts": [
+              {
+                "name": "default-token-zkgn4",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+              }
+            ],
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "imagePullPolicy": "IfNotPresent"
+          }
+        ],
+        "restartPolicy": "Always",
+        "terminationGracePeriodSeconds": 30,
+        "dnsPolicy": "ClusterFirst",
+        "serviceAccountName": "default",
+        "serviceAccount": "default",
+        "nodeName": "minikube",
+        "securityContext": {
+
+        },
+        "schedulerName": "default-scheduler"
+      },
+      "status": {
+        "phase": "Running",
+        "conditions": [
+          {
+            "type": "Initialized",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2017-12-06T15:30:22Z"
+          },
+          {
+            "type": "Ready",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2017-12-06T17:37:17Z"
+          },
+          {
+            "type": "PodScheduled",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2017-12-06T15:30:22Z"
+          }
+        ],
+        "hostIP": "192.168.99.109",
+        "podIP": "172.17.0.7",
+        "startTime": "2017-12-06T15:30:22Z",
+        "containerStatuses": [
+          {
+            "name": "akka-cluster-tooling-example",
+            "state": {
+              "running": {
+                "startedAt": "2017-12-06T17:37:16Z"
+              }
+            },
+            "lastState": {
+              "terminated": {
+                "exitCode": 137,
+                "reason": "Error",
+                "startedAt": "2017-12-06T15:30:24Z",
+                "finishedAt": "2017-12-06T17:36:50Z",
+                "containerID": "docker://c516ab6640a1a67d6f24337025930812ec73f08a1ba1ae2a3533c6645a751d31"
+              }
+            },
+            "ready": true,
+            "restartCount": 1,
+            "image": "akka-cluster-tooling-example/akka-cluster-tooling-example:0.1.0",
+            "imageID": "docker://sha256:db3827171cfd7cea96f35e75e9df30e198f25b66a8e75e8167b09ad9e1a18c10",
+            "containerID": "docker://075e85c889ffd715849f8d683702623790c44f93beeea5711a63a8b6ef9e5272"
+          }
+        ],
+        "qosClass": "BestEffort"
+      }
+    }
+  ]
+}

--- a/discovery-kubernetes-api/src/test/scala/akka/discovery/kubernetes/JsonFormatSpec.scala
+++ b/discovery-kubernetes-api/src/test/scala/akka/discovery/kubernetes/JsonFormatSpec.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.discovery.kubernetes
+
+import org.scalatest.{Matchers, WordSpec}
+import spray.json._
+import scala.io.Source
+
+import PodList._
+
+class JsonFormatSpec extends WordSpec with Matchers {
+  "JsonFormat" should {
+    val data = resourceAsString("pods.json")
+
+    "work" in {
+      JsonFormat
+        .podListFormat
+        .read(data.parseJson) shouldBe PodList(
+          List(
+            Item(
+              Spec(
+                List(
+                  Container(
+                    "akka-cluster-tooling-example",
+                    List(Port("akka-remote", 10000), Port("akka-mgmt-http", 10001), Port("http", 10002))))),
+              Status(Some("172.17.0.4"))),
+
+            Item(
+              Spec(
+                List(
+                  Container(
+                    "akka-cluster-tooling-example",
+                    List(Port("akka-remote", 10000), Port("akka-mgmt-http", 10001), Port("http", 10002))))),
+              Status(Some("172.17.0.6"))),
+
+            Item(
+              Spec(
+                List(
+                  Container(
+                    "akka-cluster-tooling-example",
+                    List(Port("akka-remote", 10000), Port("akka-mgmt-http", 10001), Port("http", 10002))))),
+              Status(Some("172.17.0.7")))))
+    }
+  }
+
+  private def resourceAsString(name: String): String =
+    Source
+      .fromInputStream(getClass.getClassLoader.getResourceAsStream(name))
+      .mkString
+}

--- a/discovery-kubernetes-api/src/test/scala/akka/discovery/kubernetes/KubernetesApiSimpleServiceDiscoverySpec.scala
+++ b/discovery-kubernetes-api/src/test/scala/akka/discovery/kubernetes/KubernetesApiSimpleServiceDiscoverySpec.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.discovery.kubernetes
+
+import akka.discovery.SimpleServiceDiscovery.ResolvedTarget
+import org.scalatest.{ Matchers, WordSpec }
+
+import PodList._
+
+class KubernetesApiSimpleServiceDiscoverySpec extends WordSpec with Matchers {
+  "targets" should {
+    "calculate the correct list of resolved targets" in {
+      val podList = PodList(
+        List(
+          Item(
+            Spec(
+              List(
+                Container(
+                  "akka-cluster-tooling-example",
+                  List(Port("akka-remote", 10000), Port("akka-mgmt-http", 10001), Port("http", 10002))))),
+            Status(Some("172.17.0.4"))),
+
+          Item(
+            Spec(
+              List(
+                Container(
+                  "akka-cluster-tooling-example",
+                  List(Port("akka-remote", 10000), Port("akka-mgmt-http", 10001), Port("http", 10002))))),
+            Status(None)),
+
+          Item(
+            Spec(
+              List(
+                Container(
+                  "akka-cluster-tooling-other-example",
+                  List(Port("akka-remote", 10000), Port("akka-mgmt-http", 10001), Port("http", 10002))))),
+            Status(Some("172.17.0.6"))),
+
+          Item(
+            Spec(
+              List(
+                Container(
+                  "akka-cluster-tooling-another-example",
+                  List(Port("akka-remote", 10000), Port("akka-mgmt-http", 10001), Port("http", 10002))))),
+            Status(Some("172.17.0.7")))))
+
+      KubernetesApiSimpleServiceDiscovery.targets(podList, "akka-cluster-tooling-example", "akka-mgmt-http") shouldBe List(
+        ResolvedTarget("172.17.0.4", Some(10001)))
+    }
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -67,6 +67,12 @@ object Dependencies {
       )
   )
 
+  val DiscoveryKubernetesApi = Seq(
+    libraryDependencies ++=
+      DependencyGroups.AkkaActor ++
+      DependencyGroups.AkkaHttp
+  )
+
   val ManagementHttp = Seq(
     libraryDependencies ++=
       DependencyGroups.AkkaHttp ++


### PR DESCRIPTION
This adds a K8s-API based implementation of `SimpleServiceDiscovery`. By using this (instead of the DNS one), the cluster can bootstrap itself before passing its readiness checks.