### PR TITLE
Remove filter for k8s pod names as that is done by the selector

### DIFF
--- a/discovery-kubernetes-api/src/test/scala/akka/discovery/kubernetes/KubernetesApiSimpleServiceDiscoverySpec.scala
+++ b/discovery-kubernetes-api/src/test/scala/akka/discovery/kubernetes/KubernetesApiSimpleServiceDiscoverySpec.scala
@@ -11,42 +11,17 @@ import PodList._
 class KubernetesApiSimpleServiceDiscoverySpec extends WordSpec with Matchers {
   "targets" should {
     "calculate the correct list of resolved targets" in {
-      val podList = PodList(
-        List(
-          Item(
-            Spec(
-              List(
-                Container(
-                  "akka-cluster-tooling-example",
+      // Note: This method doesn't
+
+      val podList = PodList(List(Item(Spec(List(Container("akka-cluster-tooling-example",
                   List(Port("akka-remote", 10000), Port("akka-mgmt-http", 10001), Port("http", 10002))))),
             Status(Some("172.17.0.4"))),
-
-          Item(
-            Spec(
-              List(
-                Container(
-                  "akka-cluster-tooling-example",
+          Item(Spec(List(Container("akka-cluster-tooling-example",
                   List(Port("akka-remote", 10000), Port("akka-mgmt-http", 10001), Port("http", 10002))))),
-            Status(None)),
+            Status(None))))
 
-          Item(
-            Spec(
-              List(
-                Container(
-                  "akka-cluster-tooling-other-example",
-                  List(Port("akka-remote", 10000), Port("akka-mgmt-http", 10001), Port("http", 10002))))),
-            Status(Some("172.17.0.6"))),
-
-          Item(
-            Spec(
-              List(
-                Container(
-                  "akka-cluster-tooling-another-example",
-                  List(Port("akka-remote", 10000), Port("akka-mgmt-http", 10001), Port("http", 10002))))),
-            Status(Some("172.17.0.7")))))
-
-      KubernetesApiSimpleServiceDiscovery.targets(podList, "akka-cluster-tooling-example", "akka-mgmt-http") shouldBe List(
-        ResolvedTarget("172.17.0.4", Some(10001)))
+      KubernetesApiSimpleServiceDiscovery.targets(podList,
+        "akka-mgmt-http") shouldBe List(ResolvedTarget("172.17.0.4", Some(10001)))
     }
   }
 }

--- a/discovery-kubernetes-api/src/test/scala/akka/discovery/kubernetes/KubernetesApiSimpleServiceDiscoverySpec.scala
+++ b/discovery-kubernetes-api/src/test/scala/akka/discovery/kubernetes/KubernetesApiSimpleServiceDiscoverySpec.scala
@@ -11,8 +11,6 @@ import PodList._
 class KubernetesApiSimpleServiceDiscoverySpec extends WordSpec with Matchers {
   "targets" should {
     "calculate the correct list of resolved targets" in {
-      // Note: This method doesn't
-
       val podList = PodList(List(Item(Spec(List(Container("akka-cluster-tooling-example",
                   List(Port("akka-remote", 10000), Port("akka-mgmt-http", 10001), Port("http", 10002))))),
             Status(Some("172.17.0.4"))),


### PR DESCRIPTION
This fixes a bug in the Kubernetes discovery API. `targets` shouldn't be filtering by container name as that is the job of the configured selector, which out of the box defaults to `app=<actor-system-name>`

Thus, this PR allows containers with different names to join the same cluster if configured with an appropriate selector.

For instance, given `-Dakka.discovery.kubernetes-api.pod-label-selector=actorSystemName=my-system`, any pods that specify `label: { "actorSystemName": "my-system" }` will now be returned by the k8s service discovery module.

Note that this was the original intent but filtering by name in `targets` was included by oversight.

I've tested this locally with a custom project of two different applications and will be publishing said project shortly.
 
**Update: Here's said project: https://github.com/longshorej/akka-management-example**