### PR TITLE
Discovery: EC2 Tag Based - now can support additional filters

### DIFF
--- a/discovery-aws-api/src/main/resources/reference.conf
+++ b/discovery-aws-api/src/main/resources/reference.conf
@@ -12,6 +12,9 @@ akka.discovery {
 
     tag-key = "service"
 
+    # filters have to be in key=value format, separated by semi-colon
+    filters = ""
+
   }
 
 }

--- a/discovery-aws-api/src/main/scala/akka/discovery/awsapi/ec2/Ec2TagBasedSimpleServiceDiscovery.scala
+++ b/discovery-aws-api/src/main/scala/akka/discovery/awsapi/ec2/Ec2TagBasedSimpleServiceDiscovery.scala
@@ -7,9 +7,9 @@ import java.util
 
 import akka.actor.ActorSystem
 import akka.discovery.SimpleServiceDiscovery
-import akka.discovery.SimpleServiceDiscovery.{Resolved, ResolvedTarget}
+import akka.discovery.SimpleServiceDiscovery.{ Resolved, ResolvedTarget }
 import com.amazonaws.services.ec2.AmazonEC2ClientBuilder
-import com.amazonaws.services.ec2.model.{DescribeInstancesRequest, Filter}
+import com.amazonaws.services.ec2.model.{ DescribeInstancesRequest, Filter }
 
 import scala.collection.JavaConverters._
 import scala.concurrent.Future
@@ -26,16 +26,17 @@ class Ec2TagBasedSimpleServiceDiscovery(system: ActorSystem) extends SimpleServi
 
     val runningInstancesFilter = new Filter("instance-state-name", List("running").asJava)
 
-    val otherFiltersString = system.settings.config.getConfig("akka.discovery.aws-api-ec2-tag-based").getString("filters")
+    val otherFiltersString =
+      system.settings.config.getConfig("akka.discovery.aws-api-ec2-tag-based").getString("filters")
 
-    val otherFilters: util.List[Filter] = otherFiltersString.split(";")
+    val otherFilters: util.List[Filter] = otherFiltersString
+      .split(";")
       .map(kv => kv.split("="))
       .toList
       .map(kv => {
         assert(kv.length == 2, "failed to parse one of the key-value pairs in filters")
         new Filter(kv(0), List(kv(1)).asJava)
-      }
-      )
+      })
       .asJava
 
     val request = new DescribeInstancesRequest()

--- a/discovery-aws-api/src/main/scala/akka/discovery/awsapi/ec2/Ec2TagBasedSimpleServiceDiscovery.scala
+++ b/discovery-aws-api/src/main/scala/akka/discovery/awsapi/ec2/Ec2TagBasedSimpleServiceDiscovery.scala
@@ -3,11 +3,13 @@
  */
 package akka.discovery.awsapi.ec2
 
+import java.util
+
 import akka.actor.ActorSystem
 import akka.discovery.SimpleServiceDiscovery
-import akka.discovery.SimpleServiceDiscovery.{ Resolved, ResolvedTarget }
+import akka.discovery.SimpleServiceDiscovery.{Resolved, ResolvedTarget}
 import com.amazonaws.services.ec2.AmazonEC2ClientBuilder
-import com.amazonaws.services.ec2.model.{ DescribeInstancesRequest, Filter }
+import com.amazonaws.services.ec2.model.{DescribeInstancesRequest, Filter}
 
 import scala.collection.JavaConverters._
 import scala.concurrent.Future
@@ -24,7 +26,22 @@ class Ec2TagBasedSimpleServiceDiscovery(system: ActorSystem) extends SimpleServi
 
     val runningInstancesFilter = new Filter("instance-state-name", List("running").asJava)
 
-    val request = new DescribeInstancesRequest().withFilters(tagFilter).withFilters(runningInstancesFilter)
+    val otherFiltersString = system.settings.config.getConfig("akka.discovery.aws-api-ec2-tag-based").getString("filters")
+
+    val otherFilters: util.List[Filter] = otherFiltersString.split(";")
+      .map(kv => kv.split("="))
+      .toList
+      .map(kv => {
+        assert(kv.length == 2, "failed to parse one of the key-value pairs in filters")
+        new Filter(kv(0), List(kv(1)).asJava)
+      }
+      )
+      .asJava
+
+    val request = new DescribeInstancesRequest()
+      .withFilters(tagFilter)
+      .withFilters(runningInstancesFilter)
+      .withFilters(otherFilters)
 
     implicit val timeout = resolveTimeout
 

--- a/docs/src/main/paradox/discovery.md
+++ b/docs/src/main/paradox/discovery.md
@@ -187,7 +187,7 @@ Screenshot of two tagged EC2 instances:
 
 ![EC2 instances](images/discovery-aws-ec2-tagged-instances.png)
 
-Note the tag **service** -> *products-api*. It's set on both instances. 
+Note the tag **service** -> *products-api*. It is set on both instances. 
  
 Note that this implementation is adequate for users running service clusters on *vanilla* EC2 instances. These
 instances can be created and tagged manually, or created via an auto-scaling group (ASG). If they are created via an ASG,

--- a/docs/src/main/paradox/discovery.md
+++ b/docs/src/main/paradox/discovery.md
@@ -227,14 +227,26 @@ Attach this IAM role to the instances that make up the cluster. See the docs for
 * In general, for the EC2 instances to "talk to each other" (necessary for forming a cluster), they need to be in the
 same security group and [the proper rules have to be set](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/security-group-rules-reference.html#sg-rules-other-instances).
 
-* You can set additional filters (by instance type, region, other tags etc.) in your `application.conf`, in the
-`akka.discovery.aws-api-ec2-tag-based.filters` key. The filters have to be `key=value` pairs separated by the semicolon
-character. For example, `akka.discovery.aws-api-ec2-tag-based.filters="instance-type=m1.small;tag:purpose=production"`.
+* You can set additional filters (by instance type, region, other tags etc.) in your application.conf file, in the
+`akka.discovery.aws-api-ec2-tag-based.filters` key. The filters have to be key=value pairs separated by the semicolon
+character. For example: 
+    ```
+    akka {
+      discovery {
+        aws-api-ec2-tag-based {
+          filters = "instance-type=m1.small;tag:purpose=production"
+        }
+      }
+    }
+    ```
 
 * This module does not support running multiple Akka nodes (i.e. multiple JVMs) per EC2 instance. 
 
 * You can change the default tag key from "service" to something else. This can be done via `application.conf`, by 
 setting `akka.discovery.aws-api-ec2-tag-based.tag-key` to something else. 
+    ```
+    akka.discovery.aws-api-ec2-tag-based.tag-key = "akka-cluster"
+    ```
 
 Demo:
 

--- a/docs/src/main/paradox/discovery.md
+++ b/docs/src/main/paradox/discovery.md
@@ -180,17 +180,17 @@ spec:
 ## Discovery Method: AWS API - EC2 Tag-Based Discovery
 
 If you're an AWS user, you can use tags to simply mark the instances that belong to the same cluster. Use a tag that
-has "service" as the key and set the value equal to your `akka.cluster.bootstrap.contact-point-discovery.service-name` 
-defined in `application.conf`.
+has "service" as the key and set the value equal to the name of your service (same value as `akka.cluster.bootstrap.contact-point-discovery.service-name` 
+defined in `application.conf`, if you're using this module for bootstrapping your Akka cluster).
  
 Screenshot of two tagged EC2 instances:
 
 ![EC2 instances](images/discovery-aws-ec2-tagged-instances.png)
 
-Note the tag **service** -> *products-api*. 
+Note the tag **service** -> *products-api*. It's set on both instances. 
  
 Note that this implementation is adequate for users running service clusters on *vanilla* EC2 instances. These
-instances can be created and tagged manually, or created via an auto-scaling group. If they are created via an ASG,
+instances can be created and tagged manually, or created via an auto-scaling group (ASG). If they are created via an ASG,
 they can be tagged automatically on creation. Simply add the tag to the auto-scaling group configuration and 
 ensure the "Tag New Instances" option is checked.
 
@@ -198,8 +198,6 @@ This implementation can also work with ECS / EKS with host-based networking, if 
 deploying one container per cluster member. If you're using Amazon EKS (Amazon Elastic Container Service for 
 Kubernetes), then you may want to use 
 the @ref:['Kubernetes API'-based discovery method](discovery.md#discovery-method-kubernetes-api) instead.
-
-
 
 ### Dependencies and usage
 
@@ -229,8 +227,19 @@ Attach this IAM role to the instances that make up the cluster. See the docs for
 * In general, for the EC2 instances to "talk to each other" (necessary for forming a cluster), they need to be in the
 same security group and [the proper rules have to be set](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/security-group-rules-reference.html#sg-rules-other-instances).
 
-* The implementation, at this time, does not filter based on region or instance type etc.
+* You can set additional filters (by instance type, region, other tags etc.) in your `application.conf`, in the
+`akka.discovery.aws-api-ec2-tag-based.filters` key. The filters have to be `key=value` pairs separated by the semicolon
+character. For example, `akka.discovery.aws-api-ec2-tag-based.filters="instance-type=m1.small;tag:purpose=production"`.
 
+* This module does not support running multiple Akka nodes (i.e. multiple JVMs) per EC2 instance. 
+
+* You can change the default tag key from "service" to something else. This can be done via `application.conf`, by 
+setting `akka.discovery.aws-api-ec2-tag-based.tag-key` to something else. 
+
+Demo:
+
+* A working demo app is available in the [bootstrap-joining-demo](https://github.com/akka/akka-management/tree/master/bootstrap-joining-demo/aws-api) 
+folder.
 
 ## How to contribute implementations
 


### PR DESCRIPTION
This allows the user to add additional filters to the tag based discovery. For example, you usually may want to subset by region or some tag that indicates the environment (test, production etc.). This is optional though. 