### PR TITLE
Enable remote address header for akka management server

### DIFF
--- a/management/src/main/scala/akka/management/AkkaManagement.scala
+++ b/management/src/main/scala/akka/management/AkkaManagement.scala
@@ -13,6 +13,7 @@ import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.Uri
 import akka.http.scaladsl.server.Directives.{ authenticateBasicAsync, pathPrefix, rawPathPrefix, AsyncAuthenticator }
 import akka.http.scaladsl.server.{ Directive, Directives, Route, RouteResult }
+import akka.http.scaladsl.settings.ServerSettings
 import akka.management.http.{ ManagementRouteProvider, ManagementRouteProviderSettings }
 import akka.stream.ActorMaterializer
 
@@ -106,7 +107,8 @@ final class AkkaManagement(implicit system: ExtendedActorSystem) extends Extensi
               RouteResult.route2HandlerFlow(routes),
               hostname,
               port,
-              connectionContext = this._connectionContext
+              connectionContext = this._connectionContext,
+              settings = ServerSettings(system).withRemoteAddressHeader(true)
             )
 
           serverBindingPromise.completeWith(serverFutureBinding).future.flatMap { _ =>


### PR DESCRIPTION
Fixes #91 

Enabled programatically so as to not affect other HTTP servers (that may not want it enabled).