### PR TITLE
Add setting to prevent a new cluster from being formed

### DIFF
--- a/cluster-bootstrap/src/main/resources/reference.conf
+++ b/cluster-bootstrap/src/main/resources/reference.conf
@@ -8,6 +8,10 @@ akka.management {
   http.route-providers += "akka.management.cluster.bootstrap.ClusterBootstrap$"
 
   cluster.bootstrap {
+    # When enabled, a new cluster will be formed via the bootstrapping mechanism. This can be disabled to only
+    # allow a node to join already existing clusters.
+
+    allow-formation = true
 
     # Configuration for the first phase of bootstraping, during which contact points are discovered
     # using the configured service discovery mechanism (e.g. DNS records).

--- a/cluster-bootstrap/src/main/resources/reference.conf
+++ b/cluster-bootstrap/src/main/resources/reference.conf
@@ -8,10 +8,10 @@ akka.management {
   http.route-providers += "akka.management.cluster.bootstrap.ClusterBootstrap$"
 
   cluster.bootstrap {
-    # When enabled, a new cluster will be formed via the bootstrapping mechanism. This can be disabled to only
+    # When enabled (default), a new cluster will be formed via the bootstrapping mechanism. This can be disabled to only
     # allow a node to join already existing clusters.
 
-    allow-formation = true
+    form-new-cluster = true
 
     # Configuration for the first phase of bootstraping, during which contact points are discovered
     # using the configured service discovery mechanism (e.g. DNS records).

--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/ClusterBootstrapSettings.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/ClusterBootstrapSettings.scala
@@ -21,6 +21,8 @@ final class ClusterBootstrapSettings(config: Config) {
 
   private val bootConfig = config.getConfig("akka.management.cluster.bootstrap")
 
+  val allowFormation: Boolean = bootConfig.getBoolean("allow-formation")
+
   object contactPointDiscovery {
     private val discoveryConfig: Config = bootConfig.getConfig("contact-point-discovery")
 

--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/ClusterBootstrapSettings.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/ClusterBootstrapSettings.scala
@@ -21,7 +21,7 @@ final class ClusterBootstrapSettings(config: Config) {
 
   private val bootConfig = config.getConfig("akka.management.cluster.bootstrap")
 
-  val allowFormation: Boolean = bootConfig.getBoolean("allow-formation")
+  val formNewCluster: Boolean = bootConfig.getBoolean("form-new-cluster")
 
   object contactPointDiscovery {
     private val discoveryConfig: Config = bootConfig.getConfig("contact-point-discovery")

--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/dns/HeadlessServiceDnsBootstrap.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/dns/HeadlessServiceDnsBootstrap.scala
@@ -178,7 +178,7 @@ final class HeadlessServiceDnsBootstrap(discovery: SimpleServiceDiscovery, setti
     case NoSeedNodesObtainedWithinDeadline(contactPoint) ⇒
       log.info(
           "Contact point [{}] exceeded stable margin with no seed-nodes in sight. " +
-          "Considering weather this node is allowed to JOIN itself to initiate a new cluster.", contactPoint)
+          "Considering whether this node is allowed to JOIN itself to initiate a new cluster.", contactPoint)
 
       onNoSeedNodesObtainedWithinStableDeadline(contactPoint)
   }

--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/dns/HttpContactPointBootstrap.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/dns/HttpContactPointBootstrap.scala
@@ -100,7 +100,7 @@ private[dns] class HttpContactPointBootstrap(
 
     case response @ SeedNodes(node, members) ⇒
       if (members.isEmpty) {
-        if (clusterNotObservedWithinDeadline && settings.allowFormation) {
+        if (clusterNotObservedWithinDeadline && settings.formNewCluster) {
           permitParentToFormClusterIfPossible()
 
           // if we are not the lowest address, we won't join ourselves,

--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/dns/HttpContactPointBootstrap.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/dns/HttpContactPointBootstrap.scala
@@ -100,7 +100,7 @@ private[dns] class HttpContactPointBootstrap(
 
     case response @ SeedNodes(node, members) ⇒
       if (members.isEmpty) {
-        if (clusterNotObservedWithinDeadline) {
+        if (clusterNotObservedWithinDeadline && settings.allowFormation) {
           permitParentToFormClusterIfPossible()
 
           // if we are not the lowest address, we won't join ourselves,
@@ -113,17 +113,10 @@ private[dns] class HttpContactPointBootstrap(
           scheduleNextContactPointProbing()
         }
       } else {
-        notifyParentNoSeedNodesWereFoundWithinDeadline(response)
-        // we notified the parent that it may join itself if it is the designated node,
-        // since we did not observe any existing cluster. However, in case this node
-        // can't join itself (it's not the lowest address), some other node will --
-        // so we continue probing.
-        //
-        // Summing up, one of the following will happen:
-        // A) this node is allowed to join itself, and does so, and stops this probing actor -- our job is done.
-        // B) some other node triggers the same process and joins itself
-        //    - in which case we'll notice seed-nodes in our probing sooner or later!
-        scheduleNextContactPointProbing()
+        // we have seed nodes, so we notify the parent. Our job is then done -- the parent
+        // will join the cluster
+
+        notifyParentSeedNodesWereFoundWithinDeadline(response)
       }
   }
 
@@ -137,7 +130,7 @@ private[dns] class HttpContactPointBootstrap(
     context.parent ! HeadlessServiceDnsBootstrap.Protocol.NoSeedNodesObtainedWithinDeadline(baseUri)
   }
 
-  private def notifyParentNoSeedNodesWereFoundWithinDeadline(members: SeedNodes): Unit = {
+  private def notifyParentSeedNodesWereFoundWithinDeadline(members: SeedNodes): Unit = {
     log.info("Found existing cluster, {} returned seed-nodes: {}", members.selfNode, members.seedNodes)
 
     val seedAddresses = members.seedNodes.map(_.node)

--- a/docs/src/main/paradox/bootstrap.md
+++ b/docs/src/main/paradox/bootstrap.md
@@ -114,6 +114,11 @@ from the contact points.
         - Notice that this phase is exactly the same as the "epidemic joining" in the more complicated Case 1 when a new 
           cluster has to be formed.
 
+Additionally, a setting is provided, `akka.cluster.bootstrap.form-new-cluster` that can be disabled to only allow the
+node to join existing clusters (Case 2 above). This can be used to provide additional safety during the typical deployment
+as it is relatively rare that no cluster exists. It can be specified in your `application.conf` or provided as an
+argument to the process itself via `-Dakka.cluster.bootstrap.form-new-cluster=<true|false>`. By default, it is enabled.
+
 In the next sections we explain the process in more detail.
 
 ### Case 1: "Initial" Bootstrap process


### PR DESCRIPTION
This a setting, `allow-formation` which when disabled will prevent a new cluster from being formed, i.e. it will only attempt to join others.

Fixes #95 