### PR TITLE
Discovery mechanism for Marathon API

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,7 @@ lazy val `akka-management-root` = project
     `akka-discovery`,
     `akka-discovery-dns`,
     `akka-discovery-kubernetes-api`,
+    `akka-discovery-marathon-api`,
     `akka-discovery-aws-api`,
     `akka-management`,
     `cluster-http`,
@@ -48,6 +49,18 @@ lazy val `akka-discovery-kubernetes-api` = project
     name := "akka-discovery-kubernetes-api",
     organization := "com.lightbend.akka.discovery",
     Dependencies.DiscoveryKubernetesApi
+  )
+  .dependsOn(`akka-discovery`)
+
+// Marathon API implementation of discovery, allows port discovery and formation to work even when readiness/health checks are failing
+lazy val `akka-discovery-marathon-api` = project
+  .in(file("discovery-marathon-api"))
+  .enablePlugins(AutomateHeaderPlugin)
+  .settings(unidocSettings)
+  .settings(
+    name := "akka-discovery-marathon-api",
+    organization := "com.lightbend.akka.discovery",
+    Dependencies.DiscoveryMarathonApi
   )
   .dependsOn(`akka-discovery`)
 

--- a/discovery-marathon-api/src/main/resources/reference.conf
+++ b/discovery-marathon-api/src/main/resources/reference.conf
@@ -1,0 +1,24 @@
+######################################################
+# Akka Service Discovery Marathon API Config         #
+######################################################
+
+akka.discovery {
+  # Set the following in your application.conf if you want to use this discovery mechanism:
+  # method = marathon-api
+
+  marathon-api {
+    class = akka.discovery.marathon.MarathonApiSimpleServiceDiscovery
+
+    # URL for getting list of apps from Marathon. Verified on OSS DC/OS 1.8, 1.9
+    # TODO: Future improvement would be keys for auth token, CA cert
+    app-api-url = "http://marathon.mesos:8080/v2/apps"
+
+    # The name of the akka management port - this cannot have underscores or dashes (env var name)
+    app-port-name = "akkamgmthttp"
+
+    # Used to find other apps running by Marathon. This will be passed as the label query string parameter
+    # to the apps-api-url defined above.
+    # `%s` will be replaced with the configured effective name, which defaults to the actor system name
+    app-label-query = "ACTOR_SYSTEM_NAME==%s"
+  }
+}

--- a/discovery-marathon-api/src/main/scala/akka/discovery/marathon/AppList.scala
+++ b/discovery-marathon-api/src/main/scala/akka/discovery/marathon/AppList.scala
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.discovery.marathon
+
+import scala.collection.immutable.Seq
+
+object AppList {
+  case class App(container: Option[Container], portDefinitions: Option[Seq[PortDefinition]], tasks: Option[Seq[Task]])
+  case class Container(portMappings: Option[Seq[PortMapping]])
+  case class Task(host: Option[String], ports: Option[Seq[Int]])
+  case class PortDefinition(name: Option[String], port: Option[Int])
+  case class PortMapping(servicePort: Option[Int], name: Option[String])
+}
+
+import AppList._
+
+case class AppList(apps: Seq[App])

--- a/discovery-marathon-api/src/main/scala/akka/discovery/marathon/JsonFormat.scala
+++ b/discovery-marathon-api/src/main/scala/akka/discovery/marathon/JsonFormat.scala
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.discovery.marathon
+
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import spray.json._
+import AppList._
+
+object JsonFormat extends SprayJsonSupport with DefaultJsonProtocol {
+  implicit val taskFormat: JsonFormat[Task] = jsonFormat2(Task)
+  implicit val portDefinitionFormat: JsonFormat[PortDefinition] = jsonFormat2(PortDefinition)
+  implicit val portMappingFormat: JsonFormat[PortMapping] = jsonFormat2(PortMapping)
+  implicit val containerFormat: JsonFormat[Container] = jsonFormat1(Container)
+  implicit val appFormat: JsonFormat[App] = jsonFormat3(App)
+  implicit val appListFormat: RootJsonFormat[AppList] = jsonFormat1(AppList.apply)
+}

--- a/discovery-marathon-api/src/main/scala/akka/discovery/marathon/MarathonApiSimpleServiceDiscovery.scala
+++ b/discovery-marathon-api/src/main/scala/akka/discovery/marathon/MarathonApiSimpleServiceDiscovery.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.discovery.marathon
+
+import akka.actor.ActorSystem
+import akka.discovery._
+import akka.http.scaladsl._
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.unmarshalling.Unmarshal
+import akka.stream.ActorMaterializer
+import scala.collection.immutable.Seq
+import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
+
+import AppList._
+import JsonFormat._
+import SimpleServiceDiscovery.{ Resolved, ResolvedTarget }
+
+object MarathonApiSimpleServiceDiscovery {
+
+  /**
+   * Finds relevant targets given a pod list. Note that this doesn't filter by name as it is the job of the selector
+   * to do that.
+   */
+  private[marathon] def targets(appList: AppList, portName: String): Seq[ResolvedTarget] = {
+    def appContainerPort(app: App) =
+      app.container
+        .flatMap(_.portMappings)
+        .getOrElse(Seq.empty)
+        .zipWithIndex
+        .find(_._1.name.contains(portName))
+        .map(_._2)
+
+    def appPort(app: App) =
+      app.portDefinitions.getOrElse(Seq.empty).zipWithIndex.find(_._1.name.contains(portName)).map(_._2)
+
+    // Tasks in the API don't have port names, so we have to look to the app to get the position we use
+    def portIndex(app: App) =
+      appContainerPort(app).orElse(appPort(app))
+
+    for {
+      app <- appList.apps
+      task <- app.tasks.getOrElse(Seq.empty)
+      portNumber <- portIndex(app)
+      taskHost <- task.host
+      taskPorts <- task.ports
+      taskAkkaManagementPort <- taskPorts.lift(portNumber)
+    } yield ResolvedTarget(taskHost, Some(taskAkkaManagementPort))
+  }
+}
+
+/**
+ * Service discovery that uses the Marathon API.
+ */
+class MarathonApiSimpleServiceDiscovery(system: ActorSystem) extends SimpleServiceDiscovery {
+  import MarathonApiSimpleServiceDiscovery._
+  import system.dispatcher
+
+  private val http = Http()(system)
+
+  private val settings = Settings(system)
+
+  private implicit val mat: ActorMaterializer = ActorMaterializer()(system)
+
+  def lookup(name: String, resolveTimeout: FiniteDuration): Future[Resolved] = {
+    val uri =
+      Uri(settings.appApiUrl).withQuery(Uri.Query("embed" -> "apps.tasks", "embed" -> "apps.deployments",
+          "label" -> settings.appLabelQuery.format(name)))
+
+    val request = HttpRequest(uri = uri)
+
+    for {
+      response <- http.singleRequest(request)
+
+      entity <- response.entity.toStrict(resolveTimeout)
+
+      appList <- Unmarshal(entity).to[AppList]
+
+    } yield Resolved(name, targets(appList, settings.appPortName))
+  }
+}

--- a/discovery-marathon-api/src/main/scala/akka/discovery/marathon/Settings.scala
+++ b/discovery-marathon-api/src/main/scala/akka/discovery/marathon/Settings.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.discovery.marathon
+
+import akka.actor._
+
+final class Settings(system: ExtendedActorSystem) extends Extension {
+  private val marathonApi = system.settings.config.getConfig("akka.discovery.marathon-api")
+
+  val appApiUrl: String =
+    marathonApi.getString("app-api-url")
+
+  val appPortName: String =
+    marathonApi.getString("app-port-name")
+
+  val appLabelQuery: String =
+    marathonApi.getString("app-label-query")
+}
+
+object Settings extends ExtensionId[Settings] with ExtensionIdProvider {
+  override def get(system: ActorSystem): Settings = super.get(system)
+
+  override def lookup: Settings.type = Settings
+
+  override def createExtension(system: ExtendedActorSystem): Settings = new Settings(system)
+}

--- a/discovery-marathon-api/src/test/resources/apps.json
+++ b/discovery-marathon-api/src/test/resources/apps.json
@@ -1,0 +1,412 @@
+{
+    "apps": [
+        {
+            "acceptedResourceRoles": [
+                "slave_public"
+            ],
+            "backoffFactor": 1.15,
+            "backoffSeconds": 1,
+            "container": {
+                "docker": {
+                    "forcePullImage": false,
+                    "image": "mesosphere/simple-docker",
+                    "parameters": [],
+                    "privileged": false
+                },
+                "portMappings": [
+                    {
+                        "containerPort": 0,
+                        "hostPort": 0,
+                        "labels": {},
+                        "name": "akka-mgmt-http",
+                        "protocol": "tcp",
+                        "servicePort": 10005
+                    }
+                ],
+                "type": "DOCKER",
+                "volumes": []
+            },
+            "cpus": 0.1,
+            "deployments": [],
+            "disk": 0,
+            "executor": "",
+            "gpus": 0,
+            "id": "/test/test2/nginx",
+            "instances": 1,
+            "killSelection": "YOUNGEST_FIRST",
+            "labels": {
+                "ACTOR_SYSTEM_NAME": "mytest"
+            },
+            "maxLaunchDelaySeconds": 3600,
+            "mem": 64,
+            "networks": [
+                {
+                    "mode": "container/bridge"
+                }
+            ],
+            "requirePorts": false,
+            "tasks": [
+                {
+                    "appId": "/test/test2/nginx",
+                    "host": "192.168.65.60",
+                    "id": "test_test2_nginx.37c4831e-f702-11e7-a764-70b3d5800001",
+                    "ipAddresses": [
+                        {
+                            "ipAddress": "172.17.0.5",
+                            "protocol": "IPv4"
+                        }
+                    ],
+                    "ports": [
+                        23236
+                    ],
+                    "slaveId": "b8655d84-dbd5-44c2-a932-e9c2399e2371-S3",
+                    "stagedAt": "2018-01-11T19:04:15.572Z",
+                    "startedAt": "2018-01-11T19:04:16.395Z",
+                    "state": "TASK_RUNNING",
+                    "version": "2018-01-11T19:04:15.529Z"
+                }
+            ],
+            "tasksHealthy": 0,
+            "tasksRunning": 1,
+            "tasksStaged": 0,
+            "tasksUnhealthy": 0,
+            "unreachableStrategy": {
+                "expungeAfterSeconds": 0,
+                "inactiveAfterSeconds": 0
+            },
+            "upgradeStrategy": {
+                "maximumOverCapacity": 1,
+                "minimumHealthCapacity": 1
+            },
+            "version": "2018-01-11T19:04:15.529Z",
+            "versionInfo": {
+                "lastConfigChangeAt": "2018-01-11T19:04:15.529Z",
+                "lastScalingAt": "2018-01-11T19:04:15.529Z"
+            }
+        },
+        {
+            "backoffFactor": 1.15,
+            "backoffSeconds": 1,
+            "cmd": "sleep 100000000",
+            "container": {
+                "type": "MESOS",
+                "volumes": []
+            },
+            "cpus": 1,
+            "deployments": [],
+            "disk": 0,
+            "executor": "",
+            "gpus": 0,
+            "id": "/my-interactive-app2",
+            "instances": 1,
+            "killSelection": "YOUNGEST_FIRST",
+            "labels": {},
+            "maxLaunchDelaySeconds": 3600,
+            "mem": 128,
+            "networks": [
+                {
+                    "mode": "host"
+                }
+            ],
+            "portDefinitions": [
+                {
+                    "port": 10000,
+                    "protocol": "tcp",
+                    "name": "akka-mgmt-http"
+                },
+                {
+                    "port": 10001,
+                    "protocol": "tcp"
+                },
+                {
+                    "port": 10002,
+                    "protocol": "tcp"
+                }
+            ],
+            "requirePorts": false,
+            "tasks": [
+                {
+                    "appId": "/my-interactive-app2",
+                    "host": "192.168.65.111",
+                    "id": "my-interactive-app2.baeb50f6-f6fa-11e7-a764-70b3d5800001",
+                    "ipAddresses": [
+                        {
+                            "ipAddress": "192.168.65.111",
+                            "protocol": "IPv4"
+                        }
+                    ],
+                    "ports": [
+                        6850,
+                        6851,
+                        6852
+                    ],
+                    "slaveId": "b8655d84-dbd5-44c2-a932-e9c2399e2371-S2",
+                    "stagedAt": "2018-01-11T18:10:39.634Z",
+                    "startedAt": "2018-01-11T18:10:39.797Z",
+                    "state": "TASK_RUNNING",
+                    "version": "2018-01-11T18:10:39.605Z"
+                }
+            ],
+            "tasksHealthy": 0,
+            "tasksRunning": 1,
+            "tasksStaged": 0,
+            "tasksUnhealthy": 0,
+            "unreachableStrategy": {
+                "expungeAfterSeconds": 0,
+                "inactiveAfterSeconds": 0
+            },
+            "upgradeStrategy": {
+                "maximumOverCapacity": 1,
+                "minimumHealthCapacity": 1
+            },
+            "version": "2018-01-11T18:10:39.605Z",
+            "versionInfo": {
+                "lastConfigChangeAt": "2018-01-11T18:10:39.605Z",
+                "lastScalingAt": "2018-01-11T18:10:39.605Z"
+            }
+        },
+        {
+            "backoffFactor": 1.15,
+            "backoffSeconds": 1,
+            "cmd": "sleep 100000000",
+            "container": {
+                "type": "MESOS",
+                "volumes": []
+            },
+            "cpus": 1,
+            "deployments": [],
+            "disk": 0,
+            "executor": "",
+            "gpus": 0,
+            "id": "/my-interactive-app",
+            "instances": 1,
+            "killSelection": "YOUNGEST_FIRST",
+            "labels": {},
+            "maxLaunchDelaySeconds": 3600,
+            "mem": 128,
+            "networks": [
+                {
+                    "mode": "host"
+                }
+            ],
+            "portDefinitions": [
+                {
+                    "name": "test",
+                    "port": 10000,
+                    "protocol": "tcp"
+                },
+                {
+                    "port": 10001,
+                    "protocol": "tcp"
+                },
+                {
+                    "port": 10002,
+                    "protocol": "tcp"
+                }
+            ],
+            "requirePorts": false,
+            "tasks": [
+                {
+                    "appId": "/my-interactive-app",
+                    "host": "192.168.65.111",
+                    "id": "my-interactive-app.e5227d6d-f701-11e7-a764-70b3d5800001",
+                    "ipAddresses": [
+                        {
+                            "ipAddress": "192.168.65.111",
+                            "protocol": "IPv4"
+                        }
+                    ],
+                    "ports": [
+                        14041,
+                        14042,
+                        14043
+                    ],
+                    "slaveId": "b8655d84-dbd5-44c2-a932-e9c2399e2371-S2",
+                    "stagedAt": "2018-01-11T19:01:56.937Z",
+                    "startedAt": "2018-01-11T19:01:57.187Z",
+                    "state": "TASK_RUNNING",
+                    "version": "2018-01-11T19:01:56.151Z"
+                }
+            ],
+            "tasksHealthy": 0,
+            "tasksRunning": 1,
+            "tasksStaged": 0,
+            "tasksUnhealthy": 0,
+            "unreachableStrategy": {
+                "expungeAfterSeconds": 0,
+                "inactiveAfterSeconds": 0
+            },
+            "upgradeStrategy": {
+                "maximumOverCapacity": 1,
+                "minimumHealthCapacity": 1
+            },
+            "version": "2018-01-11T19:01:56.151Z",
+            "versionInfo": {
+                "lastConfigChangeAt": "2018-01-11T19:01:56.151Z",
+                "lastScalingAt": "2018-01-11T19:01:56.151Z"
+            }
+        },
+        {
+            "acceptedResourceRoles": [
+                "slave_public"
+            ],
+            "backoffFactor": 1.15,
+            "backoffSeconds": 1,
+            "container": {
+                "docker": {
+                    "forcePullImage": false,
+                    "image": "mesosphere/simple-docker",
+                    "parameters": [],
+                    "privileged": false
+                },
+                "portMappings": [
+                    {
+                        "containerPort": 80,
+                        "hostPort": 0,
+                        "labels": {},
+                        "protocol": "tcp",
+                        "servicePort": 10004
+                    }
+                ],
+                "type": "DOCKER",
+                "volumes": []
+            },
+            "cpus": 0.1,
+            "deployments": [],
+            "disk": 0,
+            "executor": "",
+            "gpus": 0,
+            "id": "/nginx2",
+            "instances": 1,
+            "killSelection": "YOUNGEST_FIRST",
+            "labels": {},
+            "maxLaunchDelaySeconds": 3600,
+            "mem": 64,
+            "networks": [
+                {
+                    "mode": "container/bridge"
+                }
+            ],
+            "requirePorts": false,
+            "tasks": [
+                {
+                    "appId": "/nginx2",
+                    "host": "192.168.65.60",
+                    "id": "nginx2.6b50e929-f6fe-11e7-a764-70b3d5800001",
+                    "ipAddresses": [
+                        {
+                            "ipAddress": "172.17.0.3",
+                            "protocol": "IPv4"
+                        }
+                    ],
+                    "ports": [
+                        31242
+                    ],
+                    "slaveId": "b8655d84-dbd5-44c2-a932-e9c2399e2371-S3",
+                    "stagedAt": "2018-01-11T18:37:04.069Z",
+                    "startedAt": "2018-01-11T18:37:04.909Z",
+                    "state": "TASK_RUNNING",
+                    "version": "2018-01-11T18:37:04.018Z"
+                }
+            ],
+            "tasksHealthy": 0,
+            "tasksRunning": 1,
+            "tasksStaged": 0,
+            "tasksUnhealthy": 0,
+            "unreachableStrategy": {
+                "expungeAfterSeconds": 0,
+                "inactiveAfterSeconds": 0
+            },
+            "upgradeStrategy": {
+                "maximumOverCapacity": 1,
+                "minimumHealthCapacity": 1
+            },
+            "version": "2018-01-11T18:37:04.018Z",
+            "versionInfo": {
+                "lastConfigChangeAt": "2018-01-11T18:37:04.018Z",
+                "lastScalingAt": "2018-01-11T18:37:04.018Z"
+            }
+        },
+        {
+            "acceptedResourceRoles": [
+                "slave_public"
+            ],
+            "backoffFactor": 1.15,
+            "backoffSeconds": 1,
+            "container": {
+                "docker": {
+                    "forcePullImage": false,
+                    "image": "mesosphere/simple-docker",
+                    "parameters": [],
+                    "privileged": false
+                },
+                "portMappings": [
+                    {
+                        "containerPort": 80,
+                        "hostPort": 0,
+                        "labels": {},
+                        "protocol": "tcp",
+                        "servicePort": 10003
+                    }
+                ],
+                "type": "DOCKER",
+                "volumes": []
+            },
+            "cpus": 0.1,
+            "deployments": [],
+            "disk": 0,
+            "executor": "",
+            "gpus": 0,
+            "id": "/nginx",
+            "instances": 1,
+            "killSelection": "YOUNGEST_FIRST",
+            "labels": {},
+            "maxLaunchDelaySeconds": 3600,
+            "mem": 64,
+            "networks": [
+                {
+                    "mode": "container/bridge"
+                }
+            ],
+            "requirePorts": false,
+            "tasks": [
+                {
+                    "appId": "/nginx",
+                    "host": "192.168.65.60",
+                    "id": "nginx.3ecf21b8-f6fd-11e7-a764-70b3d5800001",
+                    "ipAddresses": [
+                        {
+                            "ipAddress": "172.17.0.2",
+                            "protocol": "IPv4"
+                        }
+                    ],
+                    "ports": [
+                        6356
+                    ],
+                    "slaveId": "b8655d84-dbd5-44c2-a932-e9c2399e2371-S3",
+                    "stagedAt": "2018-01-11T18:28:39.901Z",
+                    "startedAt": "2018-01-11T18:28:42.147Z",
+                    "state": "TASK_RUNNING",
+                    "version": "2018-01-11T18:28:39.862Z"
+                }
+            ],
+            "tasksHealthy": 0,
+            "tasksRunning": 1,
+            "tasksStaged": 0,
+            "tasksUnhealthy": 0,
+            "unreachableStrategy": {
+                "expungeAfterSeconds": 0,
+                "inactiveAfterSeconds": 0
+            },
+            "upgradeStrategy": {
+                "maximumOverCapacity": 1,
+                "minimumHealthCapacity": 1
+            },
+            "version": "2018-01-11T18:28:39.862Z",
+            "versionInfo": {
+                "lastConfigChangeAt": "2018-01-11T18:28:39.862Z",
+                "lastScalingAt": "2018-01-11T18:28:39.862Z"
+            }
+        }
+    ]
+}

--- a/discovery-marathon-api/src/test/scala/akka/discovery/marathon/MarathonApiSimpleServiceDiscoverySpec.scala
+++ b/discovery-marathon-api/src/test/scala/akka/discovery/marathon/MarathonApiSimpleServiceDiscoverySpec.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.discovery.marathon
+
+import akka.discovery.SimpleServiceDiscovery.ResolvedTarget
+import org.scalatest.{ Matchers, WordSpec }
+import spray.json._
+import scala.io.Source
+
+class MarathonApiSimpleServiceDiscoverySpec extends WordSpec with Matchers {
+  "targets" should {
+    "calculate the correct list of resolved targets" in {
+      val data = resourceAsString("apps.json")
+
+      val appList = JsonFormat.appListFormat.read(data.parseJson)
+
+      MarathonApiSimpleServiceDiscovery.targets(appList, "akka-mgmt-http") shouldBe List(
+          ResolvedTarget("192.168.65.60", Some(23236)), ResolvedTarget("192.168.65.111", Some(6850)))
+    }
+  }
+
+  private def resourceAsString(name: String): String =
+    Source.fromInputStream(getClass.getClassLoader.getResourceAsStream(name)).mkString
+}

--- a/docs/src/main/paradox/discovery.md
+++ b/docs/src/main/paradox/discovery.md
@@ -177,6 +177,51 @@ spec:
           protocol: TCP
 ```
 
+## Discovery Method: Marathon API
+
+If you're a Mesos or DC/OS user, you can use the provided Marathon API implementation. You'll need to add a label
+to your Marathon JSON (named `ACTOR_SYSTEM_NAME`  by default) and set the value equal to the name of the configured
+effective name, which defaults to your applications actor system name.
+
+You'll also have to add a named port, by default `akkamgmthttp`, and ensure that Akka Management's HTTP interface
+is bound to this port.
+
+### Dependencies and usage
+
+This is a separate JAR file:
+
+@@dependency[sbt,Gradle,Maven] {
+  group="com.lightbend.akka.discovery"
+  artifact="akka-discovery-marathon-api"
+  version="$version$"
+}
+
+And in your `application.conf`:
+
+```
+akka.discovery {
+  method = marathon-api
+}
+```
+
+And in your `marathon.json`:
+```
+{
+   ...
+   "cmd": "path-to-your-app -Dakka.remote.netty.tcp.hostname=$HOST -Dakka.remote.netty.tcp.port=$PORT_AKKAREMOTE -Dakka.management.http.hostname=$HOST -Dakka.management.http.port=$PORT_AKKAMGMTHTTP",
+
+   "labels": {
+     "ACTOR_SYSTEM_NAME": "my-system"
+   },
+
+   "portDefinitions": [
+     { "port": 0, "name": "akkaremote" },
+     { "port": 0, "name": "akkamgmthttp" }
+   ]
+   ...
+}
+```
+
 ## Discovery Method: AWS API - EC2 Tag-Based Discovery
 
 If you're an AWS user, you can use tags to simply mark the instances that belong to the same cluster. Use a tag that

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -73,6 +73,12 @@ object Dependencies {
       DependencyGroups.AkkaHttp
   )
 
+  val DiscoveryMarathonApi = Seq(
+    libraryDependencies ++=
+      DependencyGroups.AkkaActor ++
+        DependencyGroups.AkkaHttp
+  )
+
   val DiscoveryAwsApi = Seq(
     libraryDependencies ++=
       DependencyGroups.AkkaActor ++ Seq("com.amazonaws" % "aws-java-sdk-ec2" % "1.11.257")


### PR DESCRIPTION
This adds another discovery mechanism, this time for Marathon. This allows you to discover other nodes for the bootstrapping process while also defining health checks. It also allows you to take advantage of DC/OS's dynamic port declarations.

I've verified this with an example I'm preparing in another repository. I'll try to clean it up and submit it as an example in this repo via a follow-up PR.