### PR TITLE
Mesos bridge mode support

### DIFF
--- a/docs/src/main/paradox/akka-management.md
+++ b/docs/src/main/paradox/akka-management.md
@@ -114,6 +114,19 @@ Java
     AkkaManagement.get(actorSystem2).start();
     ```
 
+When running akka nodes behind NATs or inside docker containers in bridge mode, 
+it's necessary to set different hostname and port number to bind for the HTTP Server for Http Cluster Management:
+
+application.conf
+:   ```
+    akka.management.http.hostname = ${HOST} //Get hostname from environmental variable HOST
+    akka.management.port = 19999
+    akka.management.port = ${?PORT_19999} //Get port from environmental variable PORT_19999 if it's defined, otherwise 19999
+
+    akka.management.http.bind-hostname = 0.0.0.0
+    akka.management.http.bind-port = 19999    
+    ```  
+
 It is also possible to modify the base path of the API, by setting the appropriate value in application conf: 
 
 application.conf

--- a/management/src/main/resources/reference.conf
+++ b/management/src/main/resources/reference.conf
@@ -29,27 +29,27 @@ akka.management {
     #
     # akka.management.http.port = 2552
     # akka.management.http.bind-port = 2553
-    # Network interface will be bound to the 2553 port, but remoting protocol will
+    # Network interface will be bound to the 2553 port, but the HTTP Server for Http Cluster Management will
     # expect messages sent to port 2552.
     #
     # akka.management.http.port = 0
     # akka.management.http.bind-port = 0
-    # Network interface will be bound to a random port, and remoting protocol will
+    # Network interface will be bound to a random port, and the HTTP Server for Http Cluster Management will
     # expect messages sent to the bound port.
     #
     # akka.management.http.port = 2552
     # akka.management.http.bind-port = 0
-    # Network interface will be bound to a random port, but remoting protocol will
+    # Network interface will be bound to a random port, but the HTTP Server for Http Cluster Management will
     # expect messages sent to port 2552.
     #
     # akka.management.http.port = 0
     # akka.management.http.bind-port = 2553
-    # Network interface will be bound to the 2553 port, and remoting protocol will
+    # Network interface will be bound to the 2553 port, and the HTTP Server for Http Cluster Management will
     # expect messages sent to the bound port.
     #
     # akka.management.http.port = 2552
     # akka.management.http.bind-port = ""
-    # Network interface will be bound to the 2552 port, and remoting protocol will
+    # Network interface will be bound to the 2552 port, and the HTTP Server for Http Cluster Management will
     # expect messages sent to the bound port.
     #
     # akka.management.http.port if empty

--- a/management/src/main/resources/reference.conf
+++ b/management/src/main/resources/reference.conf
@@ -16,6 +16,45 @@ akka.management {
     # The value will need to be from 0 to 65535.
     port = 19999
 
+    # Use this setting to bind a network interface to a different hostname or ip
+    # than the HTTP Server for Http Cluster Management.
+    # Use "0.0.0.0" to bind to all interfaces.
+    # akka.management.http.hostname if empty
+    bind-hostname = ""
+
+    # Use this setting to bind a network interface to a different port
+    # than the HTTP Server for Http Cluster Management. This may be used
+    # when running akka nodes in a separated networks (under NATs or docker containers).
+    # Use 0 if you want a random available port. Examples:
+    #
+    # akka.management.http.port = 2552
+    # akka.management.http.bind-port = 2553
+    # Network interface will be bound to the 2553 port, but remoting protocol will
+    # expect messages sent to port 2552.
+    #
+    # akka.management.http.port = 0
+    # akka.management.http.bind-port = 0
+    # Network interface will be bound to a random port, and remoting protocol will
+    # expect messages sent to the bound port.
+    #
+    # akka.management.http.port = 2552
+    # akka.management.http.bind-port = 0
+    # Network interface will be bound to a random port, but remoting protocol will
+    # expect messages sent to port 2552.
+    #
+    # akka.management.http.port = 0
+    # akka.management.http.bind-port = 2553
+    # Network interface will be bound to the 2553 port, and remoting protocol will
+    # expect messages sent to the bound port.
+    #
+    # akka.management.http.port = 2552
+    # akka.management.http.bind-port = ""
+    # Network interface will be bound to the 2552 port, and remoting protocol will
+    # expect messages sent to the bound port.
+    #
+    # akka.management.http.port if empty
+    bind-port = ""
+
     # path prefix for all management routes, usually best to keep the default value here
     base-path = ""
 

--- a/management/src/main/resources/reference.conf
+++ b/management/src/main/resources/reference.conf
@@ -25,32 +25,7 @@ akka.management {
     # Use this setting to bind a network interface to a different port
     # than the HTTP Server for Http Cluster Management. This may be used
     # when running akka nodes in a separated networks (under NATs or docker containers).
-    # Use 0 if you want a random available port. Examples:
-    #
-    # akka.management.http.port = 2552
-    # akka.management.http.bind-port = 2553
-    # Network interface will be bound to the 2553 port, but the HTTP Server for Http Cluster Management will
-    # expect messages sent to port 2552.
-    #
-    # akka.management.http.port = 0
-    # akka.management.http.bind-port = 0
-    # Network interface will be bound to a random port, and the HTTP Server for Http Cluster Management will
-    # expect messages sent to the bound port.
-    #
-    # akka.management.http.port = 2552
-    # akka.management.http.bind-port = 0
-    # Network interface will be bound to a random port, but the HTTP Server for Http Cluster Management will
-    # expect messages sent to port 2552.
-    #
-    # akka.management.http.port = 0
-    # akka.management.http.bind-port = 2553
-    # Network interface will be bound to the 2553 port, and the HTTP Server for Http Cluster Management will
-    # expect messages sent to the bound port.
-    #
-    # akka.management.http.port = 2552
-    # akka.management.http.bind-port = ""
-    # Network interface will be bound to the 2552 port, and the HTTP Server for Http Cluster Management will
-    # expect messages sent to the bound port.
+    # Use 0 if you want a random available port.
     #
     # akka.management.http.port if empty
     bind-port = ""

--- a/management/src/main/scala/akka/management/AkkaManagement.scala
+++ b/management/src/main/scala/akka/management/AkkaManagement.scala
@@ -86,8 +86,8 @@ final class AkkaManagement(implicit system: ExtendedActorSystem) extends Extensi
       val hostname = settings.Http.Hostname
       val port = settings.Http.Port
 
-      val bindHostname = settings.Http.BindHostname
-      val bindPort = settings.Http.BindPort
+      val effectiveBindHostname = settings.Http.EffectiveBindHostname
+      val effectiveBindPort = settings.Http.EffectiveBindPort
 
       // port is on purpose never inferred from protocol, because this HTTP endpoint is not the "main" one for the app
       val protocol = if (_connectionContext.isSecure) "https" else "http"
@@ -104,18 +104,18 @@ final class AkkaManagement(implicit system: ExtendedActorSystem) extends Extensi
           // ----
           // FIXME -- think about the style of how we want to make these available
 
-          log.info("Binding Akka Management (HTTP) endpoint to: {}:{}", bindHostname, bindPort)
+          log.info("Binding Akka Management (HTTP) endpoint to: {}:{}", effectiveBindHostname, effectiveBindPort)
 
           val serverFutureBinding =
             Http().bindAndHandle(
               RouteResult.route2HandlerFlow(routes),
-              bindHostname,
-              bindPort,
+              effectiveBindHostname,
+              effectiveBindPort,
               connectionContext = this._connectionContext
             )
 
           serverBindingPromise.completeWith(serverFutureBinding).future.flatMap { _ =>
-            log.info("Bound Akka Management (HTTP) endpoint to: {}:{}", bindHostname, bindPort)
+            log.info("Bound Akka Management (HTTP) endpoint to: {}:{}", effectiveBindHostname, effectiveBindPort)
             selfUriPromise.success(selfBaseUri).future
           }
 

--- a/management/src/main/scala/akka/management/AkkaManagementSettings.scala
+++ b/management/src/main/scala/akka/management/AkkaManagementSettings.scala
@@ -29,6 +29,19 @@ final class AkkaManagementSettings(val config: Config) {
       p
     }
 
+    val BindHostname: String = cc.getString("bind-hostname") match {
+      case "" ⇒ Hostname
+      case value ⇒ value
+    }
+
+    val BindPort: Int = cc.getString("bind-port") match {
+      case "" ⇒ Port
+      case value ⇒
+        val p = value.toInt
+        require(p >= 0, s"akka.management.http.bind-port MUST be > 0 (was ${p})")
+        p
+    }
+
     val BasePath: Option[String] =
       Option(cc.getString("base-path")).flatMap(it ⇒ if (it.trim == "") None else Some(it))
 

--- a/management/src/main/scala/akka/management/AkkaManagementSettings.scala
+++ b/management/src/main/scala/akka/management/AkkaManagementSettings.scala
@@ -29,12 +29,12 @@ final class AkkaManagementSettings(val config: Config) {
       p
     }
 
-    val BindHostname: String = cc.getString("bind-hostname") match {
+    val EffectiveBindHostname: String = cc.getString("bind-hostname") match {
       case "" ⇒ Hostname
       case value ⇒ value
     }
 
-    val BindPort: Int = cc.getString("bind-port") match {
+    val EffectiveBindPort: Int = cc.getString("bind-port") match {
       case "" ⇒ Port
       case value ⇒
         val p = value.toInt

--- a/management/src/main/scala/akka/management/AkkaManagementSettings.scala
+++ b/management/src/main/scala/akka/management/AkkaManagementSettings.scala
@@ -25,7 +25,7 @@ final class AkkaManagementSettings(val config: Config) {
 
     val Port: Int = {
       val p = cc.getInt("port")
-      require(p >= 0, s"akka.management.http.port MUST be > 0 (was ${p})")
+      require(0 to 65535 contains p, s"akka.management.http.port must be 0 through 65535 (was ${p})")
       p
     }
 
@@ -38,7 +38,7 @@ final class AkkaManagementSettings(val config: Config) {
       case "" ⇒ Port
       case value ⇒
         val p = value.toInt
-        require(p >= 0, s"akka.management.http.bind-port MUST be > 0 (was ${p})")
+        require(0 to 65535 contains p, s"akka.management.http.bind-port must be 0 through 65535 (was ${p})")
         p
     }
 


### PR DESCRIPTION
In order to support network bridge mode on Mesosphere, had to introduce bind-hostname to be able bind to interface within container, but still be able to address it externally and compare it with the list of seed nodes provided by bootstrap.

It solves the issue described in https://github.com/akka/akka-management/issues/64