### PR TITLE
Add example for using Marathon API

### DIFF
--- a/bootstrap-joining-demo/marathon-api/README.md
+++ b/bootstrap-joining-demo/marathon-api/README.md
@@ -1,0 +1,60 @@
+Your Akka Cluster on DC/OS
+==========================
+
+Prerequisites
+-------------
+
+* A DC/OS cluster with `dcos` command configured to point at it
+* SBT
+* Webserver to host build artifact
+* A terminal with working directory `bootstrap-joining-demo/marathon-api`
+
+Step 1: Package the App
+-----------------------
+
+Compile and package the demo app.
+
+```bash
+sbt universal:packageZipTarball
+```
+
+Now, in the `target/universal` folder, you should have a
+`bootstrap-joining-demo-marathon-api-0.1.0.tgz` file. 
+
+Step 2: Upload the App
+----------------------
+
+Upload `bootstrap-joining-demo-marathon-api-0.1.0.tgz` to a webserver that your DC/OS cluster can access.
+
+
+Step 3: Edit Config
+-------------------
+
+Edit `marathon/app.json`, replacing the value at `fetch[0].uri` ("http://yourwebserver.example.com/bootstrap-joining-demo-marathon-api-0.1.0.tgz")
+with the URL of the packaged application.
+
+Step 4: Deploy the App
+----------------------
+
+Using the `dcos` command, deploy the application:
+
+```bash
+dcos marathon app add dcos/marathon.json
+```
+
+Step 5: Verify the cluster formation
+------------------------------------
+
+Using `dcos task log` you can watch the output of the application.
+
+```bash
+dcos task log --follow bootstrap-joining-demo-marathon-api-0.1.0
+```
+
+Successful log output will look something like the following:
+
+```
+[INFO] [01/11/2018 21:19:48.113] [my-system-akka.actor.default-dispatcher-6] [akka.cluster.Cluster(akka://my-system)] Cluster Node [akka.tcp://my-system@192.168.65.111:14878] - Sending InitJoinAck message from node [akka.tcp://my-system@192.168.65.111:14878] to [Actor[akka.tcp://my-system@192.168.65.111:7664/system/cluster/core/daemon/joinSeedNodeProcess-1#-1012708477]]
+[INFO] [01/11/2018 21:19:48.145] [my-system-akka.actor.default-dispatcher-6] [akka.cluster.Cluster(akka://my-system)] Cluster Node [akka.tcp://my-system@192.168.65.111:14878] - Node [akka.tcp://my-system@192.168.65.111:7664] is JOINING, roles [dc-default]
+[INFO] [01/11/2018 21:19:49.139] [my-system-akka.actor.default-dispatcher-18] [akka.cluster.Cluster(akka://my-system)] Cluster Node [akka.tcp://my-system@192.168.65.111:14878] - Leader is moving node [akka.tcp://my-system@192.168.65.111:7664] to [Up]
+```

--- a/bootstrap-joining-demo/marathon-api/build.sbt
+++ b/bootstrap-joining-demo/marathon-api/build.sbt
@@ -1,0 +1,14 @@
+enablePlugins(JavaServerAppPackaging)
+name := "bootstrap-joining-demo-marathon-api"
+
+version := "0.1.0"
+
+scalaVersion := "2.12.4"
+
+libraryDependencies ++= Vector(
+  "com.lightbend.akka.management" %% "akka-management-cluster-bootstrap" % "0.8.1",
+
+  "com.lightbend.akka.management" %% "akka-management-cluster-http" % "0.8.1",
+
+  "com.lightbend.akka.discovery" %% "akka-discovery-marathon-api" % "0.8.1"
+)

--- a/bootstrap-joining-demo/marathon-api/marathon/app.json
+++ b/bootstrap-joining-demo/marathon-api/marathon/app.json
@@ -1,0 +1,34 @@
+{
+  "id": "/bootstrap-joining-demo-marathon-api-0.1.0",
+  "cmd": "./bootstrap-joining-demo-marathon-api-0.1.0/bin/bootstrap-joining-demo-marathon-api -java-home $(echo $(pwd)/jre*) -Dakka.remote.netty.tcp.hostname=$HOST -Dakka.remote.netty.tcp.port=$PORT_AKKAREMOTE -Dakka.management.http.hostname=$HOST -Dakka.management.http.port=$PORT_AKKAMGMTHTTP",
+  "cpus": 1.0,
+  "mem": 512,
+  "instances": 2,
+  "labels": {
+    "ACTOR_SYSTEM_NAME": "my-system"
+  },
+  "portDefinitions": [
+    {
+      "port": 0,
+      "name": "akkaremote"
+    },
+    {
+      "port": 0,
+      "name": "akkamgmthttp"
+    }
+  ],
+  "fetch": [
+    {
+      "uri": "http://yourwebserver.example.com/bootstrap-joining-demo-marathon-api-0.1.0.tgz",
+      "extract": true,
+      "executable": false,
+      "cache": false
+    },
+    {
+      "uri": "https://downloads.mesosphere.com/java/jre-8u121-linux-x64.tar.gz",
+      "extract": true,
+      "executable": false,
+      "cache": true
+    }
+  ]
+}

--- a/bootstrap-joining-demo/marathon-api/project/build.properties
+++ b/bootstrap-joining-demo/marathon-api/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.16

--- a/bootstrap-joining-demo/marathon-api/project/plugins.sbt
+++ b/bootstrap-joining-demo/marathon-api/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.2")

--- a/bootstrap-joining-demo/marathon-api/src/main/resources/application.conf
+++ b/bootstrap-joining-demo/marathon-api/src/main/resources/application.conf
@@ -1,6 +1,6 @@
 akka {
 
-  discovery.method = aws-api-ec2-tag-based
+  discovery.method = marathon-api-based
 
   actor {
     provider = "cluster"

--- a/bootstrap-joining-demo/marathon-api/src/main/resources/application.conf
+++ b/bootstrap-joining-demo/marathon-api/src/main/resources/application.conf
@@ -1,0 +1,39 @@
+akka {
+
+  discovery.method = aws-api-ec2-tag-based
+
+  actor {
+    provider = "cluster"
+  }
+
+  remote {
+    netty.tcp {
+      port = 2551
+    }
+  }
+
+  management {
+    http {
+      port = 19999
+    }
+  }
+
+  management {
+
+    cluster.bootstrap {
+
+      contact-point-discovery {
+        service-name = "products-api"
+      }
+
+      contact-point {
+        fallback-port = 19999
+
+        no-seeds-stable-margin = 5 seconds
+      }
+
+    }
+
+  }
+
+}

--- a/bootstrap-joining-demo/marathon-api/src/main/resources/application.conf
+++ b/bootstrap-joining-demo/marathon-api/src/main/resources/application.conf
@@ -1,6 +1,6 @@
 akka {
 
-  discovery.method = marathon-api-based
+  discovery.method = marathon-api
 
   actor {
     provider = "cluster"

--- a/bootstrap-joining-demo/marathon-api/src/main/scala/akka/cluster/bootstrap/DemoApp.scala
+++ b/bootstrap-joining-demo/marathon-api/src/main/scala/akka/cluster/bootstrap/DemoApp.scala
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.cluster.bootstrap
+
+import akka.actor.ActorSystem
+import akka.management.AkkaManagement
+import akka.management.cluster.bootstrap.ClusterBootstrap
+
+object DemoApp extends App {
+
+  implicit val system = ActorSystem("my-system")
+
+  AkkaManagement(system).start()
+  ClusterBootstrap(system).start()
+
+}


### PR DESCRIPTION
Adds an example for #98. Example won't work until a release is done with that PR in (version used is 0.8.1 below, can change if released with different version)