### PR TITLE
Re-discover when contact point probing fails 

### DIFF
--- a/cluster-bootstrap/src/main/resources/reference.conf
+++ b/cluster-bootstrap/src/main/resources/reference.conf
@@ -73,6 +73,10 @@ akka.management {
       # coordinating process may decide to join itself, or keep waiting for discovering of a seed node.
       no-seeds-stable-margin = 5 seconds
 
+      # If some discovered seed node will keep failing to connect for specified period of time,
+      # it will initiate rediscovery again instead of keep trying.
+      probing-failure-timeout = 5 seconds
+
       # Interval at which contact points should be polled
       # the effective interval used is this value plus the same value multiplied by the jitter value
       probe-interval = 1 second

--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/ClusterBootstrapSettings.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/ClusterBootstrapSettings.scala
@@ -75,6 +75,9 @@ final class ClusterBootstrapSettings(config: Config) {
     val noSeedsStableMargin: FiniteDuration =
       contactPointConfig.getDuration("no-seeds-stable-margin", TimeUnit.MILLISECONDS).millis
 
+    val probingFailureTimeout: FiniteDuration =
+      contactPointConfig.getDuration("probing-failure-timeout", TimeUnit.MILLISECONDS).millis
+
     val probeInterval: FiniteDuration =
       contactPointConfig.getDuration("probe-interval", TimeUnit.MILLISECONDS).millis
 

--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/dns/HttpContactPointBootstrap.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/dns/HttpContactPointBootstrap.scala
@@ -99,7 +99,7 @@ private[dns] class HttpContactPointBootstrap(
         .flatMap(res ⇒ Unmarshal(res).to[SeedNodes])
         .pipeTo(self)
 
-    case failure @ Status.Failure(cause) =>
+    case Status.Failure(cause) =>
       log.error("Probing {} failed due to {}", probeRequest.uri, cause.getMessage)
       if (probingKeepFailingWithinDeadline) {
         log.error("Overdue of probing-failure-timeout, stop probing, signaling that it's failed")

--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/dns/HttpContactPointBootstrap.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/dns/HttpContactPointBootstrap.scala
@@ -80,9 +80,9 @@ private[dns] class HttpContactPointBootstrap(
   private val existingClusterNotObservedWithinDeadline: Deadline = settings.contactPoint.noSeedsStableMargin.fromNow
 
   /**
-    * If probing keeps failing until the deadline triggers, we notify the parent,
-    * such that it rediscover again.
-    */
+   * If probing keeps failing until the deadline triggers, we notify the parent,
+   * such that it rediscover again.
+   */
   private val existingProbingKeepFailingWithinDeadline: Deadline = settings.contactPoint.probingFailureTimeout.fromNow
 
   override def preStart(): Unit =

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapBasePathIntegrationSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapBasePathIntegrationSpec.scala
@@ -67,10 +67,11 @@ class ClusterBootstrapBasePathIntegrationSpec extends WordSpecLike with Matchers
     // prepare the "mock DNS"
     val name = "basepathsystem.svc.cluster.local"
     MockDiscovery.set(name,
-      Resolved(name,
-        List(
-          ResolvedTarget("127.0.0.1", Some(managementPort))
-        )))
+      () =>
+        Resolved(name,
+          List(
+            ResolvedTarget("127.0.0.1", Some(managementPort))
+          )))
 
     "start listening with the http contact-points on system" in {
       managementA.start()


### PR DESCRIPTION
#105 
In the first step, discovery service returns non-empty list of contact point nodes, even if these nodes are unreachable, bootstrap won't request it ever again, but will keep trying.
This change makes it escalate repeating connection error and initiate rediscovery if probing keep resulting with failure for the some period of time as specified in `probing-failure-timeout`