### PR TITLE
marathon-api add docker-support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 target
 
 *.orig
+**/.idea

--- a/bootstrap-joining-demo/marathon-api-docker/README.md
+++ b/bootstrap-joining-demo/marathon-api-docker/README.md
@@ -62,19 +62,23 @@ see `bootstrap-joining-demo/marathon-api-docker/marathon/marathon-api-docker-app
 ...
 ```
 
-Build
------
+How to Build
+------------
 
-Build and publish docker image into the local repo.
-`sbt docker:publishLocal`
+1. Set DOCKER_USER env variable and authenticated to your docker hub account:
 
-Set your $DOCKER_HUB_ID:
-`export DOCKER_HUB_ID=<your docker hub id>`
+`export DOCKER_USER=<your-docker-hub-account>`
 
-Tag built image:
-`docker tag bootstrap-joining-demo-marathon-api-docker:1.0 $DOCKER_HUB_ID/bootstrap-joining-demo-marathon-api-docker:1.0`
+2. In order to build and publish this example into your docker hub repo run next command from `akka-management` work folder
 
-Push image into DockerHub 
-`docker push $DOCKER_HUB_ID/bootstrap-joining-demo-marathon-api-docker:1.0`
+`sbt bootstrap-joining-demo-marathon-api-docker/docker:publish`
 
+How to Deploy
+-------------
+
+Use next template for Marathon application descriptor. 
+
+`bootstrap-joining-demo/marathon-api-docker/marathon/marathon-api-docker-app.json`
+
+> NOTE: Make sure to substitute $DOCKER_USER in it to point to your docker hub repo.
 

--- a/bootstrap-joining-demo/marathon-api-docker/README.md
+++ b/bootstrap-joining-demo/marathon-api-docker/README.md
@@ -1,0 +1,80 @@
+Marathon API Docker lookup example
+==================================
+
+This example demonstrates Marathon API discovery mechanism when an application runs inside a docker container in 
+network bridge mode with automatic host port allocation.
+
+Marathon API discovery mechanism uses Marathon API to find other application instances (contact points) to form Akka cluster.
+In order to identify contact points it uses a label assigned to the application in the application description and 
+a port name to identify Akka HTTP management port:
+
+Label need to be defined in two places. 
+First place is the application configuration:
+see `bootstrap-joining-demo/marathon-api-docker/src/main/resources/application.conf`:
+```
+    akka.management.cluster.bootstrap.contact-point-discovery.effective-name = "marathon-api-docker-app-label"
+```
+
+> NOTE: if `effective-name` is not defined explicitly then Discovery Mechanism will use concatenation of
+> `service-name` and `.service-namespace` if any of them defined in the application config. Otherwise, it will use
+> the application ActorSystem name.
+
+The second place is the application description:
+see `bootstrap-joining-demo/marathon-api-docker/marathon/marathon-api-docker-app.json`:
+```
+  ...
+  "labels": {
+    "ACTOR_SYSTEM_NAME": "marathon-api-docker-app-label"
+  }
+  ...
+
+```
+
+> NOTE: Discovery Mechanism uses `ACTOR_SYSTEM_NAME` label name as a part of Marathon API query param to find relevant contact points.
+> This default value can be overridden in the application config `akka.discovery.marathon-api.app-label-query`
+
+After Discovery mechanism found potential contact points by the label it needs to find Akka HTTP management port.
+
+It uses `app-port-name`:
+see `bootstrap-joining-demo/marathon-api-docker/src/main/resources/application.conf`:
+```
+...
+akka.discovery.marathon-api.app-port-name = "akkamgmthttp"
+... 
+``` 
+
+it should match with Akka HTTP management port name in Marathon application description docker port declaration:
+see `bootstrap-joining-demo/marathon-api-docker/marathon/marathon-api-docker-app.json`:
+```
+...
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      ...
+      "portMappings": [
+        ...
+        {
+          "containerPort": 19999,
+          "hostPort": 0,
+          "servicePort": 10206,
+          "protocol": "tcp",
+          "name": "akkamgmthttp"
+...
+```
+
+Build
+-----
+
+Build and publish docker image into the local repo.
+`sbt docker:publishLocal`
+
+Set your $DOCKER_HUB_ID:
+`export DOCKER_HUB_ID=<your docker hub id>`
+
+Tag built image:
+`docker tag bootstrap-joining-demo-marathon-api-docker:1.0 $DOCKER_HUB_ID/bootstrap-joining-demo-marathon-api-docker:1.0`
+
+Push image into DockerHub 
+`docker push $DOCKER_HUB_ID/bootstrap-joining-demo-marathon-api-docker:1.0`
+
+

--- a/bootstrap-joining-demo/marathon-api-docker/build.sbt
+++ b/bootstrap-joining-demo/marathon-api-docker/build.sbt
@@ -1,0 +1,17 @@
+enablePlugins(JavaServerAppPackaging)
+name := "bootstrap-joining-demo-marathon-api-docker"
+
+version := "1.0"
+
+scalaVersion := "2.12.4"
+
+//TODO: update to the latest release with Marathon API Docker support
+val akkaVersion = "0.9.0-SNAPSHOT"
+
+libraryDependencies ++= Vector(
+  "com.lightbend.akka.management" %% "akka-management-cluster-bootstrap" % akkaVersion,
+
+  "com.lightbend.akka.management" %% "akka-management-cluster-http" % akkaVersion,
+
+  "com.lightbend.akka.discovery" %% "akka-discovery-marathon-api" % akkaVersion
+)

--- a/bootstrap-joining-demo/marathon-api-docker/build.sbt
+++ b/bootstrap-joining-demo/marathon-api-docker/build.sbt
@@ -1,17 +1,7 @@
+import com.typesafe.sbt.packager.docker._
+
 enablePlugins(JavaServerAppPackaging)
-name := "bootstrap-joining-demo-marathon-api-docker"
 
 version := "1.0"
 
-scalaVersion := "2.12.4"
-
-//TODO: update to the latest release with Marathon API Docker support
-val akkaVersion = "0.9.0-SNAPSHOT"
-
-libraryDependencies ++= Vector(
-  "com.lightbend.akka.management" %% "akka-management-cluster-bootstrap" % akkaVersion,
-
-  "com.lightbend.akka.management" %% "akka-management-cluster-http" % akkaVersion,
-
-  "com.lightbend.akka.discovery" %% "akka-discovery-marathon-api" % akkaVersion
-)
+dockerUsername := sys.env.get("DOCKER_USER")

--- a/bootstrap-joining-demo/marathon-api-docker/marathon/marathon-api-docker-app.json
+++ b/bootstrap-joining-demo/marathon-api-docker/marathon/marathon-api-docker-app.json
@@ -1,0 +1,57 @@
+{
+  "id": "/products-api",
+  "instances": 2,
+  "labels": {
+    "ACTOR_SYSTEM_NAME": "marathon-api-docker-app-label"
+  },
+  "cpus": 0.1,
+  "mem": 512,
+  "disk": 0,
+  "gpus": 0,
+  "constraints": [],
+  "fetch": [],
+  "storeUrls": [],
+  "backoffSeconds": 1,
+  "backoffFactor": 1.15,
+  "maxLaunchDelaySeconds": 3600,
+  "container": {
+    "type": "DOCKER",
+    "volumes": [],
+    "docker": {
+      "image": "occo6er/bootstrap-joining-demo-marathon-api-docker:1.0",
+      "network": "BRIDGE",
+      "portMappings": [
+        {
+          "containerPort": 2551,
+          "hostPort": 0,
+          "servicePort": 10205,
+          "protocol": "udp,tcp",
+          "name": "remoting"
+        },
+        {
+          "containerPort": 19999,
+          "hostPort": 0,
+          "servicePort": 10206,
+          "protocol": "tcp",
+          "name": "akkamgmthttp"
+        }
+      ],
+      "privileged": false,
+      "parameters": [],
+      "forcePullImage": true
+    }
+  },
+  "healthChecks": [],
+  "readinessChecks": [],
+  "dependencies": [],
+  "upgradeStrategy": {
+    "minimumHealthCapacity": 1,
+    "maximumOverCapacity": 1
+  },
+  "unreachableStrategy": {
+    "inactiveAfterSeconds": 300,
+    "expungeAfterSeconds": 600
+  },
+  "killSelection": "YOUNGEST_FIRST",
+  "requirePorts": true
+}

--- a/bootstrap-joining-demo/marathon-api-docker/marathon/marathon-api-docker-app.json
+++ b/bootstrap-joining-demo/marathon-api-docker/marathon/marathon-api-docker-app.json
@@ -4,7 +4,7 @@
   "labels": {
     "ACTOR_SYSTEM_NAME": "marathon-api-docker-app-label"
   },
-  "cpus": 0.1,
+  "cpus": 0.25,
   "mem": 512,
   "disk": 0,
   "gpus": 0,
@@ -18,7 +18,7 @@
     "type": "DOCKER",
     "volumes": [],
     "docker": {
-      "image": "occo6er/bootstrap-joining-demo-marathon-api-docker:1.0",
+      "image": "$DOCKER_USER/akka-management-bootstrap-joining-demo-marathon-api-docker:1.0",
       "network": "BRIDGE",
       "portMappings": [
         {

--- a/bootstrap-joining-demo/marathon-api-docker/project/build.properties
+++ b/bootstrap-joining-demo/marathon-api-docker/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.16

--- a/bootstrap-joining-demo/marathon-api-docker/project/plugins.sbt
+++ b/bootstrap-joining-demo/marathon-api-docker/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.2")

--- a/bootstrap-joining-demo/marathon-api-docker/src/main/resources/application.conf
+++ b/bootstrap-joining-demo/marathon-api-docker/src/main/resources/application.conf
@@ -1,0 +1,71 @@
+akka {
+
+  loglevel = INFO
+
+  discovery {
+    method = marathon-api
+
+    marathon-api {
+      class = akka.discovery.marathon.MarathonApiSimpleServiceDiscovery
+
+      # URL for getting list of apps from Marathon. Verified on OSS DC/OS 1.8, 1.9
+      app-api-url = "http://marathon.mesos:8080/v2/apps"
+
+      # The name of the akka management port - this cannot have underscores or dashes (env var name)
+      app-port-name = "akkamgmthttp"
+
+      # Used to find other apps running by Marathon. This will be passed as the label query string parameter
+      # to the apps-api-url defined above.
+      # `%s` will be replaced with the configured effective name, which defaults to the actor system name
+      app-label-query = "ACTOR_SYSTEM_NAME==%s"
+    }
+  }
+
+  actor {
+    provider = "cluster"
+  }
+
+  remote {
+    netty.tcp {
+      hostname = ${HOST}
+      port = 2551
+      port = ${?PORT_2551}
+
+      bind-hostname = 0.0.0.0
+      bind-port = 2551
+    }
+  }
+
+  management {
+    http {
+      # The hostname where the HTTP Server for Http Cluster Management will be started.
+      # This defines the interface to use.
+      # InetAddress.getLocalHost.getHostAddress is used not overriden or empty
+      hostname = ${HOST}
+      port = 19999
+      port = ${?PORT_19999}
+
+      bind-hostname = 0.0.0.0
+      bind-port = 19999
+    }
+
+    cluster.bootstrap {
+
+      # Configuration for the first phase of bootstraping, during which contact points are discovered
+      # using the configured service discovery mechanism.
+      contact-point-discovery {
+
+        # Marathon API discovery uses effective-name when it's defined.
+        #
+        # Marathon API dicsovery uses this value to substitute to the query `app-label-query`
+        #
+        # It should match with application LABEL value declared in Marathon description.
+        #
+        effective-name= "marathon-api-docker-app-label"
+      }
+
+    }
+
+  }
+
+}

--- a/bootstrap-joining-demo/marathon-api-docker/src/main/scala/akka/cluster/bootstrap/DemoApp.scala
+++ b/bootstrap-joining-demo/marathon-api-docker/src/main/scala/akka/cluster/bootstrap/DemoApp.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.cluster.bootstrap
+
+import akka.actor.{ Actor, ActorLogging, ActorSystem, Props }
+import akka.cluster.ClusterEvent.ClusterDomainEvent
+import akka.cluster.{ Cluster, ClusterEvent }
+import akka.http.scaladsl.Http
+import akka.management.AkkaManagement
+import akka.management.cluster.bootstrap.ClusterBootstrap
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.Sink
+import akka.management.http._
+import akka.stream.scaladsl.Source
+import com.typesafe.config.ConfigFactory
+
+object DemoApp extends App {
+
+  implicit val system = ActorSystem("simple")
+
+  import system.log
+  import system.dispatcher
+  implicit val mat = ActorMaterializer()
+  implicit val cluster = Cluster(system)
+
+  log.info("Started [{}], cluster.selfAddress = {}", system, cluster.selfAddress)
+
+  AkkaManagement(system).start()
+  ClusterBootstrap(system).start()
+
+  cluster
+    .subscribe(system.actorOf(Props[ClusterWatcher]), ClusterEvent.InitialStateAsEvents, classOf[ClusterDomainEvent])
+
+  import akka.http.scaladsl.server.Directives._
+  Http().bindAndHandle(complete("Hello world"), "0.0.0.0", 8080)
+
+}
+
+class ClusterWatcher extends Actor with ActorLogging {
+  implicit val cluster = Cluster(context.system)
+
+  override def receive = {
+    case msg ⇒ log.info("Cluster {} >>> {}", msg, cluster.selfAddress)
+  }
+}

--- a/bootstrap-joining-demo/marathon-api-docker/src/main/scala/akka/cluster/bootstrap/DemoApp.scala
+++ b/bootstrap-joining-demo/marathon-api-docker/src/main/scala/akka/cluster/bootstrap/DemoApp.scala
@@ -19,28 +19,7 @@ object DemoApp extends App {
 
   implicit val system = ActorSystem("simple")
 
-  import system.log
-  import system.dispatcher
-  implicit val mat = ActorMaterializer()
-  implicit val cluster = Cluster(system)
-
-  log.info("Started [{}], cluster.selfAddress = {}", system, cluster.selfAddress)
-
   AkkaManagement(system).start()
   ClusterBootstrap(system).start()
 
-  cluster
-    .subscribe(system.actorOf(Props[ClusterWatcher]), ClusterEvent.InitialStateAsEvents, classOf[ClusterDomainEvent])
-
-  import akka.http.scaladsl.server.Directives._
-  Http().bindAndHandle(complete("Hello world"), "0.0.0.0", 8080)
-
-}
-
-class ClusterWatcher extends Actor with ActorLogging {
-  implicit val cluster = Cluster(context.system)
-
-  override def receive = {
-    case msg ⇒ log.info("Cluster {} >>> {}", msg, cluster.selfAddress)
-  }
 }

--- a/discovery-marathon-api/src/main/scala/akka/discovery/marathon/AppList.scala
+++ b/discovery-marathon-api/src/main/scala/akka/discovery/marathon/AppList.scala
@@ -7,7 +7,8 @@ import scala.collection.immutable.Seq
 
 object AppList {
   case class App(container: Option[Container], portDefinitions: Option[Seq[PortDefinition]], tasks: Option[Seq[Task]])
-  case class Container(portMappings: Option[Seq[PortMapping]])
+  case class Container(portMappings: Option[Seq[PortMapping]], docker: Option[Docker])
+  case class Docker(portMappings: Option[Seq[PortMapping]])
   case class Task(host: Option[String], ports: Option[Seq[Int]])
   case class PortDefinition(name: Option[String], port: Option[Int])
   case class PortMapping(servicePort: Option[Int], name: Option[String])

--- a/discovery-marathon-api/src/main/scala/akka/discovery/marathon/JsonFormat.scala
+++ b/discovery-marathon-api/src/main/scala/akka/discovery/marathon/JsonFormat.scala
@@ -11,7 +11,8 @@ object JsonFormat extends SprayJsonSupport with DefaultJsonProtocol {
   implicit val taskFormat: JsonFormat[Task] = jsonFormat2(Task)
   implicit val portDefinitionFormat: JsonFormat[PortDefinition] = jsonFormat2(PortDefinition)
   implicit val portMappingFormat: JsonFormat[PortMapping] = jsonFormat2(PortMapping)
-  implicit val containerFormat: JsonFormat[Container] = jsonFormat1(Container)
+  implicit val dockerFormat: JsonFormat[Docker] = jsonFormat1(Docker)
+  implicit val containerFormat: JsonFormat[Container] = jsonFormat2(Container)
   implicit val appFormat: JsonFormat[App] = jsonFormat3(App)
   implicit val appListFormat: RootJsonFormat[AppList] = jsonFormat1(AppList.apply)
 }

--- a/discovery-marathon-api/src/test/resources/docker-app.json
+++ b/discovery-marathon-api/src/test/resources/docker-app.json
@@ -1,0 +1,145 @@
+{
+  "apps": [
+    {
+      "id": "/products-api",
+      "cmd": null,
+      "args": null,
+      "user": null,
+      "env": {
+        "SERVICE_NAME_1": "_bootstrap.products-api._tcp.marathon.mesos",
+        "SERVICE_NAME": "products-api.marathon.mesos"
+      },
+      "instances": 2,
+      "cpus": 0.1,
+      "mem": 1024,
+      "disk": 0,
+      "gpus": 0,
+      "executor": "",
+      "constraints": [],
+      "uris": [],
+      "fetch": [],
+      "storeUrls": [],
+      "backoffSeconds": 1,
+      "backoffFactor": 1.15,
+      "maxLaunchDelaySeconds": 3600,
+      "container": {
+        "type": "DOCKER",
+        "volumes": [],
+        "docker": {
+          "image": "occo6er/bootstrap-joining-demo-marathon-api:1.0",
+          "network": "BRIDGE",
+          "portMappings": [
+            {
+              "containerPort": 2551,
+              "hostPort": 0,
+              "servicePort": 10205,
+              "protocol": "udp,tcp",
+              "name": "remoting",
+              "labels": {}
+            },
+            {
+              "containerPort": 19999,
+              "hostPort": 0,
+              "servicePort": 10206,
+              "protocol": "tcp",
+              "name": "akkamgmthttp",
+              "labels": {}
+            }
+          ],
+          "privileged": false,
+          "parameters": [],
+          "forcePullImage": true
+        }
+      },
+      "healthChecks": [],
+      "readinessChecks": [],
+      "dependencies": [],
+      "upgradeStrategy": {
+        "minimumHealthCapacity": 1,
+        "maximumOverCapacity": 1
+      },
+      "labels": {
+        "ACTOR_SYSTEM_NAME": "simple"
+      },
+      "ipAddress": null,
+      "version": "2018-01-18T02:03:43.580Z",
+      "residency": null,
+      "secrets": {},
+      "taskKillGracePeriodSeconds": null,
+      "unreachableStrategy": {
+        "inactiveAfterSeconds": 300,
+        "expungeAfterSeconds": 600
+      },
+      "killSelection": "YOUNGEST_FIRST",
+      "ports": [
+        10205,
+        10206
+      ],
+      "portDefinitions": [
+        {
+          "port": 10205,
+          "protocol": "tcp",
+          "name": "default",
+          "labels": {}
+        },
+        {
+          "port": 10206,
+          "protocol": "tcp",
+          "labels": {}
+        }
+      ],
+      "requirePorts": true,
+      "versionInfo": {
+        "lastScalingAt": "2018-01-18T02:03:43.580Z",
+        "lastConfigChangeAt": "2018-01-18T01:56:24.053Z"
+      },
+      "tasksStaged": 0,
+      "tasksRunning": 2,
+      "tasksHealthy": 0,
+      "tasksUnhealthy": 0,
+      "deployments": [],
+      "tasks": [
+        {
+          "ipAddresses": [
+            {
+              "ipAddress": "172.17.0.6",
+              "protocol": "IPv4"
+            }
+          ],
+          "stagedAt": "2018-01-18T02:03:47.410Z",
+          "state": "TASK_RUNNING",
+          "ports": [
+            29479,
+            29480
+          ],
+          "startedAt": "2018-01-18T02:04:26.580Z",
+          "version": "2018-01-18T02:03:43.580Z",
+          "id": "products-api.d1d4d3b2-fbf3-11e7-938e-3ed03be94955",
+          "appId": "/products-api",
+          "slaveId": "f42d0ac1-1395-45ac-8062-5b0ef80b60db-S1",
+          "host": "10.121.48.204"
+        },
+        {
+          "ipAddresses": [
+            {
+              "ipAddress": "172.17.0.16",
+              "protocol": "IPv4"
+            }
+          ],
+          "stagedAt": "2018-01-18T02:03:47.409Z",
+          "state": "TASK_RUNNING",
+          "ports": [
+            10135,
+            10136
+          ],
+          "startedAt": "2018-01-18T02:04:26.580Z",
+          "version": "2018-01-18T02:03:43.580Z",
+          "id": "products-api.d1d4aca1-fbf3-11e7-938e-3ed03be94955",
+          "appId": "/products-api",
+          "slaveId": "f42d0ac1-1395-45ac-8062-5b0ef80b60db-S1",
+          "host": "10.121.48.204"
+        }
+      ]
+    }
+  ]
+}

--- a/discovery-marathon-api/src/test/scala/akka/discovery/marathon/MarathonApiSimpleServiceDiscoverySpec.scala
+++ b/discovery-marathon-api/src/test/scala/akka/discovery/marathon/MarathonApiSimpleServiceDiscoverySpec.scala
@@ -18,6 +18,14 @@ class MarathonApiSimpleServiceDiscoverySpec extends WordSpec with Matchers {
       MarathonApiSimpleServiceDiscovery.targets(appList, "akka-mgmt-http") shouldBe List(
           ResolvedTarget("192.168.65.60", Some(23236)), ResolvedTarget("192.168.65.111", Some(6850)))
     }
+    "calculate the correct list of resolved targets for docker" in {
+      val data = resourceAsString("docker-app.json")
+
+      val appList = JsonFormat.appListFormat.read(data.parseJson)
+
+      MarathonApiSimpleServiceDiscovery.targets(appList, "akkamgmthttp") shouldBe List(ResolvedTarget("10.121.48.204",
+          Some(29480)), ResolvedTarget("10.121.48.204", Some(10136)))
+    }
   }
 
   private def resourceAsString(name: String): String =

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild := "0.9.0-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,0 @@
-version in ThisBuild := "0.9.0-SNAPSHOT"


### PR DESCRIPTION
@longshorej I added Docker support. When a docker container selected, a port name declaration placed in different location of an application description: `apps/contatiner/docker/portMappings`