### PR TITLE
Improve marathon demos, adding health/readiness checks

### DIFF
--- a/bootstrap-joining-demo/marathon-api-docker/build.sbt
+++ b/bootstrap-joining-demo/marathon-api-docker/build.sbt
@@ -1,7 +1,21 @@
 import com.typesafe.sbt.packager.docker._
 
+name := "bootstrap-joining-demo-marathon-api-docker"
+
+version := "0.1.0"
+
+scalaVersion := "2.12.4"
+
 enablePlugins(JavaServerAppPackaging)
 
 version := "1.0"
 
 dockerUsername := sys.env.get("DOCKER_USER")
+
+val akkaManagementVersion = "0.10.0"
+
+libraryDependencies ++= Vector(
+  "com.lightbend.akka.management" %% "akka-management-cluster-bootstrap" % akkaManagementVersion,
+  "com.lightbend.akka.management" %% "akka-management-cluster-http"      % akkaManagementVersion,
+  "com.lightbend.akka.discovery"  %% "akka-discovery-marathon-api"       % akkaManagementVersion
+)

--- a/bootstrap-joining-demo/marathon-api-docker/marathon/marathon-api-docker-app.json
+++ b/bootstrap-joining-demo/marathon-api-docker/marathon/marathon-api-docker-app.json
@@ -1,5 +1,5 @@
 {
-  "id": "/products-api",
+  "id": "/bootstrap-joining-demo-marathon-api-docker",
   "instances": 2,
   "labels": {
     "ACTOR_SYSTEM_NAME": "marathon-api-docker-app-label"
@@ -22,6 +22,13 @@
       "network": "BRIDGE",
       "portMappings": [
         {
+          "containerPort": 8080,
+          "hostPort": 0,
+          "servicePort": 10204,
+          "protocol": "tcp",
+          "name": "http"
+        },
+        {
           "containerPort": 2551,
           "hostPort": 0,
           "servicePort": 10205,
@@ -41,12 +48,32 @@
       "forcePullImage": true
     }
   },
-  "healthChecks": [],
-  "readinessChecks": [],
+  "readinessChecks": [{
+    "path": "/ready",
+    "portName": "http",
+    "protocol": "HTTP",
+    "gracePeriodSeconds": 300,
+    "intervalSeconds": 10,
+    "timeoutSeconds": 5,
+    "maxConsecutiveFailures": 3,
+    "ignoreHttp1xx": false
+  }],
+  "healthChecks": [
+    {
+      "path": "/healthy",
+      "portName": "http",
+      "protocol": "HTTP",
+      "gracePeriodSeconds": 300,
+      "intervalSeconds": 10,
+      "timeoutSeconds": 5,
+      "maxConsecutiveFailures": 3,
+      "ignoreHttp1xx": false
+    }
+  ],
   "dependencies": [],
   "upgradeStrategy": {
-    "minimumHealthCapacity": 1,
-    "maximumOverCapacity": 1
+    "maximumOverCapacity": 0,
+    "minimumHealthCapacity": 0.5
   },
   "unreachableStrategy": {
     "inactiveAfterSeconds": 300,

--- a/bootstrap-joining-demo/marathon-api/build.sbt
+++ b/bootstrap-joining-demo/marathon-api/build.sbt
@@ -1,14 +1,15 @@
 enablePlugins(JavaServerAppPackaging)
+
 name := "bootstrap-joining-demo-marathon-api"
 
 version := "0.1.0"
 
 scalaVersion := "2.12.4"
 
+val akkaManagementVersion = "0.10.0"
+
 libraryDependencies ++= Vector(
-  "com.lightbend.akka.management" %% "akka-management-cluster-bootstrap" % "0.8.1",
-
-  "com.lightbend.akka.management" %% "akka-management-cluster-http" % "0.8.1",
-
-  "com.lightbend.akka.discovery" %% "akka-discovery-marathon-api" % "0.8.1"
+  "com.lightbend.akka.management" %% "akka-management-cluster-bootstrap" % akkaManagementVersion,
+  "com.lightbend.akka.management" %% "akka-management-cluster-http"      % akkaManagementVersion,
+  "com.lightbend.akka.discovery"  %% "akka-discovery-marathon-api"       % akkaManagementVersion
 )

--- a/bootstrap-joining-demo/marathon-api/marathon/app.json
+++ b/bootstrap-joining-demo/marathon-api/marathon/app.json
@@ -10,6 +10,10 @@
   "portDefinitions": [
     {
       "port": 0,
+      "name": "http"
+    },
+    {
+      "port": 0,
       "name": "akkaremote"
     },
     {
@@ -17,6 +21,33 @@
       "name": "akkamgmthttp"
     }
   ],
+  "readinessChecks": [{
+    "path": "/ready",
+    "portName": "http",
+    "protocol": "HTTP",
+    "gracePeriodSeconds": 300,
+    "intervalSeconds": 10,
+    "timeoutSeconds": 5,
+    "maxConsecutiveFailures": 3,
+    "ignoreHttp1xx": false
+  }],
+  "healthChecks": [
+    {
+      "path": "/healthy",
+      "portName": "http",
+      "protocol": "HTTP",
+      "gracePeriodSeconds": 300,
+      "intervalSeconds": 10,
+      "timeoutSeconds": 5,
+      "maxConsecutiveFailures": 3,
+      "ignoreHttp1xx": false
+    }
+  ],
+  "upgradeStrategy": {
+    "maximumOverCapacity": 0,
+    "minimumHealthCapacity": 0.5
+  },
+  "killSelection": "YOUNGEST_FIRST",
   "fetch": [
     {
       "uri": "http://yourwebserver.example.com/bootstrap-joining-demo-marathon-api-0.1.0.tgz",

--- a/bootstrap-joining-demo/marathon-api/src/main/resources/application.conf
+++ b/bootstrap-joining-demo/marathon-api/src/main/resources/application.conf
@@ -1,5 +1,4 @@
 akka {
-
   discovery.method = marathon-api
 
   actor {
@@ -19,21 +18,12 @@ akka {
   }
 
   management {
-
     cluster.bootstrap {
-
-      contact-point-discovery {
-        service-name = "products-api"
-      }
-
       contact-point {
         fallback-port = 19999
 
         no-seeds-stable-margin = 5 seconds
       }
-
     }
-
   }
-
 }

--- a/bootstrap-joining-demo/marathon-api/src/main/scala/akka/cluster/bootstrap/DemoApp.scala
+++ b/bootstrap-joining-demo/marathon-api/src/main/scala/akka/cluster/bootstrap/DemoApp.scala
@@ -5,14 +5,41 @@
 package akka.cluster.bootstrap
 
 import akka.actor.ActorSystem
+import akka.cluster.{ Cluster, MemberStatus }
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.server.Directives._
 import akka.management.AkkaManagement
 import akka.management.cluster.bootstrap.ClusterBootstrap
+import akka.stream.ActorMaterializer
 
 object DemoApp extends App {
-
   implicit val system = ActorSystem("my-system")
+  implicit val materializer = ActorMaterializer()
+
+  val cluster = Cluster(system)
+
+  def isReady() = {
+    val selfNow = cluster.selfMember
+
+    selfNow.status == MemberStatus.Up
+  }
+
+  def isHealthy() = {
+    isReady()
+  }
+
+  val route =
+    concat(
+      path("ping")(complete("pong!")),
+      path("healthy")(complete(if (isHealthy()) StatusCodes.OK else StatusCodes.ServiceUnavailable)),
+      path("ready")(complete(if (isReady()) StatusCodes.OK else StatusCodes.ServiceUnavailable)))
 
   AkkaManagement(system).start()
   ClusterBootstrap(system).start()
 
+  Http().bindAndHandle(
+    route,
+    sys.env.get("HOST").getOrElse("127.0.0.1"),
+    sys.env.get("PORT_HTTP").map(_.toInt).getOrElse(8080))
 }


### PR DESCRIPTION
This improves the Marathon demos:

* Adds health/readiness checks based on cluster status.
* Sets `minimumHealthCapcity` and `maximumOverCapacity` to values recommended by Mesosphere for stateful applications: https://mesosphere.github.io/marathon/docs/persistent-volumes.html#upgradingrestarting-stateful-applications
* Sets `"killSelection": "YOUNGEST_FIRST"` as well which is particularly important for singletons during a deployment.

This results in these demos being much more reliable when restarting applications.

/cc @mitkus