### PR TITLE
Make akka.discovery.aws-api-ec2-tag-based.filters optional

### DIFF
--- a/discovery-aws-api/src/main/scala/akka/discovery/awsapi/ec2/Ec2TagBasedSimpleServiceDiscovery.scala
+++ b/discovery-aws-api/src/main/scala/akka/discovery/awsapi/ec2/Ec2TagBasedSimpleServiceDiscovery.scala
@@ -31,6 +31,7 @@ class Ec2TagBasedSimpleServiceDiscovery(system: ActorSystem) extends SimpleServi
 
     val otherFilters: util.List[Filter] = otherFiltersString
       .split(";")
+      .filter(_.nonEmpty)
       .map(kv => kv.split("="))
       .toList
       .map(kv => {


### PR DESCRIPTION
RIght now if no filters are defined, and default value `""` is used it will fail with `java.lang.AssertionError: assertion failed: failed to parse one of the key-value pairs in filters`