### PR TITLE
Kubernetes discovery debugability / parsing improvements

### DIFF
--- a/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/JsonFormat.scala
+++ b/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/JsonFormat.scala
@@ -9,11 +9,11 @@ import spray.json._
 import PodList._
 
 object JsonFormat extends SprayJsonSupport with DefaultJsonProtocol {
-  implicit val portFormat: JsonFormat[Port] = jsonFormat2(Port)
+  implicit val containerPortFormat: JsonFormat[ContainerPort] = jsonFormat2(ContainerPort)
   implicit val containerFormat: JsonFormat[Container] = jsonFormat2(Container)
-  implicit val specFormat: JsonFormat[Spec] = jsonFormat1(Spec)
-  implicit val statusFormat: JsonFormat[Status] = jsonFormat1(Status)
-  implicit val metaDataFormat: JsonFormat[Metadata] = jsonFormat1(Metadata)
-  implicit val itemFormat: JsonFormat[Item] = jsonFormat3(Item)
+  implicit val podSpecFormat: JsonFormat[PodSpec] = jsonFormat1(PodSpec)
+  implicit val podStatusFormat: JsonFormat[PodStatus] = jsonFormat1(PodStatus)
+  implicit val metadataFormat: JsonFormat[Metadata] = jsonFormat1(Metadata)
+  implicit val podFormat: JsonFormat[Pod] = jsonFormat3(Pod)
   implicit val podListFormat: RootJsonFormat[PodList] = jsonFormat1(PodList.apply)
 }

--- a/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/PodList.scala
+++ b/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/PodList.scala
@@ -7,13 +7,13 @@ import scala.collection.immutable.Seq
 
 object PodList {
   case class Metadata(deletionTimestamp: Option[String])
-  case class Port(name: String, containerPort: Int)
-  case class Container(name: String, ports: Seq[Port])
-  case class Spec(containers: Seq[Container])
-  case class Status(podIP: Option[String])
-  case class Item(spec: Spec, status: Status, metadata: Metadata)
+  case class ContainerPort(name: Option[String], containerPort: Int)
+  case class Container(name: String, ports: Option[Seq[ContainerPort]])
+  case class PodSpec(containers: Seq[Container])
+  case class PodStatus(podIP: Option[String])
+  case class Pod(spec: Option[PodSpec], status: Option[PodStatus], metadata: Option[Metadata])
 }
 
 import PodList._
 
-case class PodList(items: Seq[Item])
+case class PodList(items: Seq[Pod])

--- a/discovery-kubernetes-api/src/test/scala/akka/discovery/kubernetes/JsonFormatSpec.scala
+++ b/discovery-kubernetes-api/src/test/scala/akka/discovery/kubernetes/JsonFormatSpec.scala
@@ -18,29 +18,32 @@ class JsonFormatSpec extends WordSpec with Matchers {
         .podListFormat
         .read(data.parseJson) shouldBe PodList(
           List(
-            Item(
-              Spec(
-                List(
-                  Container(
-                    "akka-cluster-tooling-example",
-                    List(Port("akka-remote", 10000), Port("akka-mgmt-http", 10001), Port("http", 10002))))),
-              Status(Some("172.17.0.4")), Metadata(deletionTimestamp = None)),
+            Pod(
+              Some(
+                PodSpec(
+                  List(
+                    Container(
+                      "akka-cluster-tooling-example",
+                      Some(List(ContainerPort(Some("akka-remote"), 10000), ContainerPort(Some("akka-mgmt-http"), 10001), ContainerPort(Some("http"), 10002))))))),
+                Some(PodStatus(Some("172.17.0.4"))), Some(Metadata(deletionTimestamp = None))),
 
-            Item(
-              Spec(
-                List(
-                  Container(
-                    "akka-cluster-tooling-example",
-                    List(Port("akka-remote", 10000), Port("akka-mgmt-http", 10001), Port("http", 10002))))),
-              Status(Some("172.17.0.6")), Metadata(deletionTimestamp = None)),
+            Pod(
+              Some(
+                PodSpec(
+                  List(
+                    Container(
+                      "akka-cluster-tooling-example",
+                      Some(List(ContainerPort(Some("akka-remote"), 10000), ContainerPort(Some("akka-mgmt-http"), 10001), ContainerPort(Some("http"), 10002))))))),
+                Some(PodStatus(Some("172.17.0.6"))), Some(Metadata(deletionTimestamp = None))),
 
-            Item(
-              Spec(
-                List(
-                  Container(
-                    "akka-cluster-tooling-example",
-                    List(Port("akka-remote", 10000), Port("akka-mgmt-http", 10001), Port("http", 10002))))),
-              Status(Some("172.17.0.7")), Metadata(deletionTimestamp = Some("2017-12-06T16:30:22Z")))))
+            Pod(
+              Some(
+                PodSpec(
+                  List(
+                    Container(
+                      "akka-cluster-tooling-example",
+                      Some(List(ContainerPort(Some("akka-remote"), 10000), ContainerPort(Some("akka-mgmt-http"), 10001), ContainerPort(Some("http"), 10002))))))),
+                  Some(PodStatus(Some("172.17.0.7"))), Some(Metadata(deletionTimestamp = Some("2017-12-06T16:30:22Z"))))))
     }
   }
 

--- a/discovery-kubernetes-api/src/test/scala/akka/discovery/kubernetes/KubernetesApiSimpleServiceDiscoverySpec.scala
+++ b/discovery-kubernetes-api/src/test/scala/akka/discovery/kubernetes/KubernetesApiSimpleServiceDiscoverySpec.scala
@@ -11,21 +11,26 @@ import PodList._
 class KubernetesApiSimpleServiceDiscoverySpec extends WordSpec with Matchers {
   "targets" should {
     "calculate the correct list of resolved targets" in {
-      val podList = PodList(List(Item(Spec(List(Container("akka-cluster-tooling-example",
-                  List(Port("akka-remote", 10000), Port("akka-mgmt-http", 10001), Port("http", 10002))))),
-            Status(Some("172.17.0.4")), Metadata(deletionTimestamp = None)),
-          Item(Spec(List(Container("akka-cluster-tooling-example",
-                  List(Port("akka-remote", 10000), Port("akka-mgmt-http", 10001), Port("http", 10002))))),
-            Status(None), Metadata(deletionTimestamp = None))))
+      val podList =
+        PodList(List(Pod(Some(PodSpec(List(Container("akka-cluster-tooling-example",
+                      Some(List(ContainerPort(Some("akka-remote"), 10000),
+                          ContainerPort(Some("akka-mgmt-http"), 10001), ContainerPort(Some("http"), 10002))))))),
+              Some(PodStatus(Some("172.17.0.4"))), Some(Metadata(deletionTimestamp = None))),
+            Pod(Some(PodSpec(List(Container("akka-cluster-tooling-example",
+                      Some(List(ContainerPort(Some("akka-remote"), 10000),
+                          ContainerPort(Some("akka-mgmt-http"), 10001), ContainerPort(Some("http"), 10002))))))),
+              Some(PodStatus(None)), Some(Metadata(deletionTimestamp = None)))))
 
       KubernetesApiSimpleServiceDiscovery.targets(podList,
         "akka-mgmt-http") shouldBe List(ResolvedTarget("172.17.0.4", Some(10001)))
     }
 
     "ignore deleted pods" in {
-      val podList = PodList(List(Item(Spec(List(Container("akka-cluster-tooling-example",
-                  List(Port("akka-remote", 10000), Port("akka-mgmt-http", 10001), Port("http", 10002))))),
-            Status(Some("172.17.0.4")), Metadata(deletionTimestamp = Some("2017-12-06T16:30:22Z")))))
+      val podList =
+        PodList(List(Pod(Some(PodSpec(List(Container("akka-cluster-tooling-example",
+                      Some(List(ContainerPort(Some("akka-remote"), 10000),
+                          ContainerPort(Some("akka-mgmt-http"), 10001), ContainerPort(Some("http"), 10002))))))),
+              Some(PodStatus(Some("172.17.0.4"))), Some(Metadata(deletionTimestamp = Some("2017-12-06T16:30:22Z"))))))
 
       KubernetesApiSimpleServiceDiscovery.targets(podList, "akka-mgmt-http") shouldBe List.empty
     }


### PR DESCRIPTION
* Fixes the Kubernetes discovery to be inline with the types defined by the K8s docs, notably several fields made optional
* Renames the local types to what they're actually named in the K8s docs
* Some logging improvements to help debug failures

Fixes #147 