### PR TITLE
Fix log inconsistency when using kubernetes-api

### DIFF
--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/internal/BootstrapCoordinator.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/internal/BootstrapCoordinator.scala
@@ -121,8 +121,8 @@ private[akka] final class BootstrapCoordinator(discovery: SimpleServiceDiscovery
   /** Awaiting initial signal to start the bootstrap process */
   override def receive: Receive = {
     case InitiateBootstrapping ⇒
-      log.info("Locating service members; Lookup [{}]. Using discovery [{}], join decider [{}]", serviceName,
-        discovery.getClass.getName, joinDecider.getClass.getName)
+      log.info("Locating service members. Using discovery [{}], join decider [{}]", discovery.getClass.getName,
+        joinDecider.getClass.getName)
       lookup()
 
       context become bootstrapping(sender())
@@ -135,6 +135,7 @@ private[akka] final class BootstrapCoordinator(discovery: SimpleServiceDiscovery
 
     case SimpleServiceDiscovery.Resolved(name, contactPoints) ⇒
       serviceName = name
+      log.info("Located service members with name: [{}].", serviceName)
       onContactPointsResolved(contactPoints)
 
     case ex: Failure ⇒

--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/internal/BootstrapCoordinator.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/internal/BootstrapCoordinator.scala
@@ -135,7 +135,7 @@ private[akka] final class BootstrapCoordinator(discovery: SimpleServiceDiscovery
 
     case SimpleServiceDiscovery.Resolved(name, contactPoints) ⇒
       serviceName = name
-      log.info("Located service members with name: [{}].", serviceName)
+      log.info("Located service members with name: [{}]: [{}]", serviceName, contactPoints.mkString(", "))
       onContactPointsResolved(contactPoints)
 
     case ex: Failure ⇒

--- a/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/KubernetesApiSimpleServiceDiscovery.scala
+++ b/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/KubernetesApiSimpleServiceDiscovery.scala
@@ -90,7 +90,7 @@ class KubernetesApiSimpleServiceDiscovery(system: ActorSystem) extends SimpleSer
         unmarshalled
       }
 
-    } yield Resolved(name, targets(podList, settings.podPortName))
+    } yield Resolved(labelSelector, targets(podList, settings.podPortName))
 
   private def apiToken() =
     FileIO.fromPath(Paths.get(settings.apiTokenPath)).runFold("")(_ + _.utf8String).recover { case _: Throwable => "" }


### PR DESCRIPTION
**Problem**
When you use `kubernetes-api` as a discovery mechanism, and the property `pod-label-selector` is different from `effective-name`, you will see in the logs still `effective-name` being used (while it's not the case *only* with kubernetes-api). 

**Solution**
The solution proposed here is to remove `effective-name` from the logged statement. Then, once we retrieve the Resolved points, we can log the service-name used to locate the members. For this reason, we also need to change what `KubernetesApiSimpleServiceDiscovery.lookup` returns, because it doesn't return a Resolved object with `serviceName=pod-label-selector` but  `serviceName=effective-name`. I think this is a good trade-off, because we don't lose the log (which may be useful).

This is a fix for https://github.com/akka/akka-management/issues/167.

Note: I signed the CLA.