### PR TITLE
Fix aws-api-async not being built/published

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,8 +12,10 @@ lazy val `akka-management-root` = project
     `akka-discovery-kubernetes-api`,
     `akka-discovery-marathon-api`,
     `akka-discovery-aws-api`,
+    `akka-discovery-aws-api-async`,
     `akka-management`,
     `bootstrap-joining-demo-aws-api-ec2-tag-based`,
+    `bootstrap-joining-demo-aws-api-ecs`,
     `cluster-http`,
     `cluster-bootstrap`,
     docs)


### PR DESCRIPTION
Issue found as follows:

1. I try updating Liquidity to 0.11.0 now that it's been released.

   Uh oh:
```
   sbt:liquidity> update
   [info] Updating server
   [info] Resolved server dependencies
   [error] coursier.ResolutionException: Encountered 1 error(s) in dependency resolution:
   [error]     com.lightbend.akka.discovery:akka-discovery-aws-api-async_2.12:0.11.0:
   [error]         not found:
   [error]             /home/david/.ivy2/local/com.lightbend.akka.discovery/akka-discovery-aws-api-async_2.12/0.11.0/ivys/ivy.xml
   [error]             https://repo1.maven.org/maven2/com/lightbend/akka/discovery/akka-discovery-aws-api-async_2.12/0.11.0/akka-discovery-aws-api-async_2.12-0.11.0.pom
   [error] (server / coursierResolutions) coursier.ResolutionException: Encountered 1 error(s) in dependency resolution:
   [error]     com.lightbend.akka.discovery:akka-discovery-aws-api-async_2.12:0.11.0:
   [error]         not found:
   [error]             /home/david/.ivy2/local/com.lightbend.akka.discovery/akka-discovery-aws-api-async_2.12/0.11.0/ivys/ivy.xml
   [error]             https://repo1.maven.org/maven2/com/lightbend/akka/discovery/akka-discovery-aws-api-async_2.12/0.11.0/akka-discovery-aws-api-async_2.12-0.11.0.pom
   [error] Total time: 1 s, completed 10-Apr-2018 19:45:59
```
2. I check
   https://bintray.com/akka/maven/akka-management/0.11.0#files/com%2Flightbend%2Fakka%2Fdiscovery
   and see that every expected module is there except for
   akka-discovery-aws-api-async_2.11 and akka-discovery-aws-api-async_2.11.

3. I check .travis.yml and see that the publish is achieved by just calling the
   publish task.

4. I realise I failed to include the new module in the override of the root
   module in #140 (I also check the Travis logs and they confirm that the
   tasks of the module are not called). I think the reason I forgot to do so is
   that I rarely have need to override the root module in other projects,
   instead relying on the default (which automatically aggregates all other
   modules without having to explicitly include them via `aggregrate`).

Oops!