### PR TITLE
Fixed aws-api ec2 use of filters

### DIFF
--- a/discovery-aws-api/src/main/scala/akka/discovery/awsapi/ec2/Ec2TagBasedSimpleServiceDiscovery.scala
+++ b/discovery-aws-api/src/main/scala/akka/discovery/awsapi/ec2/Ec2TagBasedSimpleServiceDiscovery.scala
@@ -44,12 +44,11 @@ class Ec2TagBasedSimpleServiceDiscovery(system: ActorSystem) extends SimpleServi
     val otherFiltersString =
       system.settings.config.getConfig("akka.discovery.aws-api-ec2-tag-based").getString("filters")
 
-    val otherFilters: util.List[Filter] = parseFiltersString(otherFiltersString).asJava
+    val otherFilters = parseFiltersString(otherFiltersString)
 
-    val request = new DescribeInstancesRequest()
-      .withFilters(runningInstancesFilter)
-      .withFilters(tagFilter)
-      .withFilters(otherFilters)
+    val allFilters: util.List[Filter] = (List(runningInstancesFilter, tagFilter) ::: otherFilters).asJava
+
+    val request = new DescribeInstancesRequest().withFilters(allFilters) // withFilters is a set operation
 
     import system.dispatcher
 

--- a/discovery-aws-api/src/main/scala/akka/discovery/awsapi/ec2/Ec2TagBasedSimpleServiceDiscovery.scala
+++ b/discovery-aws-api/src/main/scala/akka/discovery/awsapi/ec2/Ec2TagBasedSimpleServiceDiscovery.scala
@@ -46,7 +46,7 @@ class Ec2TagBasedSimpleServiceDiscovery(system: ActorSystem) extends SimpleServi
 
     val otherFilters = parseFiltersString(otherFiltersString)
 
-    val allFilters: util.List[Filter] = (List(runningInstancesFilter, tagFilter) ::: otherFilters).asJava
+    val allFilters: util.List[Filter] = (runningInstancesFilter :: tagFilter :: otherFilters).asJava
 
     val request = new DescribeInstancesRequest().withFilters(allFilters) // withFilters is a set operation
 


### PR DESCRIPTION
The `withFilters` method of AWS' `DescribeInstancesRequest` is always a set operation when used with a collection. Ec2TagBasedSimpleServiceDiscovery chains calls to withFilters and ends the chain by passing a collection to the method, which effectively drops all filters previously set.

This change merges all ec2 filters in a single java list before building the `DescribeInstancesRequest`.

Closes https://github.com/akka/akka-management/issues/177.