### PR TITLE
Add a "Role-Based Access Control" heading

### DIFF
--- a/docs/src/main/paradox/discovery.md
+++ b/docs/src/main/paradox/discovery.md
@@ -177,14 +177,15 @@ spec:
           protocol: TCP
 ```
 
-If your Kubernetes cluster has [Role-Based Access Control](https://kubernetes.io/docs/admin/authorization/rbac/) enabled,
-you'll also have to grant the Service Account that your pods run under access to list pods. The following configuration
-can be used as a starting point. It creates a `Role`, `pod-reader`, which grants access to query pod information. It
-then binds the default Service Account to the `Role` by creating a `RoleBinding`.
+### Role-Based Access Control
+
+If your Kubernetes cluster has [Role-Based Access Control (RBAC)](https://kubernetes.io/docs/admin/authorization/rbac/) 
+enabled, you'll also have to grant the Service Account that your pods run under access to list pods. The following 
+configuration can be used as a starting point. It creates a `Role`, `pod-reader`, which grants access to query pod 
+information. It then binds the default Service Account to the `Role` by creating a `RoleBinding`.
 Adjust as necessary.
 
 ```yaml
-
 ---
 #
 # Create a role, `pod-reader`, that can list pods and


### PR DESCRIPTION
This will make the section stand out more and is easier to link to.

Also include the abbreviation "RBAC" in the text for SEO purposes. The abbreviation is used much more commonly than the fully spelled-out term.

Minikube now enables RBAC by default, as does Google Cloud, so this will be a common need for many users.