### PR TITLE
additional logging info

### DIFF
--- a/discovery-marathon-api/src/main/scala/akka/discovery/marathon/MarathonApiSimpleServiceDiscovery.scala
+++ b/discovery-marathon-api/src/main/scala/akka/discovery/marathon/MarathonApiSimpleServiceDiscovery.scala
@@ -89,9 +89,8 @@ class MarathonApiSimpleServiceDiscovery(system: ActorSystem) extends SimpleServi
         val unmarshalled = Unmarshal(entity).to[AppList]
 
         unmarshalled.failed.foreach { _ =>
-          system.log.error("Failed to unmarshal Marathon API response status [{}]", response.status.value)
-          system.log.error("Marathon API entity: [{}]", entity.data.utf8String)
-          system.log.error("URI: {}", uri)
+          system.log.error("Failed to unmarshal Marathon API response status [{}], entity: [{}], uri: [{}]", 
+                           response.status.value, entity.data.utf8String, uri)
         }
         unmarshalled
       }

--- a/discovery-marathon-api/src/main/scala/akka/discovery/marathon/MarathonApiSimpleServiceDiscovery.scala
+++ b/discovery-marathon-api/src/main/scala/akka/discovery/marathon/MarathonApiSimpleServiceDiscovery.scala
@@ -90,7 +90,7 @@ class MarathonApiSimpleServiceDiscovery(system: ActorSystem) extends SimpleServi
 
         unmarshalled.failed.foreach { _ =>
           system.log.error("Failed to unmarshal Marathon API response status [{}], entity: [{}], uri: [{}]", 
-                           response.status.value, entity.data.utf8String, uri)
+            response.status.value, entity.data.utf8String, uri)
         }
         unmarshalled
       }

--- a/discovery-marathon-api/src/main/scala/akka/discovery/marathon/MarathonApiSimpleServiceDiscovery.scala
+++ b/discovery-marathon-api/src/main/scala/akka/discovery/marathon/MarathonApiSimpleServiceDiscovery.scala
@@ -89,7 +89,7 @@ class MarathonApiSimpleServiceDiscovery(system: ActorSystem) extends SimpleServi
         val unmarshalled = Unmarshal(entity).to[AppList]
 
         unmarshalled.failed.foreach { _ =>
-          system.log.error("Failed to unmarshal Marathon API response status [{}], entity: [{}], uri: [{}]", 
+          system.log.error("Failed to unmarshal Marathon API response status [{}], entity: [{}], uri: [{}]",
             response.status.value, entity.data.utf8String, uri)
         }
         unmarshalled


### PR DESCRIPTION
We added a bit more verbosity to the system logs if debug is enabled, as well as print out full object if serialization failure...