### PR TITLE
implement backoff in discovery usage in bootstrap #193

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,11 @@ lazy val `akka-management-root` = project
     `bootstrap-joining-demo-aws-api-ecs`,
     `cluster-http`,
     `cluster-bootstrap`,
-    docs)
+    docs
+  )
+  .settings(
+    parallelExecution in GlobalScope := false
+  )
 
 // interfaces and extension for Discovery
 lazy val `akka-discovery` = project

--- a/cluster-bootstrap/src/main/resources/reference.conf
+++ b/cluster-bootstrap/src/main/resources/reference.conf
@@ -49,7 +49,25 @@ akka.management {
       stable-margin = 5 seconds
 
       # Interval at which service discovery will be polled in search for new contact-points
+      #
+      # Note that actual timing of lookups will be the following:
+      # - perform initial lookup; interval is this base interval
+      # - await response within resolve-timeout
+      #   (this can be larger than interval, which means interval effectively is resolveTimeout + interval,
+      #    this has been specifically made so, to not hit discovery services with requests while the lookup is being serviced)
+      #   - if failure happens apply backoff to interval (the backoff growth is exponential)
+      # - if no failure happened, and we receive a resolved list of services, schedule another lookup in interval time
+      #   - if previously failures happened during discovery, a successful lookup resets the interval to `interval` again
+      # = repeat until stable-margin is reached
       interval = 1 second
+
+      # Adds "noise" to vary the intervals between retries slightly (0.2 means 20% of base value).
+      # This is important in order to avoid the various nodes performing lookups in the same interval,
+      # potentially causing a thundering heard effect. Usually there is no need to tweak this parameter.
+      exponential-backoff-random-factor = 0.2
+
+      # Maximum interval to which the exponential backoff is allowed to grow
+      exponential-backoff-max = 15 seconds
 
       # The smallest number of contact points that need to be discovered before the bootstrap process can start.
       # For optimal safety during cluster formation, you may want to set these value to the number of initial

--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/ClusterBootstrapSettings.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/ClusterBootstrapSettings.scala
@@ -4,12 +4,13 @@
 package akka.management.cluster.bootstrap
 
 import java.util.Locale
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.{ ThreadLocalRandom, TimeUnit }
 
 import akka.actor.ActorSystem
 import com.typesafe.config.Config
 
 import scala.concurrent.duration.{ FiniteDuration, _ }
+import scala.util.Try
 
 final class ClusterBootstrapSettings(config: Config) {
   private implicit class HasDefined(val config: Config) {
@@ -59,6 +60,14 @@ final class ClusterBootstrapSettings(config: Config) {
 
     val interval: FiniteDuration =
       discoveryConfig.getDuration("interval", TimeUnit.MILLISECONDS).millis
+
+    val exponentialBackoffRandomFactor: Double =
+      discoveryConfig.getDouble("exponential-backoff-random-factor")
+
+    val exponentialBackoffMax: FiniteDuration =
+      discoveryConfig.getDuration("exponential-backoff-max", TimeUnit.MILLISECONDS).millis
+
+    require(exponentialBackoffMax >= interval, "exponential-backoff-max has to be greater or equal to interval")
 
     val requiredContactPointsNr: Int = discoveryConfig.getInt("required-contact-point-nr")
 

--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/internal/HttpContactPointBootstrap.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/internal/HttpContactPointBootstrap.scala
@@ -100,10 +100,8 @@ private[bootstrap] class HttpContactPointBootstrap(
         .flatMap(_.entity.toStrict(1.second))
         .flatMap(res ⇒ Unmarshal(res).to[SeedNodes])
 
-      Future
-        .firstCompletedOf(List(reply,
-            after(settings.contactPoint.probingFailureTimeout, context.system.scheduler)(replyTimeout)))
-        .pipeTo(self)
+      val afterTimeout = after(settings.contactPoint.probingFailureTimeout, context.system.scheduler)(replyTimeout)
+      Future.firstCompletedOf(List(reply, afterTimeout)).pipeTo(self)
 
     case Status.Failure(cause) =>
       log.error("Probing [{}] failed due to: {}", probeRequest.uri, cause.getMessage)

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapBasePathIntegrationSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapBasePathIntegrationSpec.scala
@@ -14,6 +14,7 @@ import akka.testkit.{ SocketUtil, TestKit, TestProbe }
 import com.typesafe.config.ConfigFactory
 import org.scalatest.{ Matchers, WordSpecLike }
 
+import scala.concurrent.Future
 import scala.concurrent.duration._
 
 /**
@@ -68,10 +69,12 @@ class ClusterBootstrapBasePathIntegrationSpec extends WordSpecLike with Matchers
     val name = "basepathsystem.svc.cluster.local"
     MockDiscovery.set(name,
       () =>
-        Resolved(name,
-          List(
-            ResolvedTarget("127.0.0.1", Some(managementPort))
-          )))
+        Future.successful(
+          Resolved(name,
+            List(
+              ResolvedTarget("127.0.0.1", Some(managementPort))
+            ))
+      ))
 
     "start listening with the http contact-points on system" in {
       managementA.start()

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapDiscoveryBackoffIntegrationSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapDiscoveryBackoffIntegrationSpec.scala
@@ -14,27 +14,32 @@ import akka.management.cluster.bootstrap.ClusterBootstrap
 import akka.stream.ActorMaterializer
 import akka.testkit.{ SocketUtil, TestKit, TestProbe }
 import com.typesafe.config.{ Config, ConfigFactory }
+import org.scalactic.Tolerance
 import org.scalatest.{ Matchers, WordSpecLike }
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-class ClusterBootstrapIntegrationSpec extends WordSpecLike with Matchers {
+class ClusterBootstrapDiscoveryBackoffIntegrationSpec extends WordSpecLike with Matchers with Tolerance {
 
   "Cluster Bootstrap" should {
 
     var remotingPorts = Map.empty[String, Int]
     var contactPointPorts = Map.empty[String, Int]
+    var unreachablePorts = Map.empty[String, Int]
 
     def config(id: String): Config = {
       val managementPort = SocketUtil.temporaryServerAddress("127.0.0.1").getPort
       val remotingPort = SocketUtil.temporaryServerAddress("127.0.0.1").getPort
+      val unreachablePort = SocketUtil.temporaryServerAddress("127.0.0.1").getPort
 
-      info(s"System [$id]: management port: $managementPort")
-      info(s"System [$id]:   remoting port: $remotingPort")
+      info(s"System [$id]:  management port: $managementPort")
+      info(s"System [$id]:    remoting port: $remotingPort")
+      info(s"System [$id]: unreachable port: $unreachablePort")
 
       contactPointPorts = contactPointPorts.updated(id, managementPort)
       remotingPorts = remotingPorts.updated(id, remotingPort)
+      unreachablePorts = unreachablePorts.updated(id, unreachablePort)
 
       ConfigFactory.parseString(s"""
         akka {
@@ -57,6 +62,8 @@ class ClusterBootstrapIntegrationSpec extends WordSpecLike with Matchers {
                 service-namespace = "svc.cluster.local"
 
                 stable-margin = 4 seconds
+
+                interval = 500 ms
               }
             }
           }
@@ -66,28 +73,49 @@ class ClusterBootstrapIntegrationSpec extends WordSpecLike with Matchers {
 
     val systemA = ActorSystem("System", config("A"))
     val systemB = ActorSystem("System", config("B"))
-    val systemC = ActorSystem("System", config("C"))
 
     val clusterA = Cluster(systemA)
     val clusterB = Cluster(systemB)
-    val clusterC = Cluster(systemC)
 
     val bootstrapA = ClusterBootstrap(systemA)
     val bootstrapB = ClusterBootstrap(systemB)
-    val bootstrapC = ClusterBootstrap(systemC)
 
-    // prepare the "mock DNS"
+    val baseTime = System.currentTimeMillis()
+    case class DiscoveryRequest(time: Long, attempt: Int, res: Future[_]) {
+      override def toString = s"DiscoveryRequest(${(time - baseTime).millis}, $attempt, $res)"
+    }
+    val resolveProbe = TestProbe()(systemA)
+
+    // prepare the "mock DNS" - this resolves to unreachable addresses for the first three
+    // times it is called, thus testing that discovery is called multiple times and
+    // that formation will eventually succeed once discovery returns reachable addresses
+
+    @volatile var called = 0
+    @volatile var call2Timestamp = 0L
+    @volatile var call3Timestamp = 0L
     val name = "system.svc.cluster.local"
-    MockDiscovery.set(name,
-      () =>
-        Future.successful(
-          Resolved(name,
-            List(
-              ResolvedTarget(clusterA.selfAddress.host.get, contactPointPorts.get("A")),
-              ResolvedTarget(clusterB.selfAddress.host.get, contactPointPorts.get("B")),
-              ResolvedTarget(clusterC.selfAddress.host.get, contactPointPorts.get("C"))
-            ))
-      ))
+
+    MockDiscovery.set(name, { () =>
+      called += 1
+
+      if (called == 2)
+        call2Timestamp = System.nanoTime()
+      else if (called == 3)
+        call3Timestamp = System.nanoTime()
+
+      val res =
+        if (called < 4)
+          Future.failed(new Exception("Boom! Discovery failed, was rate limited for example..."))
+        else
+          Future.successful(Resolved(name,
+              List(
+                ResolvedTarget(clusterA.selfAddress.host.get, contactPointPorts.get("A")),
+                ResolvedTarget(clusterB.selfAddress.host.get, contactPointPorts.get("B"))
+              )))
+
+      resolveProbe.ref ! DiscoveryRequest(System.currentTimeMillis(), called, res)
+      res
+    })
 
     "start listening with the http contact-points on 3 systems" in {
       def start(system: ActorSystem, contactPointPort: Int) = {
@@ -103,28 +131,32 @@ class ClusterBootstrapIntegrationSpec extends WordSpecLike with Matchers {
 
       start(systemA, contactPointPorts("A"))
       start(systemB, contactPointPorts("B"))
-      start(systemC, contactPointPorts("C"))
     }
 
-    "join three DNS discovered nodes by forming new cluster (happy path)" in {
+    "poll discovery in exponentially increasing backoffs until eventually joining the returned nodes" in {
       bootstrapA.discovery.getClass should ===(classOf[MockDiscovery])
 
       bootstrapA.start()
-      bootstrapB.start()
-      bootstrapC.start()
+      // bootstrapB.start() // deliberately not discovering from this node, however its management port is available
 
       val pA = TestProbe()(systemA)
       clusterA.subscribe(pA.ref, classOf[MemberUp])
 
       pA.expectMsgType[CurrentClusterState]
-      val up1 = pA.expectMsgType[MemberUp](30.seconds)
+      val up1 = pA.expectMsgType[MemberUp](45.seconds)
       info("" + up1)
+
+      called shouldBe >=(5)
+
+      val durationBetweenCall2And3 = (call3Timestamp - call2Timestamp).nanos
+      info(s"duration between call 2 and 3 ${durationBetweenCall2And3.toMillis} ms")
+      durationBetweenCall2And3 shouldBe >=(ClusterBootstrap(systemA).settings.contactPointDiscovery.interval * 2)
+
     }
 
     "terminate all systems" in {
       try TestKit.shutdownActorSystem(systemA, 3.seconds)
-      finally try TestKit.shutdownActorSystem(systemB, 3.seconds)
-      finally TestKit.shutdownActorSystem(systemC, 3.seconds)
+      finally TestKit.shutdownActorSystem(systemB, 3.seconds)
     }
 
   }

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapDiscoveryBackoffIntegrationSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapDiscoveryBackoffIntegrationSpec.scala
@@ -71,8 +71,9 @@ class ClusterBootstrapDiscoveryBackoffIntegrationSpec extends WordSpecLike with 
         """.stripMargin).withFallback(ConfigFactory.load())
     }
 
-    val systemA = ActorSystem("System", config("A"))
-    val systemB = ActorSystem("System", config("B"))
+    val systemName = "backoff-discovery-system"
+    val systemA = ActorSystem(systemName, config("A"))
+    val systemB = ActorSystem(systemName, config("B"))
 
     val clusterA = Cluster(systemA)
     val clusterB = Cluster(systemB)
@@ -93,7 +94,7 @@ class ClusterBootstrapDiscoveryBackoffIntegrationSpec extends WordSpecLike with 
     @volatile var called = 0
     @volatile var call2Timestamp = 0L
     @volatile var call3Timestamp = 0L
-    val name = "system.svc.cluster.local"
+    val name = s"$systemName.svc.cluster.local"
 
     MockDiscovery.set(name, { () =>
       called += 1

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapDiscoveryBackoffIntegrationSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapDiscoveryBackoffIntegrationSpec.scala
@@ -138,7 +138,7 @@ class ClusterBootstrapDiscoveryBackoffIntegrationSpec extends WordSpecLike with 
       bootstrapA.discovery.getClass should ===(classOf[MockDiscovery])
 
       bootstrapA.start()
-      // bootstrapB.start() // deliberately not discovering from this node, however its management port is available
+      bootstrapB.start() // deliberately not discovering from this node, however its management port is available
 
       val pA = TestProbe()(systemA)
       clusterA.subscribe(pA.ref, classOf[MemberUp])

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapRetryUnreachableContactPointIntegrationSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapRetryUnreachableContactPointIntegrationSpec.scala
@@ -16,6 +16,7 @@ import akka.testkit.{ SocketUtil, TestKit, TestProbe }
 import com.typesafe.config.{ Config, ConfigFactory }
 import org.scalatest.{ Matchers, WordSpecLike }
 
+import scala.concurrent.Future
 import scala.concurrent.duration._
 
 class ClusterBootstrapRetryUnreachableContactPointIntegrationSpec extends WordSpecLike with Matchers {
@@ -87,18 +88,20 @@ class ClusterBootstrapRetryUnreachableContactPointIntegrationSpec extends WordSp
     MockDiscovery.set(name, { () =>
       called += 1
 
-      if (called > 3)
-        Resolved(name,
-          List(
-            ResolvedTarget(clusterA.selfAddress.host.get, contactPointPorts.get("A")),
-            ResolvedTarget(clusterB.selfAddress.host.get, contactPointPorts.get("B"))
-          ))
-      else
-        Resolved(name,
-          List(
-            ResolvedTarget(clusterA.selfAddress.host.get, unreachablePorts.get("A")),
-            ResolvedTarget(clusterB.selfAddress.host.get, unreachablePorts.get("B"))
-          ))
+      Future.successful(
+        if (called > 3)
+          Resolved(name,
+            List(
+              ResolvedTarget(clusterA.selfAddress.host.get, contactPointPorts.get("A")),
+              ResolvedTarget(clusterB.selfAddress.host.get, contactPointPorts.get("B"))
+            ))
+        else
+          Resolved(name,
+            List(
+              ResolvedTarget(clusterA.selfAddress.host.get, unreachablePorts.get("A")),
+              ResolvedTarget(clusterB.selfAddress.host.get, unreachablePorts.get("B"))
+            ))
+      )
     })
 
     "start listening with the http contact-points on 3 systems" in {


### PR DESCRIPTION
Will resolve https://github.com/akka/akka-management/issues/193 I'd hope.
It makes the timeouts more staggered as well as implements a backoff on failure