### PR TITLE
k8s pod lookup by name (#209)

### DIFF
--- a/discovery-kubernetes-api/src/main/resources/reference.conf
+++ b/discovery-kubernetes-api/src/main/resources/reference.conf
@@ -17,6 +17,8 @@ akka.discovery {
 
     # Namespace to query for pods
     pod-namespace = "default"
+    # Domain of the k8s cluster
+    pod-domain = "cluster.local"
 
     # Selector value to query pod API with.
     # `%s` will be replaced with the configured effective name, which defaults to the actor system name

--- a/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/Settings.scala
+++ b/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/Settings.scala
@@ -23,6 +23,9 @@ final class Settings(system: ExtendedActorSystem) extends Extension {
   val podNamespace: String =
     kubernetesApi.getString("pod-namespace")
 
+  val podDomain: String =
+    kubernetesApi.getString("pod-domain")
+
   def podLabelSelector(name: String): String =
     kubernetesApi.getString("pod-label-selector").format(name)
 

--- a/discovery-kubernetes-api/src/test/scala/akka/discovery/kubernetes/KubernetesApiSimpleServiceDiscoverySpec.scala
+++ b/discovery-kubernetes-api/src/test/scala/akka/discovery/kubernetes/KubernetesApiSimpleServiceDiscoverySpec.scala
@@ -21,8 +21,8 @@ class KubernetesApiSimpleServiceDiscoverySpec extends WordSpec with Matchers {
                           ContainerPort(Some("akka-mgmt-http"), 10001), ContainerPort(Some("http"), 10002))))))),
               Some(PodStatus(None)), Some(Metadata(deletionTimestamp = None)))))
 
-      KubernetesApiSimpleServiceDiscovery.targets(podList,
-        "akka-mgmt-http") shouldBe List(ResolvedTarget("172.17.0.4", Some(10001)))
+      KubernetesApiSimpleServiceDiscovery.targets(podList, "akka-mgmt-http", "default", "cluster.local") shouldBe List(
+          ResolvedTarget("172-17-0-4.default.pod.cluster.local", Some(10001)))
     }
 
     "ignore deleted pods" in {
@@ -32,7 +32,8 @@ class KubernetesApiSimpleServiceDiscoverySpec extends WordSpec with Matchers {
                           ContainerPort(Some("akka-mgmt-http"), 10001), ContainerPort(Some("http"), 10002))))))),
               Some(PodStatus(Some("172.17.0.4"))), Some(Metadata(deletionTimestamp = Some("2017-12-06T16:30:22Z"))))))
 
-      KubernetesApiSimpleServiceDiscovery.targets(podList, "akka-mgmt-http") shouldBe List.empty
+      KubernetesApiSimpleServiceDiscovery.targets(podList, "akka-mgmt-http", "default",
+        "cluster.local") shouldBe List.empty
     }
   }
 }


### PR DESCRIPTION
Istio service mesh requires that every service (e.g. bootstrap contact points) be requested by name (not by ip-addr).

Pods are assigned a DNS A record in the form of “**pod-ip-address**.my-namespace.**pod**.cluster.local”. [see](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pods)

This is a simple implementation for k8s pod lookup by name.