### PR TITLE
Fixes Kubernetes API Revolved value

### DIFF
--- a/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/KubernetesApiSimpleServiceDiscovery.scala
+++ b/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/KubernetesApiSimpleServiceDiscovery.scala
@@ -94,7 +94,11 @@ class KubernetesApiSimpleServiceDiscovery(system: ActorSystem) extends SimpleSer
         unmarshalled
       }
 
-    } yield Resolved(labelSelector, targets(podList, settings.podPortName, settings.podNamespace, settings.podDomain))
+    } yield
+      Resolved(
+        serviceName = name,
+        addresses = targets(podList, settings.podPortName, settings.podNamespace, settings.podDomain)
+      )
 
   private def apiToken() =
     FileIO.fromPath(Paths.get(settings.apiTokenPath)).runFold("")(_ + _.utf8String).recover { case _: Throwable => "" }


### PR DESCRIPTION
Fixes https://github.com/akka/akka-management/issues/222

The `Revolved` record expects the service name, but the Kubernetes API discovery's `Resolved` record currently returns the label selector instead of the queried service name.

This causes Lagom to fail on startup on Kubernetes with a strange error.

```
akka.actor.ActorSystemImpl [sourceThread=application-akka.actor.default-dispatcher-3, akkaTimestamp=xxxx, akkaSource=akka.actor.ActorSystemImpl(application), sourceActorSystem=application]
- Kubernetes API entity: [{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"found '=', expected: ',' or 'end of string'","reason":"BadRequest","code":400}
```

This is likely caused by querying  `app=app=foo`.