### PR TITLE
Allow an IP address to be used for the lowest "address"

### DIFF
--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/LowestAddressJoinDecider.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/LowestAddressJoinDecider.scala
@@ -135,12 +135,16 @@ class LowestAddressJoinDecider(system: ActorSystem, settings: ClusterBootstrapSe
               "Bootstrap.selfContactPoint was NOT set! This is required for the bootstrap to work! " +
               "If binding bootstrap routes manually and not via akka-management"))
 
+      // some discovery mechanism can return both host name and IP address. this checks for both.
+      def hostMatches(host: String, lowest: ResolvedTarget): Boolean =
+        (Some(host) == lowest.address) || (host == lowest.host)
+
       // we check if a contact point is "us", by comparing host and port that we've bound to
       def lowestContactPointIsSelfManagement(lowest: ResolvedTarget): Boolean = lowest.port match {
         case None =>
-          selfContactPoints.exists { case (host, _) => host == lowest.host }
+          selfContactPoints.exists { case (host, _) => hostMatches(host, lowest) }
         case Some(lowestPort) =>
-          selfContactPoints.exists { case (host, port) => host == lowest.host && port == lowestPort }
+          selfContactPoints.exists { case (host, port) => hostMatches(host, lowest) && port == lowestPort }
       }
 
       lowestAddressContactPoint(info) match {

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/LowestAddressJoinDeciderSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/LowestAddressJoinDeciderSpec.scala
@@ -54,19 +54,24 @@ class LowestAddressJoinDeciderSpec extends WordSpecLike with Matchers with Scala
     val system = ActorSystem("sys", config)
     val settings = ClusterBootstrapSettings(system.settings.config)
 
-    val contactA = ResolvedTarget("127.0.0.1", None)
-    val contactB = ResolvedTarget("b", None)
-    val contactC = ResolvedTarget("c", None)
+    val contactA = ResolvedTarget(host = "127.0.0.1", port = None, address = Some("127.0.0.1"))
+    val contactB = ResolvedTarget(host = "b", port = None, address = None)
+    val contactC = ResolvedTarget(host = "c", port = None, address = None)
 
     "sort ResolvedTarget by lowest hostname:port" in {
-      List(ResolvedTarget("c", None), ResolvedTarget("a", None), ResolvedTarget("b", None)).sorted should ===(
-        List(ResolvedTarget("a", None), ResolvedTarget("b", None), ResolvedTarget("c", None))
+      List(ResolvedTarget("c", None, None), ResolvedTarget("a", None, None),
+        ResolvedTarget("b", None, None)).sorted should ===(
+        List(ResolvedTarget("a", None, None), ResolvedTarget("b", None, None), ResolvedTarget("c", None, None))
       )
-      List(ResolvedTarget("c", Some(1)), ResolvedTarget("a", Some(3)), ResolvedTarget("b", Some(2))).sorted should ===(
-        List(ResolvedTarget("a", Some(3)), ResolvedTarget("b", Some(2)), ResolvedTarget("c", Some(1)))
+      List(ResolvedTarget("c", Some(1), None), ResolvedTarget("a", Some(3), None),
+        ResolvedTarget("b", Some(2), None)).sorted should ===(
+        List(ResolvedTarget("a", Some(3), None), ResolvedTarget("b", Some(2), None),
+          ResolvedTarget("c", Some(1), None))
       )
-      List(ResolvedTarget("a", Some(2)), ResolvedTarget("a", Some(1)), ResolvedTarget("a", Some(3))).sorted should ===(
-        List(ResolvedTarget("a", Some(1)), ResolvedTarget("a", Some(2)), ResolvedTarget("a", Some(3)))
+      List(ResolvedTarget("a", Some(2), None), ResolvedTarget("a", Some(1), None),
+        ResolvedTarget("a", Some(3), None)).sorted should ===(
+        List(ResolvedTarget("a", Some(1), None), ResolvedTarget("a", Some(2), None),
+          ResolvedTarget("a", Some(3), None))
       )
     }
 

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/LowestAddressJoinDeciderSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/LowestAddressJoinDeciderSpec.scala
@@ -44,7 +44,7 @@ class LowestAddressJoinDeciderSpec extends WordSpecLike with Matchers with Scala
             }
 
             http {
-              hostname = "127.0.0.1"
+              hostname = "10.0.0.2"
               base-path = "test"
               port = $managementPort
             }
@@ -54,7 +54,7 @@ class LowestAddressJoinDeciderSpec extends WordSpecLike with Matchers with Scala
     val system = ActorSystem("sys", config)
     val settings = ClusterBootstrapSettings(system.settings.config)
 
-    val contactA = ResolvedTarget(host = "127.0.0.1", port = None, address = Some("127.0.0.1"))
+    val contactA = ResolvedTarget(host = "10-0-0-2.default.pod.cluster.local", port = None, address = Some("10.0.0.2"))
     val contactB = ResolvedTarget(host = "b", port = None, address = None)
     val contactC = ResolvedTarget(host = "c", port = None, address = None)
 
@@ -83,9 +83,9 @@ class LowestAddressJoinDeciderSpec extends WordSpecLike with Matchers with Scala
         contactPointsChangedAt = now.minusSeconds(2),
         contactPoints = Set(contactA, contactB, contactC),
         seedNodesObservations = Set(new SeedNodesObservation(now.minusSeconds(1), contactA,
-            Address("akka", "sys", "127.0.0.1", 2552), Set(Address("akka", "sys", "127.0.0.1", 2552))))
+            Address("akka", "sys", "10.0.0.2", 2552), Set(Address("akka", "sys", "10.0.0.2", 2552))))
       )
-      decider.decide(info).futureValue should ===(JoinOtherSeedNodes(Set(Address("akka", "sys", "127.0.0.1", 2552))))
+      decider.decide(info).futureValue should ===(JoinOtherSeedNodes(Set(Address("akka", "sys", "10.0.0.2", 2552))))
     }
 
     "keep probing when contact points changed within stable-margin" in {
@@ -96,7 +96,7 @@ class LowestAddressJoinDeciderSpec extends WordSpecLike with Matchers with Scala
         contactPointsChangedAt = now.minusSeconds(2), // << 2 < stable-margin
         contactPoints = Set(contactA, contactB, contactC),
         seedNodesObservations = Set(new SeedNodesObservation(now.minusSeconds(1), contactA,
-            Address("akka", "sys", "127.0.0.1", 2552), Set.empty),
+            Address("akka", "sys", "10.0.0.2", 2552), Set.empty),
           new SeedNodesObservation(now.minusSeconds(1), contactB, Address("akka", "sys", "b", 2552), Set.empty),
           new SeedNodesObservation(now.minusSeconds(1), contactC, Address("akka", "sys", "c", 2552), Set.empty))
       )
@@ -111,7 +111,7 @@ class LowestAddressJoinDeciderSpec extends WordSpecLike with Matchers with Scala
         contactPointsChangedAt = now.minusSeconds(2),
         contactPoints = Set(contactA, contactB), // << 2 < required-contact-point-nr
         seedNodesObservations = Set(new SeedNodesObservation(now.minusSeconds(1), contactA,
-            Address("akka", "sys", "127.0.0.1", 2552), Set.empty),
+            Address("akka", "sys", "10.0.0.2", 2552), Set.empty),
           new SeedNodesObservation(now.minusSeconds(1), contactB, Address("akka", "sys", "b", 2552), Set.empty))
       )
       decider.decide(info).futureValue should ===(KeepProbing)
@@ -125,15 +125,15 @@ class LowestAddressJoinDeciderSpec extends WordSpecLike with Matchers with Scala
         contactPointsChangedAt = now.minusSeconds(2),
         contactPoints = Set(contactA, contactB, contactC),
         seedNodesObservations = Set(new SeedNodesObservation(now.minusSeconds(1), contactA,
-            Address("akka", "sys", "127.0.0.1", 2552), Set.empty),
+            Address("akka", "sys", "10.0.0.2", 2552), Set.empty),
           new SeedNodesObservation(now.minusSeconds(1), contactB, Address("akka", "sys", "b", 2552), Set.empty))
         // << 2 < required-contact-point-nr
       )
       decider.decide(info).futureValue should ===(KeepProbing)
     }
 
-    "join self when all conditions met and self is lowest address" in {
-      ClusterBootstrap(system).setSelfContactPoint(s"http://127.0.0.1:$managementPort/test")
+    "join self when all conditions met and self has the lowest address" in {
+      ClusterBootstrap(system).setSelfContactPoint(s"http://10.0.0.2:$managementPort/test")
       val decider = new LowestAddressJoinDecider(system, settings)
       val now = LocalDateTime.now()
       val info = new SeedNodesInformation(
@@ -141,7 +141,7 @@ class LowestAddressJoinDeciderSpec extends WordSpecLike with Matchers with Scala
         contactPointsChangedAt = now.minusSeconds(6),
         contactPoints = Set(contactA, contactB, contactC),
         seedNodesObservations = Set(new SeedNodesObservation(now.minusSeconds(1), contactA,
-            Address("akka", "sys", "127.0.0.1", 2552), Set.empty),
+            Address("akka", "sys", "10.0.0.2", 2552), Set.empty),
           new SeedNodesObservation(now.minusSeconds(1), contactB, Address("akka", "sys", "b", 2552), Set.empty),
           new SeedNodesObservation(now.minusSeconds(1), contactC, Address("akka", "sys", "c", 2552), Set.empty))
       )

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapBasePathIntegrationSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapBasePathIntegrationSpec.scala
@@ -72,7 +72,7 @@ class ClusterBootstrapBasePathIntegrationSpec extends WordSpecLike with Matchers
         Future.successful(
           Resolved(name,
             List(
-              ResolvedTarget("127.0.0.1", Some(managementPort))
+              ResolvedTarget(host = "127.0.0.1", port = Some(managementPort), address = Some("127.0.0.1"))
             ))
       ))
 

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapDiscoveryBackoffIntegrationSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapDiscoveryBackoffIntegrationSpec.scala
@@ -110,8 +110,16 @@ class ClusterBootstrapDiscoveryBackoffIntegrationSpec extends WordSpecLike with 
         else
           Future.successful(Resolved(name,
               List(
-                ResolvedTarget(clusterA.selfAddress.host.get, contactPointPorts.get("A")),
-                ResolvedTarget(clusterB.selfAddress.host.get, contactPointPorts.get("B"))
+                ResolvedTarget(
+                  host = clusterA.selfAddress.host.get,
+                  port = contactPointPorts.get("A"),
+                  address = clusterA.selfAddress.host
+                ),
+                ResolvedTarget(
+                  host = clusterB.selfAddress.host.get,
+                  port = contactPointPorts.get("B"),
+                  address = clusterB.selfAddress.host
+                )
               )))
 
       resolveProbe.ref ! DiscoveryRequest(System.currentTimeMillis(), called, res)

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapIntegrationSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapIntegrationSpec.scala
@@ -83,9 +83,21 @@ class ClusterBootstrapIntegrationSpec extends WordSpecLike with Matchers {
         Future.successful(
           Resolved(name,
             List(
-              ResolvedTarget(clusterA.selfAddress.host.get, contactPointPorts.get("A")),
-              ResolvedTarget(clusterB.selfAddress.host.get, contactPointPorts.get("B")),
-              ResolvedTarget(clusterC.selfAddress.host.get, contactPointPorts.get("C"))
+              ResolvedTarget(
+                host = clusterA.selfAddress.host.get,
+                port = contactPointPorts.get("A"),
+                address = clusterA.selfAddress.host
+              ),
+              ResolvedTarget(
+                host = clusterB.selfAddress.host.get,
+                port = contactPointPorts.get("B"),
+                address = clusterB.selfAddress.host
+              ),
+              ResolvedTarget(
+                host = clusterC.selfAddress.host.get,
+                port = contactPointPorts.get("C"),
+                address = clusterC.selfAddress.host
+              )
             ))
       ))
 

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapRetryUnreachableContactPointIntegrationSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapRetryUnreachableContactPointIntegrationSpec.scala
@@ -92,14 +92,30 @@ class ClusterBootstrapRetryUnreachableContactPointIntegrationSpec extends WordSp
         if (called > 3)
           Resolved(name,
             List(
-              ResolvedTarget(clusterA.selfAddress.host.get, contactPointPorts.get("A")),
-              ResolvedTarget(clusterB.selfAddress.host.get, contactPointPorts.get("B"))
+              ResolvedTarget(
+                host = clusterA.selfAddress.host.get,
+                port = contactPointPorts.get("A"),
+                address = clusterA.selfAddress.host
+              ),
+              ResolvedTarget(
+                host = clusterB.selfAddress.host.get,
+                port = contactPointPorts.get("B"),
+                address = clusterB.selfAddress.host
+              )
             ))
         else
           Resolved(name,
             List(
-              ResolvedTarget(clusterA.selfAddress.host.get, unreachablePorts.get("A")),
-              ResolvedTarget(clusterB.selfAddress.host.get, unreachablePorts.get("B"))
+              ResolvedTarget(
+                host = clusterA.selfAddress.host.get,
+                port = unreachablePorts.get("A"),
+                address = clusterA.selfAddress.host
+              ),
+              ResolvedTarget(
+                host = clusterB.selfAddress.host.get,
+                port = unreachablePorts.get("B"),
+                address = clusterB.selfAddress.host
+              )
             ))
       )
     })

--- a/discovery-aws-api-async/src/main/scala/akka/discovery/awsapi/ecs/AsyncEcsSimpleServiceDiscovery.scala
+++ b/discovery-aws-api-async/src/main/scala/akka/discovery/awsapi/ecs/AsyncEcsSimpleServiceDiscovery.scala
@@ -48,11 +48,10 @@ class AsyncEcsSimpleServiceDiscovery(system: ActorSystem) extends SimpleServiceD
                 task <- tasks
                 container <- task.containers().asScala
                 networkInterface <- container.networkInterfaces().asScala
-              } yield
-                ResolvedTarget(
-                  host = networkInterface.privateIpv4Address(),
-                  port = None
-                )
+              } yield {
+                val address = networkInterface.privateIpv4Address()
+                ResolvedTarget(host = address, port = None, address = Some(address))
+              }
           )
         )
       )

--- a/discovery-aws-api/src/main/scala/akka/discovery/awsapi/ec2/Ec2TagBasedSimpleServiceDiscovery.scala
+++ b/discovery-aws-api/src/main/scala/akka/discovery/awsapi/ec2/Ec2TagBasedSimpleServiceDiscovery.scala
@@ -105,7 +105,8 @@ class Ec2TagBasedSimpleServiceDiscovery(system: ActorSystem) extends SimpleServi
     val allFilters: List[Filter] = runningInstancesFilter :: tagFilter :: otherFilters
 
     Future {
-      getInstances(ec2Client, allFilters, None).map((ip: String) => ResolvedTarget(ip, None))
+      getInstances(ec2Client, allFilters,
+        None).map((ip: String) => ResolvedTarget(host = ip, port = None, address = Some(ip)))
     }.map(resoledTargets => Resolved(name, resoledTargets))
 
   }

--- a/discovery-aws-api/src/main/scala/akka/discovery/awsapi/ecs/EcsSimpleServiceDiscovery.scala
+++ b/discovery-aws-api/src/main/scala/akka/discovery/awsapi/ecs/EcsSimpleServiceDiscovery.scala
@@ -49,11 +49,10 @@ class EcsSimpleServiceDiscovery(system: ActorSystem) extends SimpleServiceDiscov
               task <- resolveTasks(ecsClient, cluster, name)
               container <- task.getContainers.asScala
               networkInterface <- container.getNetworkInterfaces.asScala
-            } yield
-              ResolvedTarget(
-                host = networkInterface.getPrivateIpv4Address,
-                port = None
-              )
+            } yield {
+              val address = networkInterface.getPrivateIpv4Address
+              ResolvedTarget(host = address, port = None, address = Some(address))
+            }
           )
         }
       )

--- a/discovery-config/src/main/scala/akka/discovery/config/ConfigSimpleServiceDiscovery.scala
+++ b/discovery-config/src/main/scala/akka/discovery/config/ConfigSimpleServiceDiscovery.scala
@@ -31,7 +31,7 @@ object ConfigServicesParser {
         val resolvedTargets: immutable.Seq[ResolvedTarget] = endpoints.map { c =>
           val host = c.getString("host")
           val port = if (c.hasPath("port")) Some(c.getInt("port")) else None
-          ResolvedTarget(host, port)
+          ResolvedTarget(host = host, port = port, address = None)
         }(breakOut)
         (serviceName, Resolved(serviceName, resolvedTargets))
     }

--- a/discovery-config/src/test/scala/akka/discovery/config/ConfigServicesParserSpec.scala
+++ b/discovery-config/src/test/scala/akka/discovery/config/ConfigServicesParserSpec.scala
@@ -40,7 +40,10 @@ class ConfigServicesParserSpec extends WordSpec with Matchers {
       val result = ConfigServicesParser.parse(config)
 
       result("service1") shouldEqual Resolved("service1",
-        immutable.Seq(ResolvedTarget("cat", Some(1233)), ResolvedTarget("dog", None)))
+        immutable.Seq(
+          ResolvedTarget(host = "cat", port = Some(1233), address = None),
+          ResolvedTarget(host = "dog", port = None, address = None)
+        ))
       result("service2") shouldEqual Resolved("service2", immutable.Seq())
     }
   }

--- a/discovery-config/src/test/scala/akka/discovery/config/ConfigSimpleServiceDiscoverySpec.scala
+++ b/discovery-config/src/test/scala/akka/discovery/config/ConfigSimpleServiceDiscoverySpec.scala
@@ -63,8 +63,8 @@ class ConfigSimpleServiceDiscoverySpec
       val result = discovery.lookup("service1", 100.millis).futureValue
       result.serviceName shouldEqual "service1"
       result.addresses shouldEqual immutable.Seq(
-        ResolvedTarget("cat", Some(1233)),
-        ResolvedTarget("dog", None)
+        ResolvedTarget(host = "cat", port = Some(1233), address = None),
+        ResolvedTarget(host = "dog", port = None, address = None)
       )
     }
 

--- a/discovery-consul/src/main/scala/akka/discovery/consul/ConsulSimpleServiceDiscovery.scala
+++ b/discovery-consul/src/main/scala/akka/discovery/consul/ConsulSimpleServiceDiscovery.scala
@@ -65,7 +65,12 @@ class ConsulSimpleServiceDiscovery(system: ActorSystem) extends SimpleServiceDis
       .flatMap { maybePort =>
         Try(maybePort.toInt).toOption
       }
-    ResolvedTarget(catalogService.getServiceAddress, Some(port.getOrElse(catalogService.getServicePort)))
+    val address = catalogService.getServiceAddress
+    ResolvedTarget(
+      host = address,
+      port = Some(port.getOrElse(catalogService.getServicePort)),
+      address = Some(address)
+    )
   }
 
   private def getServicesWithTags: Future[ConsulResponse[util.Map[String, util.List[String]]]] = {

--- a/discovery-consul/src/test/scala/akka/cluster/bootstrap/discovery/ConsulDiscoverySpec.scala
+++ b/discovery-consul/src/test/scala/akka/cluster/bootstrap/discovery/ConsulDiscoverySpec.scala
@@ -53,7 +53,13 @@ class ConsulDiscoverySpec
 
       val lookupService = new ConsulSimpleServiceDiscovery(system)
       val resolved = lookupService.lookup("test", 10 seconds).futureValue
-      resolved.addresses should contain(ResolvedTarget("127.0.0.1", Some(1234)))
+      resolved.addresses should contain(
+        ResolvedTarget(
+          host = "127.0.0.1",
+          port = Some(1234),
+          address = Some("127.0.0.1")
+        )
+      )
     }
   }
 

--- a/discovery-dns/src/main/scala/akka/discovery/dns/DnsSimpleServiceDiscovery.scala
+++ b/discovery-dns/src/main/scala/akka/discovery/dns/DnsSimpleServiceDiscovery.scala
@@ -30,7 +30,8 @@ class DnsSimpleServiceDiscovery(system: ActorSystem) extends SimpleServiceDiscov
       case resolved: Dns.Resolved =>
         log.info("Resolved Dns.Resolved: {}", resolved)
         val addresses = resolved.ipv4.map { entry ⇒
-          ResolvedTarget(cleanIpString(entry.getHostAddress), port = None)
+          val address = cleanIpString(entry.getHostAddress)
+          ResolvedTarget(host = address, port = None, address = Some(address))
         }
         Resolved(name, addresses)
 

--- a/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/KubernetesApiSimpleServiceDiscovery.scala
+++ b/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/KubernetesApiSimpleServiceDiscovery.scala
@@ -40,7 +40,7 @@ object KubernetesApiSimpleServiceDiscovery {
       itemStatus <- item.status
       ip <- itemStatus.podIP
       host = s"${ip.replace('.', '-')}.${podNamespace}.pod.${podDomain}"
-    } yield ResolvedTarget(host, Some(port.containerPort))
+    } yield ResolvedTarget(host = host, port = Some(port.containerPort), address = Some(ip))
 }
 
 /**

--- a/discovery-kubernetes-api/src/test/scala/akka/discovery/kubernetes/KubernetesApiSimpleServiceDiscoverySpec.scala
+++ b/discovery-kubernetes-api/src/test/scala/akka/discovery/kubernetes/KubernetesApiSimpleServiceDiscoverySpec.scala
@@ -22,7 +22,11 @@ class KubernetesApiSimpleServiceDiscoverySpec extends WordSpec with Matchers {
               Some(PodStatus(None)), Some(Metadata(deletionTimestamp = None)))))
 
       KubernetesApiSimpleServiceDiscovery.targets(podList, "akka-mgmt-http", "default", "cluster.local") shouldBe List(
-          ResolvedTarget("172-17-0-4.default.pod.cluster.local", Some(10001)))
+          ResolvedTarget(
+            host = "172-17-0-4.default.pod.cluster.local",
+            port = Some(10001),
+            address = Some("172.17.0.4")
+          ))
     }
 
     "ignore deleted pods" in {

--- a/discovery-marathon-api/src/main/scala/akka/discovery/marathon/MarathonApiSimpleServiceDiscovery.scala
+++ b/discovery-marathon-api/src/main/scala/akka/discovery/marathon/MarathonApiSimpleServiceDiscovery.scala
@@ -55,7 +55,7 @@ object MarathonApiSimpleServiceDiscovery {
       taskHost <- task.host
       taskPorts <- task.ports
       taskAkkaManagementPort <- taskPorts.lift(portNumber)
-    } yield ResolvedTarget(taskHost, Some(taskAkkaManagementPort))
+    } yield ResolvedTarget(host = taskHost, port = Some(taskAkkaManagementPort), address = None)
   }
 }
 

--- a/discovery-marathon-api/src/test/scala/akka/discovery/marathon/MarathonApiSimpleServiceDiscoverySpec.scala
+++ b/discovery-marathon-api/src/test/scala/akka/discovery/marathon/MarathonApiSimpleServiceDiscoverySpec.scala
@@ -16,15 +16,17 @@ class MarathonApiSimpleServiceDiscoverySpec extends WordSpec with Matchers {
       val appList = JsonFormat.appListFormat.read(data.parseJson)
 
       MarathonApiSimpleServiceDiscovery.targets(appList, "akka-mgmt-http") shouldBe List(
-          ResolvedTarget("192.168.65.60", Some(23236)), ResolvedTarget("192.168.65.111", Some(6850)))
+          ResolvedTarget(host = "192.168.65.60", port = Some(23236), address = Some("192.168.65.60")),
+          ResolvedTarget(host = "192.168.65.111", port = Some(6850), address = Some("192.168.65.111")))
     }
     "calculate the correct list of resolved targets for docker" in {
       val data = resourceAsString("docker-app.json")
 
       val appList = JsonFormat.appListFormat.read(data.parseJson)
 
-      MarathonApiSimpleServiceDiscovery.targets(appList, "akkamgmthttp") shouldBe List(ResolvedTarget("10.121.48.204",
-          Some(29480)), ResolvedTarget("10.121.48.204", Some(10136)))
+      MarathonApiSimpleServiceDiscovery.targets(appList, "akkamgmthttp") shouldBe List(
+          ResolvedTarget(host = "10.121.48.204", port = Some(29480), address = Some("10.121.48.204")),
+          ResolvedTarget(host = "10.121.48.204", port = Some(10136), address = Some("10.121.48.204")))
     }
   }
 

--- a/discovery/src/main/scala/akka/discovery/SimpleServiceDiscovery.scala
+++ b/discovery/src/main/scala/akka/discovery/SimpleServiceDiscovery.scala
@@ -41,11 +41,28 @@ object SimpleServiceDiscovery {
     }
   }
 
-  /** Resolved target host, with optional port and protocol spoken */
-  final case class ResolvedTarget(host: String, port: Option[Int]) {
+  /**
+   * Resolved target host, with optional port and the IP address.
+   * The address may be used for cluster bootstrap.
+   */
+  final case class ResolvedTarget(host: String, port: Option[Int], address: Option[String]) {
     def getPort: Optional[Int] = {
       import scala.compat.java8.OptionConverters._
       port.asJava
+    }
+
+    def getAddress: Optional[String] = {
+      import scala.compat.java8.OptionConverters._
+      address.asJava
+    }
+
+    override def equals(o: Any): Boolean = o match {
+      case x: ResolvedTarget => (this.host == x.host) && (this.port == x.port)
+      case _ => false
+    }
+
+    override def hashCode: Int = {
+      (host, port).##
     }
 
     override def toString(): String =


### PR DESCRIPTION
Ref #187

#217 started returning “pod-ip-address.my-namespace.pod.cluster.local” in `ResolvedTarget` for Kubernetes API Discovery.

#236 reports that this is in conflict with Cluster Bootstrap when the "self" address is still based on an IP address.

This attempts to provide a fix for the situation by returning both the host name and an optional IP address in `ResolvedTarget`, and letting `LowestAddressJoinDecider` match on either the host or the address.