### PR TITLE
Use InetAddress type to denote IPv4 address

### DIFF
--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/LowestAddressJoinDecider.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/LowestAddressJoinDecider.scala
@@ -137,7 +137,7 @@ class LowestAddressJoinDecider(system: ActorSystem, settings: ClusterBootstrapSe
 
       // some discovery mechanism can return both host name and IP address. this checks for both.
       def hostMatches(host: String, lowest: ResolvedTarget): Boolean =
-        (Some(host) == lowest.address) || (host == lowest.host)
+        (Some(host) == lowest.address.map(_.getHostAddress)) || (host == lowest.host)
 
       // we check if a contact point is "us", by comparing host and port that we've bound to
       def lowestContactPointIsSelfManagement(lowest: ResolvedTarget): Boolean = lowest.port match {

--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/LowestAddressJoinDecider.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/LowestAddressJoinDecider.scala
@@ -137,7 +137,7 @@ class LowestAddressJoinDecider(system: ActorSystem, settings: ClusterBootstrapSe
 
       // some discovery mechanism can return both host name and IP address. this checks for both.
       def hostMatches(host: String, lowest: ResolvedTarget): Boolean =
-        (Some(host) == lowest.address.map(_.getHostAddress)) || (host == lowest.host)
+        (host == lowest.host) || (Some(host) == lowest.address.map(_.getHostAddress))
 
       // we check if a contact point is "us", by comparing host and port that we've bound to
       def lowestContactPointIsSelfManagement(lowest: ResolvedTarget): Boolean = lowest.port match {

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/LowestAddressJoinDeciderSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/LowestAddressJoinDeciderSpec.scala
@@ -7,6 +7,7 @@ import java.time.LocalDateTime
 
 import scala.concurrent.duration._
 
+import java.net.InetAddress
 import akka.actor.ActorSystem
 import akka.actor.Address
 import akka.discovery.SimpleServiceDiscovery.ResolvedTarget
@@ -54,7 +55,11 @@ class LowestAddressJoinDeciderSpec extends WordSpecLike with Matchers with Scala
     val system = ActorSystem("sys", config)
     val settings = ClusterBootstrapSettings(system.settings.config)
 
-    val contactA = ResolvedTarget(host = "10-0-0-2.default.pod.cluster.local", port = None, address = Some("10.0.0.2"))
+    val contactA = ResolvedTarget(
+      host = "10-0-0-2.default.pod.cluster.local",
+      port = None,
+      address = Some(InetAddress.getByName("10.0.0.2"))
+    )
     val contactB = ResolvedTarget(host = "b", port = None, address = None)
     val contactC = ResolvedTarget(host = "c", port = None, address = None)
 

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapBasePathIntegrationSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapBasePathIntegrationSpec.scala
@@ -72,7 +72,7 @@ class ClusterBootstrapBasePathIntegrationSpec extends WordSpecLike with Matchers
         Future.successful(
           Resolved(name,
             List(
-              ResolvedTarget(host = "127.0.0.1", port = Some(managementPort), address = Some("127.0.0.1"))
+              ResolvedTarget(host = "127.0.0.1", port = Some(managementPort))
             ))
       ))
 

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapDiscoveryBackoffIntegrationSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapDiscoveryBackoffIntegrationSpec.scala
@@ -112,13 +112,11 @@ class ClusterBootstrapDiscoveryBackoffIntegrationSpec extends WordSpecLike with 
               List(
                 ResolvedTarget(
                   host = clusterA.selfAddress.host.get,
-                  port = contactPointPorts.get("A"),
-                  address = clusterA.selfAddress.host
+                  port = contactPointPorts.get("A")
                 ),
                 ResolvedTarget(
                   host = clusterB.selfAddress.host.get,
-                  port = contactPointPorts.get("B"),
-                  address = clusterB.selfAddress.host
+                  port = contactPointPorts.get("B")
                 )
               )))
 

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapIntegrationSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapIntegrationSpec.scala
@@ -85,18 +85,15 @@ class ClusterBootstrapIntegrationSpec extends WordSpecLike with Matchers {
             List(
               ResolvedTarget(
                 host = clusterA.selfAddress.host.get,
-                port = contactPointPorts.get("A"),
-                address = clusterA.selfAddress.host
+                port = contactPointPorts.get("A")
               ),
               ResolvedTarget(
                 host = clusterB.selfAddress.host.get,
-                port = contactPointPorts.get("B"),
-                address = clusterB.selfAddress.host
+                port = contactPointPorts.get("B")
               ),
               ResolvedTarget(
                 host = clusterC.selfAddress.host.get,
-                port = contactPointPorts.get("C"),
-                address = clusterC.selfAddress.host
+                port = contactPointPorts.get("C")
               )
             ))
       ))

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapRetryUnreachableContactPointIntegrationSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapRetryUnreachableContactPointIntegrationSpec.scala
@@ -94,13 +94,11 @@ class ClusterBootstrapRetryUnreachableContactPointIntegrationSpec extends WordSp
             List(
               ResolvedTarget(
                 host = clusterA.selfAddress.host.get,
-                port = contactPointPorts.get("A"),
-                address = clusterA.selfAddress.host
+                port = contactPointPorts.get("A")
               ),
               ResolvedTarget(
                 host = clusterB.selfAddress.host.get,
-                port = contactPointPorts.get("B"),
-                address = clusterB.selfAddress.host
+                port = contactPointPorts.get("B")
               )
             ))
         else
@@ -108,13 +106,11 @@ class ClusterBootstrapRetryUnreachableContactPointIntegrationSpec extends WordSp
             List(
               ResolvedTarget(
                 host = clusterA.selfAddress.host.get,
-                port = unreachablePorts.get("A"),
-                address = clusterA.selfAddress.host
+                port = unreachablePorts.get("A")
               ),
               ResolvedTarget(
                 host = clusterB.selfAddress.host.get,
-                port = unreachablePorts.get("B"),
-                address = clusterB.selfAddress.host
+                port = unreachablePorts.get("B")
               )
             ))
       )

--- a/discovery-aws-api-async/src/main/scala/akka/discovery/awsapi/ecs/AsyncEcsSimpleServiceDiscovery.scala
+++ b/discovery-aws-api-async/src/main/scala/akka/discovery/awsapi/ecs/AsyncEcsSimpleServiceDiscovery.scala
@@ -50,7 +50,7 @@ class AsyncEcsSimpleServiceDiscovery(system: ActorSystem) extends SimpleServiceD
                 networkInterface <- container.networkInterfaces().asScala
               } yield {
                 val address = networkInterface.privateIpv4Address()
-                ResolvedTarget(host = address, port = None, address = Some(address))
+                ResolvedTarget(host = address, port = None)
               }
           )
         )

--- a/discovery-aws-api/src/main/scala/akka/discovery/awsapi/ec2/Ec2TagBasedSimpleServiceDiscovery.scala
+++ b/discovery-aws-api/src/main/scala/akka/discovery/awsapi/ec2/Ec2TagBasedSimpleServiceDiscovery.scala
@@ -105,8 +105,7 @@ class Ec2TagBasedSimpleServiceDiscovery(system: ActorSystem) extends SimpleServi
     val allFilters: List[Filter] = runningInstancesFilter :: tagFilter :: otherFilters
 
     Future {
-      getInstances(ec2Client, allFilters,
-        None).map((ip: String) => ResolvedTarget(host = ip, port = None, address = Some(ip)))
+      getInstances(ec2Client, allFilters, None).map((ip: String) => ResolvedTarget(host = ip, port = None))
     }.map(resoledTargets => Resolved(name, resoledTargets))
 
   }

--- a/discovery-aws-api/src/main/scala/akka/discovery/awsapi/ecs/EcsSimpleServiceDiscovery.scala
+++ b/discovery-aws-api/src/main/scala/akka/discovery/awsapi/ecs/EcsSimpleServiceDiscovery.scala
@@ -51,7 +51,7 @@ class EcsSimpleServiceDiscovery(system: ActorSystem) extends SimpleServiceDiscov
               networkInterface <- container.getNetworkInterfaces.asScala
             } yield {
               val address = networkInterface.getPrivateIpv4Address
-              ResolvedTarget(host = address, port = None, address = Some(address))
+              ResolvedTarget(host = address, port = None)
             }
           )
         }

--- a/discovery-consul/src/main/scala/akka/discovery/consul/ConsulSimpleServiceDiscovery.scala
+++ b/discovery-consul/src/main/scala/akka/discovery/consul/ConsulSimpleServiceDiscovery.scala
@@ -68,8 +68,7 @@ class ConsulSimpleServiceDiscovery(system: ActorSystem) extends SimpleServiceDis
     val address = catalogService.getServiceAddress
     ResolvedTarget(
       host = address,
-      port = Some(port.getOrElse(catalogService.getServicePort)),
-      address = Some(address)
+      port = Some(port.getOrElse(catalogService.getServicePort))
     )
   }
 

--- a/discovery-consul/src/test/scala/akka/cluster/bootstrap/discovery/ConsulDiscoverySpec.scala
+++ b/discovery-consul/src/test/scala/akka/cluster/bootstrap/discovery/ConsulDiscoverySpec.scala
@@ -3,6 +3,7 @@
  */
 package akka.cluster.bootstrap.discovery
 
+import java.net.InetAddress
 import akka.actor.ActorSystem
 import akka.discovery.SimpleServiceDiscovery.ResolvedTarget
 import akka.discovery.consul.ConsulSimpleServiceDiscovery
@@ -57,7 +58,7 @@ class ConsulDiscoverySpec
         ResolvedTarget(
           host = "127.0.0.1",
           port = Some(1234),
-          address = Some("127.0.0.1")
+          address = Some(InetAddress.getByName("127.0.0.1"))
         )
       )
     }

--- a/discovery-dns/src/main/scala/akka/discovery/dns/DnsSimpleServiceDiscovery.scala
+++ b/discovery-dns/src/main/scala/akka/discovery/dns/DnsSimpleServiceDiscovery.scala
@@ -31,7 +31,7 @@ class DnsSimpleServiceDiscovery(system: ActorSystem) extends SimpleServiceDiscov
         log.info("Resolved Dns.Resolved: {}", resolved)
         val addresses = resolved.ipv4.map { entry ⇒
           val address = cleanIpString(entry.getHostAddress)
-          ResolvedTarget(host = address, port = None, address = Some(address))
+          ResolvedTarget(host = address, port = None)
         }
         Resolved(name, addresses)
 

--- a/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/KubernetesApiSimpleServiceDiscovery.scala
+++ b/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/KubernetesApiSimpleServiceDiscovery.scala
@@ -3,6 +3,8 @@
  */
 package akka.discovery.kubernetes
 
+import java.net.InetAddress
+import java.nio.file.Paths
 import akka.actor.ActorSystem
 import akka.discovery._
 import akka.http.scaladsl._
@@ -13,7 +15,6 @@ import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.FileIO
 import com.typesafe.sslconfig.akka.AkkaSSLConfig
 import com.typesafe.sslconfig.ssl.TrustStoreConfig
-import java.nio.file.Paths
 import scala.collection.immutable.Seq
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
@@ -40,7 +41,12 @@ object KubernetesApiSimpleServiceDiscovery {
       itemStatus <- item.status
       ip <- itemStatus.podIP
       host = s"${ip.replace('.', '-')}.${podNamespace}.pod.${podDomain}"
-    } yield ResolvedTarget(host = host, port = Some(port.containerPort), address = Some(ip))
+    } yield
+      ResolvedTarget(
+        host = host,
+        port = Some(port.containerPort),
+        address = Some(InetAddress.getByName(ip))
+      )
 }
 
 /**

--- a/discovery-kubernetes-api/src/test/scala/akka/discovery/kubernetes/KubernetesApiSimpleServiceDiscoverySpec.scala
+++ b/discovery-kubernetes-api/src/test/scala/akka/discovery/kubernetes/KubernetesApiSimpleServiceDiscoverySpec.scala
@@ -3,6 +3,7 @@
  */
 package akka.discovery.kubernetes
 
+import java.net.InetAddress
 import akka.discovery.SimpleServiceDiscovery.ResolvedTarget
 import org.scalatest.{ Matchers, WordSpec }
 
@@ -25,7 +26,7 @@ class KubernetesApiSimpleServiceDiscoverySpec extends WordSpec with Matchers {
           ResolvedTarget(
             host = "172-17-0-4.default.pod.cluster.local",
             port = Some(10001),
-            address = Some("172.17.0.4")
+            address = Some(InetAddress.getByName("172.17.0.4"))
           ))
     }
 

--- a/discovery-marathon-api/src/main/scala/akka/discovery/marathon/MarathonApiSimpleServiceDiscovery.scala
+++ b/discovery-marathon-api/src/main/scala/akka/discovery/marathon/MarathonApiSimpleServiceDiscovery.scala
@@ -55,7 +55,7 @@ object MarathonApiSimpleServiceDiscovery {
       taskHost <- task.host
       taskPorts <- task.ports
       taskAkkaManagementPort <- taskPorts.lift(portNumber)
-    } yield ResolvedTarget(host = taskHost, port = Some(taskAkkaManagementPort), address = None)
+    } yield ResolvedTarget(host = taskHost, port = Some(taskAkkaManagementPort))
   }
 }
 

--- a/discovery-marathon-api/src/test/scala/akka/discovery/marathon/MarathonApiSimpleServiceDiscoverySpec.scala
+++ b/discovery-marathon-api/src/test/scala/akka/discovery/marathon/MarathonApiSimpleServiceDiscoverySpec.scala
@@ -16,8 +16,8 @@ class MarathonApiSimpleServiceDiscoverySpec extends WordSpec with Matchers {
       val appList = JsonFormat.appListFormat.read(data.parseJson)
 
       MarathonApiSimpleServiceDiscovery.targets(appList, "akka-mgmt-http") shouldBe List(
-          ResolvedTarget(host = "192.168.65.60", port = Some(23236), address = Some("192.168.65.60")),
-          ResolvedTarget(host = "192.168.65.111", port = Some(6850), address = Some("192.168.65.111")))
+          ResolvedTarget(host = "192.168.65.60", port = Some(23236)),
+          ResolvedTarget(host = "192.168.65.111", port = Some(6850)))
     }
     "calculate the correct list of resolved targets for docker" in {
       val data = resourceAsString("docker-app.json")
@@ -25,8 +25,8 @@ class MarathonApiSimpleServiceDiscoverySpec extends WordSpec with Matchers {
       val appList = JsonFormat.appListFormat.read(data.parseJson)
 
       MarathonApiSimpleServiceDiscovery.targets(appList, "akkamgmthttp") shouldBe List(
-          ResolvedTarget(host = "10.121.48.204", port = Some(29480), address = Some("10.121.48.204")),
-          ResolvedTarget(host = "10.121.48.204", port = Some(10136), address = Some("10.121.48.204")))
+          ResolvedTarget(host = "10.121.48.204", port = Some(29480)),
+          ResolvedTarget(host = "10.121.48.204", port = Some(10136)))
     }
   }
 


### PR DESCRIPTION
This is a refinement on #242 a part of a fix towards #187

This brings `apply(String, Option[Int])` back as a factory method for `ResolvedTarget`, and changes the type of `address` to `java.net.InetAddress`.

Since various orchestration engines just return a String for "host", I am doing a quick regex check to make sure it looks like an IPv4 address, and then parsing it into an
`InetAddress`.