### PR TITLE
Clarify the way to start ClusterHTTPManagement

### DIFF
--- a/cluster-http/src/test/java/jdoc/akka/cluster/http/management/CompileOnlyTest.java
+++ b/cluster-http/src/test/java/jdoc/akka/cluster/http/management/CompileOnlyTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package jdoc.akka.cluster.http.management;
+
+import akka.actor.ActorSystem;
+import akka.management.cluster.ClusterHttpManagement;
+
+public class CompileOnlyTest {
+    public static void example() {
+        //#loading
+        ActorSystem as = ActorSystem.create();
+        ClusterHttpManagement httpMgmt = ClusterHttpManagement.get(as);
+        //#loading
+    }
+}

--- a/cluster-http/src/test/scala/doc/akka/cluster/http/management/CompileOnlySpec.scala
+++ b/cluster-http/src/test/scala/doc/akka/cluster/http/management/CompileOnlySpec.scala
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package doc.akka.cluster.http.management
+
+import akka.actor.ActorSystem
+import akka.management.cluster.ClusterHttpManagement
+
+object CompileOnlySpec {
+
+  //#loading
+  val system = ActorSystem()
+  val httpMgmt = ClusterHttpManagement(system)
+  //#loading
+}

--- a/docs/src/main/paradox/cluster-http-management.md
+++ b/docs/src/main/paradox/cluster-http-management.md
@@ -46,6 +46,16 @@ Gradle
     ```
     @@@
 
+## Running
+
+To make sure the Akka Cluster HTTP Management is running, register it with Akka Management:
+
+Scala
+:  @@snip [CompileOnlySpec.scala]($management$/cluster-http/src/test/scala/doc/akka/cluster/http/management/CompileOnlySpec.scala) { #loading }
+
+Java
+:  @@snip [CompileOnlyTest.java]($management$/cluster-http/src/test/java/jdoc/akka/cluster/http/management/CompileOnlyTest.java) { #loading }
+
 
 ## API Definition
 


### PR DESCRIPTION
I got sufficiently stuck on this today that I thought it was worth writing docs for.

(Partially?) fixes #232 
