### PR TITLE
Bootstrap: should be done only with reachable nodes that are "up", "weaklyUp" or "joining"

### DIFF
--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/contactpoint/HttpClusterBootstrapRoutes.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/contactpoint/HttpClusterBootstrapRoutes.scala
@@ -30,7 +30,7 @@ final class HttpClusterBootstrapRoutes(settings: ClusterBootstrapSettings) exten
       // TODO shuffle the members so in a big deployment nodes start joining different ones and not all the same?
       val members = state.members
         .diff(state.unreachable)
-        .filter(_.status == MemberStatus.up)
+        .filter(m => m.status == MemberStatus.up || m.status == MemberStatus.weaklyUp)
         .take(settings.contactPoint.httpMaxSeedNodesToExpose)
         .map(memberToClusterMember)
 

--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/contactpoint/HttpClusterBootstrapRoutes.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/contactpoint/HttpClusterBootstrapRoutes.scala
@@ -30,7 +30,8 @@ final class HttpClusterBootstrapRoutes(settings: ClusterBootstrapSettings) exten
       // TODO shuffle the members so in a big deployment nodes start joining different ones and not all the same?
       val members = state.members
         .diff(state.unreachable)
-        .filter(m => m.status == MemberStatus.up || m.status == MemberStatus.weaklyUp)
+        .filter(
+            m => m.status == MemberStatus.up || m.status == MemberStatus.weaklyUp || m.status == MemberStatus.joining)
         .take(settings.contactPoint.httpMaxSeedNodesToExpose)
         .map(memberToClusterMember)
 


### PR DESCRIPTION
Akka Cluster Bootstrap should response only reachable nodes that are in status "up".