### PR TITLE
Fix ClassCastException on stop when use akka-http 10.1

### DIFF
--- a/management/src/main/scala/akka/management/AkkaManagement.scala
+++ b/management/src/main/scala/akka/management/AkkaManagement.scala
@@ -165,7 +165,7 @@ final class AkkaManagement(implicit system: ExtendedActorSystem) extends Extensi
     if (binding == null) {
       Future.successful(Done)
     } else if (bindingFuture.compareAndSet(binding, null)) {
-      val stopFuture = binding.flatMap(_.unbind()).map(_ => Done)
+      val stopFuture = binding.flatMap(_.unbind()).map((_: Any) => Done)
       bindingFuture.set(null)
       stopFuture
     } else stop() // retry, CAS was not successful, someone else completed the stop()


### PR DESCRIPTION
When I call `akka.management.AkkaManagement#stop` in my project it always fails with `java.lang.ClassCastException: akka.Done$ cannot be cast to scala.runtime.BoxedUnit`. In the project I use `10.1.1` and I can not downgrade to `10.0`. In `10.1` `akka.http.scaladsl.Http.ServerBinding#unbind` returns `Future[Done]`, but in `10.0`, which is `akka-management` compiled with, it returns `Future[Unit]`, what causes problems. 