### PR TITLE
Improve Marathon API logging to see where and how seed nodes have been requested.

### DIFF
--- a/discovery-marathon-api/src/main/scala/akka/discovery/marathon/MarathonApiSimpleServiceDiscovery.scala
+++ b/discovery-marathon-api/src/main/scala/akka/discovery/marathon/MarathonApiSimpleServiceDiscovery.scala
@@ -16,6 +16,7 @@ import scala.concurrent.duration.FiniteDuration
 import AppList._
 import JsonFormat._
 import SimpleServiceDiscovery.{ Resolved, ResolvedTarget }
+import akka.event.Logging
 
 object MarathonApiSimpleServiceDiscovery {
 
@@ -66,6 +67,8 @@ class MarathonApiSimpleServiceDiscovery(system: ActorSystem) extends SimpleServi
   import MarathonApiSimpleServiceDiscovery._
   import system.dispatcher
 
+  private val log = Logging(system, getClass)
+
   private val http = Http()(system)
 
   private val settings = Settings(system)
@@ -79,7 +82,7 @@ class MarathonApiSimpleServiceDiscovery(system: ActorSystem) extends SimpleServi
 
     val request = HttpRequest(uri = uri)
 
-    system.log.info("Requesting seed nodes by: {}", request.uri)
+    log.info("Requesting seed nodes by: {}", request.uri)
 
     for {
       response <- http.singleRequest(request)
@@ -87,11 +90,11 @@ class MarathonApiSimpleServiceDiscovery(system: ActorSystem) extends SimpleServi
       entity <- response.entity.toStrict(resolveTimeout)
 
       appList <- {
-        system.log.debug("Marathon API entity: [{}]", entity.data.utf8String)
+        log.debug("Marathon API entity: [{}]", entity.data.utf8String)
         val unmarshalled = Unmarshal(entity).to[AppList]
 
         unmarshalled.failed.foreach { _ =>
-          system.log.error("Failed to unmarshal Marathon API response status [{}], entity: [{}], uri: [{}]",
+          log.error("Failed to unmarshal Marathon API response status [{}], entity: [{}], uri: [{}]",
             response.status.value, entity.data.utf8String, uri)
         }
         unmarshalled

--- a/discovery-marathon-api/src/main/scala/akka/discovery/marathon/MarathonApiSimpleServiceDiscovery.scala
+++ b/discovery-marathon-api/src/main/scala/akka/discovery/marathon/MarathonApiSimpleServiceDiscovery.scala
@@ -79,6 +79,8 @@ class MarathonApiSimpleServiceDiscovery(system: ActorSystem) extends SimpleServi
 
     val request = HttpRequest(uri = uri)
 
+    system.log.info("Requesting seed nodes by: {}", request.uri)
+
     for {
       response <- http.singleRequest(request)
 


### PR DESCRIPTION
This is driven by the real use case that took lots of time to debug. This setting was set during automatic deployment process and was pointing to the wrong Marathon master. It led to the situation when the app was joining different Akka Cluster from completely different environment.