### PR TITLE
added some buffer for k8s health check example and dependency info fo…

### DIFF
--- a/bootstrap-demo/kubernetes-api/kubernetes/akka-cluster.yml
+++ b/bootstrap-demo/kubernetes-api/kubernetes/akka-cluster.yml
@@ -22,6 +22,8 @@ spec:
         livenessProbe:
           tcpSocket:
             port: 8558
+          initialDelaySeconds: 30
+          periodSeconds: 15
         ports:
         # akka remoting
         - name: remoting

--- a/bootstrap-demo/kubernetes-dns/kubernetes/akka-cluster.yml
+++ b/bootstrap-demo/kubernetes-dns/kubernetes/akka-cluster.yml
@@ -32,8 +32,6 @@ spec:
           httpGet:
             path: /ready
             port: 8080
-          initialDelaySeconds: 30
-          periodSeconds: 15
         livenessProbe:
           httpGet:
             path: /alive

--- a/bootstrap-demo/kubernetes-dns/kubernetes/akka-cluster.yml
+++ b/bootstrap-demo/kubernetes-dns/kubernetes/akka-cluster.yml
@@ -32,10 +32,14 @@ spec:
           httpGet:
             path: /ready
             port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 15
         livenessProbe:
           httpGet:
             path: /alive
             port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 15
         env:
         ports:
         - containerPort: 8558

--- a/docs/src/main/paradox/akka-management.md
+++ b/docs/src/main/paradox/akka-management.md
@@ -33,7 +33,7 @@ it is ready and wants to start joining an existing cluster.
 
 ## Dependencies
 
-Akka management requires Akka 2.5 or later.
+Akka management requires Akka 2.5 or later.  Akka Cluster Bootstrap with DNS service discovery requires Akka 2.5.14 or later.
 
 The main Akka Management dependency is called `akka-management`. By itself however it does not provide any capabilities,
 and you have to combine it with the management extension libraries that you want to make use of (e.g. cluster http management,

--- a/docs/src/main/paradox/bootstrap/index.md
+++ b/docs/src/main/paradox/bootstrap/index.md
@@ -26,6 +26,8 @@ sbt
     ```scala
     libraryDependencies += "com.lightbend.akka.management" %% "akka-management-cluster-bootstrap" % "$version$"
     libraryDependencies += "com.lightbend.akka.discovery" %% "akka-discovery-dns"                % "$version$"
+    // USE THIS FOR KUBERNETES API SERVICE DISCOVERY
+    //libraryDependencies += "com.lightbend.akka.discovery" %% "akka-discovery-kubernetes-api"                % "$version$"
     ```
     @@@
 
@@ -42,6 +44,13 @@ Maven
       <artifactId>akka-discovery-dns_$scala.binaryVersion$</artifactId>
       <version>$version$</version>
     </dependency>
+    <!-- USE THIS FOR KUBERNETES API SERVICE DISCOVERY
+    <dependency>
+      <groupId>com.lightbend.akka.discovery</groupId>
+      <artifactId>akka-discovery-kubernetes-api_$scala.binaryVersion$</artifactId>
+      <version>$version$</version>
+    </dependency>  
+    -->  
     ```
     @@@
 
@@ -51,6 +60,8 @@ Gradle
     dependencies {
       compile group: "com.lightbend.akka.management", name: "akka-management-cluster-bootstrap_$scala.binaryVersion$", version: "$version$"
       compile group: "com.lightbend.akka.discovery", name: "akka-discovery-dns_$scala.binaryVersion$", version: "$version$"
+      // USE THIS FOR KUBERNETES API SERVICE DISCOVERY
+      // compile group: "com.lightbend.akka.discovery", name: "akka-discovery-kubernetes-api_$scala.binaryVersion$", version: "$version$"
     }
     ```
     @@@

--- a/docs/src/main/paradox/bootstrap/index.md
+++ b/docs/src/main/paradox/bootstrap/index.md
@@ -26,7 +26,7 @@ sbt
     ```scala
     libraryDependencies += "com.lightbend.akka.management" %% "akka-management-cluster-bootstrap" % "$version$"
     libraryDependencies += "com.lightbend.akka.discovery" %% "akka-discovery-dns"                % "$version$"
-    // USE THIS FOR KUBERNETES API SERVICE DISCOVERY
+    // use this for kubernetes api discovery instead of akka-discovery-dns
     //libraryDependencies += "com.lightbend.akka.discovery" %% "akka-discovery-kubernetes-api"                % "$version$"
     ```
     @@@
@@ -44,7 +44,7 @@ Maven
       <artifactId>akka-discovery-dns_$scala.binaryVersion$</artifactId>
       <version>$version$</version>
     </dependency>
-    <!-- USE THIS FOR KUBERNETES API SERVICE DISCOVERY
+    <!-- use this for kubernetes api discovery instead of akka-discovery-dns 
     <dependency>
       <groupId>com.lightbend.akka.discovery</groupId>
       <artifactId>akka-discovery-kubernetes-api_$scala.binaryVersion$</artifactId>
@@ -60,7 +60,7 @@ Gradle
     dependencies {
       compile group: "com.lightbend.akka.management", name: "akka-management-cluster-bootstrap_$scala.binaryVersion$", version: "$version$"
       compile group: "com.lightbend.akka.discovery", name: "akka-discovery-dns_$scala.binaryVersion$", version: "$version$"
-      // USE THIS FOR KUBERNETES API SERVICE DISCOVERY
+      // use this for kubernetes api discovery instead of akka-discovery-dns
       // compile group: "com.lightbend.akka.discovery", name: "akka-discovery-kubernetes-api_$scala.binaryVersion$", version: "$version$"
     }
     ```


### PR DESCRIPTION
added some padding to k8s health check examples.  I've found that in some cases when trying to spin up an akka cluster, the live and readiness checks fail too quickly because they kick in as soon as the pod is scheduled.  Since the jvm takes some time to start up, i found much better results in delaying the checks for a little bit.  I'm recommending including this in the example.  Here's a before and after comparison

![image](https://user-images.githubusercontent.com/1654394/45871019-3389e880-bd41-11e8-9b38-bc9445ca6aaa.png)

![image](https://user-images.githubusercontent.com/1654394/45871028-3d135080-bd41-11e8-89b2-31699642294c.png)

Also a couple more minor changes
- annotated documentation to clarify that bootstrap w/dns requires akka 2.5.14 and above
- added k8s service discovery example in the dependency doc since dns isn't an option yet for our Lagom users (according to @TimMoore  an update to reactivelib is needed before that can be used)