### PR TITLE
Kubernetes API to take port from Lookup

### DIFF
--- a/bootstrap-demo/kubernetes-api/kubernetes/akka-cluster.yml
+++ b/bootstrap-demo/kubernetes-api/kubernetes/akka-cluster.yml
@@ -28,13 +28,18 @@ spec:
           containerPort: 2552
           protocol: TCP
         # akka-management bootstrap
-        - name: bootstrap
+        # must match up with contact-point-discovery.port-name for boostrap
+        - name: management
           containerPort: 8558
           protocol: TCP
-        # external http
-        - name: akka-mgmt-http
-          containerPort: 8558
-          protocol: TCP
+#namespace
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+#namespace
+
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/bootstrap-demo/kubernetes-api/kubernetes/akka-cluster.yml
+++ b/bootstrap-demo/kubernetes-api/kubernetes/akka-cluster.yml
@@ -28,7 +28,7 @@ spec:
           containerPort: 2552
           protocol: TCP
         # akka-management bootstrap
-        # must match up with contact-point-discovery.port-name for boostrap
+        # must match up with contact-point-discovery.port-name for bootstrap
         - name: management
           containerPort: 8558
           protocol: TCP

--- a/bootstrap-demo/kubernetes-api/src/main/resources/application.conf
+++ b/bootstrap-demo/kubernetes-api/src/main/resources/application.conf
@@ -1,5 +1,9 @@
-akka.loglevel = "INFO"
-akka.actor.provider = cluster
+akka {
+  loggers = ["akka.event.slf4j.Slf4jLogger"]
+  loglevel = "DEBUG"
+  logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
+  actor.provider = cluster
+}
 
 #discovery-config
 akka.discovery {

--- a/bootstrap-demo/kubernetes-api/src/main/resources/application.conf
+++ b/bootstrap-demo/kubernetes-api/src/main/resources/application.conf
@@ -1,3 +1,6 @@
+akka.loglevel = "INFO"
+akka.actor.provider = cluster
+
 #discovery-config
 akka.discovery {
   kubernetes-api {

--- a/bootstrap-demo/kubernetes-api/src/main/resources/logback.xml
+++ b/bootstrap-demo/kubernetes-api/src/main/resources/logback.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <target>System.out</target>
+        <encoder>
+            <pattern>%date{MM/dd HH:mm:ss} %-5level[%thread] %logger{1} - %m%n%xException</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+</configuration>

--- a/bootstrap-demo/kubernetes-api/src/main/scala/akka/cluster/bootstrap/DemoApp.scala
+++ b/bootstrap-demo/kubernetes-api/src/main/scala/akka/cluster/bootstrap/DemoApp.scala
@@ -14,10 +14,7 @@ import com.typesafe.config.ConfigFactory
 
 object DemoApp extends App {
 
-  implicit val system = ActorSystem("Appka", ConfigFactory.parseString("""
-       akka.loglevel = INFO
-       akka.actor.provider = cluster
-    """).withFallback(ConfigFactory.load()))
+  implicit val system = ActorSystem("Appka")
 
   import system.log
   import system.dispatcher

--- a/bootstrap-demo/kubernetes-dns/src/main/scala/akka/cluster/bootstrap/KubernetesHealthChecks.scala
+++ b/bootstrap-demo/kubernetes-dns/src/main/scala/akka/cluster/bootstrap/KubernetesHealthChecks.scala
@@ -20,7 +20,8 @@ class KubernetesHealthChecks(system: ActorSystem) {
 
   // Removed is the initial state before joining. See https://github.com/akka/akka/issues/25663
   private val aliveStates: Set[MemberStatus] =
-    Set(MemberStatus.Joining, MemberStatus.WeaklyUp, MemberStatus.Up, MemberStatus.Leaving, MemberStatus.Exiting, MemberStatus.Removed)
+    Set(MemberStatus.Joining, MemberStatus.WeaklyUp, MemberStatus.Up, MemberStatus.Leaving, MemberStatus.Exiting,
+      MemberStatus.Removed)
 
   val k8sHealthChecks: Route =
     concat(

--- a/bootstrap-demo/kubernetes-dns/src/main/scala/akka/cluster/bootstrap/KubernetesHealthChecks.scala
+++ b/bootstrap-demo/kubernetes-dns/src/main/scala/akka/cluster/bootstrap/KubernetesHealthChecks.scala
@@ -17,8 +17,10 @@ class KubernetesHealthChecks(system: ActorSystem) {
 
   //#health
   private val readyStates: Set[MemberStatus] = Set(MemberStatus.Up, MemberStatus.WeaklyUp)
+
+  // Removed is the initial state before joining. See https://github.com/akka/akka/issues/25663
   private val aliveStates: Set[MemberStatus] =
-    Set(MemberStatus.Joining, MemberStatus.WeaklyUp, MemberStatus.Up, MemberStatus.Leaving, MemberStatus.Exiting)
+    Set(MemberStatus.Joining, MemberStatus.WeaklyUp, MemberStatus.Up, MemberStatus.Leaving, MemberStatus.Exiting, MemberStatus.Removed)
 
   val k8sHealthChecks: Route =
     concat(

--- a/bootstrap-demo/local/src/main/scala/akka/cluster/bootstrap/Main.scala
+++ b/bootstrap-demo/local/src/main/scala/akka/cluster/bootstrap/Main.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2017 Lightbend Inc. <http://www.lightbend.com>
+ */
 package akka.cluster.bootstrap
 
 import akka.actor.ActorSystem
@@ -21,8 +24,7 @@ object Node3 extends App {
 
 class Main(nr: Int) {
 
-  val config = ConfigFactory.parseString(
-    s"""
+  val config = ConfigFactory.parseString(s"""
       akka.remote.artery.canonical.hostname = "127.0.0.$nr"
       akka.management.http.hostname = "127.0.0.$nr"
     """).withFallback(ConfigFactory.load())

--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,7 @@ lazy val `akka-management-root` = project
     `akka-discovery-marathon-api`,
     `akka-management`,
     `bootstrap-demo-aws-api-ec2-tag-based`,
+    `bootstrap-demo-local`,
     `bootstrap-demo-aws-api-ecs`,
     `bootstrap-demo-kubernetes-api`,
     `bootstrap-demo-kubernetes-dns`,
@@ -176,7 +177,8 @@ lazy val `bootstrap-demo-kubernetes-api` = project
   .settings(
     skip in publish := true,
     sources in (Compile, doc) := Seq.empty,
-    whitesourceIgnore := true
+    whitesourceIgnore := true,
+    Dependencies.BootstrapDemoKubernetesApi
   ).dependsOn(
     `akka-management`,
     `cluster-http`,

--- a/discovery-kubernetes-api/src/main/resources/reference.conf
+++ b/discovery-kubernetes-api/src/main/resources/reference.conf
@@ -17,6 +17,16 @@ akka.discovery {
 
     # Namespace to query for pods
     pod-namespace = "default"
+
+    # Picks up namespace from $NAMESPACE env var if set. Add the following to the container spec to avoid having to
+    # hard code this
+    # env:
+    # - name: NAMESPACE
+    #   valueFrom:
+    #    fieldRef:
+    #     fieldPath: metadata.namespace
+    pod-namespace = ${?NAMESPACE}
+
     # Domain of the k8s cluster
     pod-domain = "cluster.local"
 
@@ -24,7 +34,8 @@ akka.discovery {
     # `%s` will be replaced with the configured effective name, which defaults to the actor system name
     pod-label-selector = "app=%s"
 
-    # The name of the akka management port
-    pod-port-name = "akka-mgmt-http"
+    # Only used in the case that Lookup.portName is not set. Bootstrap sets this from
+    # akka.management.cluster.boostrap.contact-point-discovery.port-name
+    pod-port-name = "management"
   }
 }

--- a/docs/src/main/paradox/bootstrap/kubernetes-api.md
+++ b/docs/src/main/paradox/bootstrap/kubernetes-api.md
@@ -18,13 +18,13 @@ The following configuration is required:
 * Set `akka.management.cluster.bootstrap.contact-point-discovery.discovery-method` to `akka.discovery.kubernetes-api`
 * Set `akka.discovery.kubernetes-api.pod-label-selector` to a label selector that will match the Akka pods
 
-@@snip [akka-cluster.yml]($management$/bootstrap-demo/kubernetes-api/src/main/resources/application.conf) { #discovery-config } 
+@@snip [akka-cluster.yml](/bootstrap-demo/kubernetes-api/src/main/resources/application.conf) { #discovery-config } 
 
 The lookup needs to know which namespace to look in. This can be configured with
 `akka.discovery.kubernetes-api.pod-namespace` or it will be picked up via the `NAMESPACE` environment
 variable that can be injected into the pod via:
 
-@@snip [akka-cluster.yml]($management$/bootstrap-demo/kubernetes-api/kubernetes/akka-cluster.yml)  { #namespace }
+@@snip [akka-cluster.yml](/bootstrap-demo/kubernetes-api/kubernetes/akka-cluster.yml)  { #namespace }
 
 If running he example in [minikube](https://github.com/kubernetes/minikube) make sure you have installed and is running:
 

--- a/docs/src/main/paradox/bootstrap/kubernetes-api.md
+++ b/docs/src/main/paradox/bootstrap/kubernetes-api.md
@@ -18,7 +18,13 @@ The following configuration is required:
 * Set `akka.management.cluster.bootstrap.contact-point-discovery.discovery-method` to `akka.discovery.kubernetes-api`
 * Set `akka.discovery.kubernetes-api.pod-label-selector` to a label selector that will match the Akka pods
 
-@@snip [akka-cluster.yml](/bootstrap-demo/kubernetes-api/src/main/resources/application.conf) { #discovery-config } 
+@@snip [akka-cluster.yml]($management$/bootstrap-demo/kubernetes-api/src/main/resources/application.conf) { #discovery-config } 
+
+The lookup needs to know which namespace to look in. This can be configured with
+`akka.discovery.kubernetes-api.pod-namespace` or it will be picked up via the `NAMESPACE` environment
+variable that can be injected into the pod via:
+
+@@snip [akka-cluster.yml]($management$/bootstrap-demo/kubernetes-api/kubernetes/akka-cluster.yml)  { #namespace }
 
 If running he example in [minikube](https://github.com/kubernetes/minikube) make sure you have installed and is running:
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,6 +15,7 @@ object Dependencies {
     )
   )
 
+
   private object DependencyGroups {
     val AkkaActor = Seq(
       "com.typesafe.akka" %% "akka-actor"                         % AkkaVersion
@@ -50,6 +51,12 @@ object Dependencies {
 
     val AkkaHttpTesting = Seq(
       "com.typesafe.akka" %% "akka-http-testkit"                  % AkkaHttpVersion % "test"
+    )
+
+    // For demos
+    val Logging = Seq(
+      "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
+      "ch.qos.logback" % "logback-classic" % "1.2.3"
     )
   }
 
@@ -120,6 +127,7 @@ object Dependencies {
       DependencyGroups.AkkaHttp ++
       DependencyGroups.AkkaTesting
   )
+
   val ClusterHttp = Seq(
     libraryDependencies ++=
       DependencyGroups.AkkaSharding ++
@@ -138,6 +146,10 @@ object Dependencies {
       DependencyGroups.AkkaHttpTesting ++ Seq(
       "com.typesafe.akka" %% "akka-distributed-data"              % AkkaVersion     % "test"
     )
+  )
+
+  val BootstrapDemoKubernetesApi = Seq(
+    libraryDependencies ++= DependencyGroups.Logging
   )
 
 }


### PR DESCRIPTION
Addresses a few gotchas when @alanngai was trying bootstrap

* Lookup contains a port, use that and fallback to the one in config
* Pick up namespace from environment variable if present
* Add some more logging to k8s api