### PR TITLE
Allow connecting to the cluster bootstrap probe endpoint by IP

### DIFF
--- a/cluster-bootstrap/src/main/resources/reference.conf
+++ b/cluster-bootstrap/src/main/resources/reference.conf
@@ -100,6 +100,12 @@ akka.management {
     # Configured how we communicate with the contact point once it is discovered
     contact-point {
 
+      # connect to the contact point by IP address instead of by hostname
+      #
+      # This is useful when coredns is configured with "pods disabled"
+      # Disabled by default because this is blocked when using Istio (#209)
+      connect-by-ip = no
+
       # If no port is discovered along with the host/ip of a contact point this port will be used as fallback
       # Also, when no port-name is used and multiple results are returned for a given service with at least one
       # port defined, this port is used to disambiguate. When set to <fallback-port>, defaults to the value of

--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/ClusterBootstrapSettings.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/ClusterBootstrapSettings.scala
@@ -122,6 +122,8 @@ final class ClusterBootstrapSettings(config: Config, log: LoggingAdapter) {
   object contactPoint {
     private val contactPointConfig = bootConfig.getConfig("contact-point")
 
+    val connectByIP = contactPointConfig.getBoolean("connect-by-ip")
+
     val fallbackPort: Int =
       contactPointConfig
         .optDefinedValue("fallback-port")

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/internal/BootstrapCoordinatorWithoutNamedLookupsSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/internal/BootstrapCoordinatorWithoutNamedLookupsSpec.scala
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.management.cluster.bootstrap.internal
+
+import java.util.concurrent.atomic.AtomicReference
+
+import akka.actor.{ ActorRef, ActorSystem, Props }
+import akka.discovery.ServiceDiscovery.{ Resolved, ResolvedTarget }
+import akka.discovery.{ Lookup, MockDiscovery }
+import akka.management.cluster.bootstrap.internal.BootstrapCoordinator.Protocol.InitiateBootstrapping
+import akka.management.cluster.bootstrap.{ ClusterBootstrapSettings, LowestAddressJoinDecider }
+import com.typesafe.config.ConfigFactory
+import org.scalatest.concurrent.Eventually
+import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpec }
+import org.scalatest.time.{ Span, Seconds, Millis }
+
+import scala.concurrent.{ Await, Future }
+import scala.concurrent.duration._
+
+class BootstrapCoordinatorWithoutNamedLookupsSpec extends WordSpec with Matchers with BeforeAndAfterAll with Eventually {
+  val serviceName = "bootstrap-coordinator-test-service"
+  val system = ActorSystem("test", ConfigFactory.parseString(s"""
+      |akka.management.cluster.bootstrap {
+      | contact-point-discovery.service-name = $serviceName
+      |}
+    """.stripMargin).withFallback(ConfigFactory.load()))
+  val settings = ClusterBootstrapSettings(system.settings.config, system.log)
+  val joinDecider = new LowestAddressJoinDecider(system, settings)
+
+  val discovery = new MockDiscovery(system)
+
+  override implicit val patienceConfig = PatienceConfig(timeout = Span(5, Seconds), interval = Span(100, Millis))
+
+  "The bootstrap coordinator, when avoiding named port lookups" should {
+
+    "probe only on the Akka Management port" in {
+      MockDiscovery.set(
+        Lookup(serviceName, portName = None, protocol = Some("tcp")),
+        () =>
+          Future.successful(Resolved(serviceName,
+              List(
+                ResolvedTarget("host1", Some(2552), None),
+                ResolvedTarget("host1", Some(8558), None),
+                ResolvedTarget("host2", Some(2552), None),
+                ResolvedTarget("host2", Some(8558), None)
+              )))
+      )
+    
+      val targets = new AtomicReference[List[ResolvedTarget]](Nil)
+      val coordinator = system.actorOf(Props(new BootstrapCoordinator(discovery, joinDecider, settings) {
+        override def ensureProbing(contactPoint: ResolvedTarget): Option[ActorRef] = {
+          println(s"Resolving $contactPoint")
+          val targetsSoFar = targets.get
+          targets.compareAndSet(targetsSoFar, contactPoint +: targetsSoFar)
+          None
+        }
+      }))
+      coordinator ! InitiateBootstrapping
+      eventually {
+        val targetsToCheck = targets.get
+        targetsToCheck.length should be >= (2)
+        targetsToCheck.map(_.host) should contain("host1")
+        targetsToCheck.map(_.host) should contain("host2")
+        targetsToCheck.flatMap(_.port).toSet should be(Set(8558))
+      }
+    }
+
+    "probe all hosts with fallback port" in {
+
+      MockDiscovery.set(
+        Lookup(serviceName, portName = None, protocol = Some("tcp")),
+        () =>
+          Future.successful(Resolved(serviceName,
+            List(
+              ResolvedTarget("host1", None, None),
+              ResolvedTarget("host1", None, None),
+              ResolvedTarget("host2", None, None),
+              ResolvedTarget("host2", None, None)
+            )))
+      )
+
+      val targets = new AtomicReference[List[ResolvedTarget]](Nil)
+      val coordinator = system.actorOf(Props(new BootstrapCoordinator(discovery, joinDecider, settings) {
+        override def ensureProbing(contactPoint: ResolvedTarget): Option[ActorRef] = {
+          println(s"Resolving $contactPoint")
+          val targetsSoFar = targets.get
+          targets.compareAndSet(targetsSoFar, contactPoint +: targetsSoFar)
+          None
+        }
+      }))
+      coordinator ! InitiateBootstrapping
+      eventually {
+        val targetsToCheck = targets.get
+        targetsToCheck.length should be >= (2)
+        targetsToCheck.map(_.host) should contain("host1")
+        targetsToCheck.map(_.host) should contain("host2")
+        targetsToCheck.flatMap(_.port).toSet shouldBe empty
+      }
+    }
+ 
+  }
+
+  override def afterAll(): Unit = {
+    Await.result(system.terminate(), 10.seconds)
+    super.afterAll()
+  }
+}

--- a/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/KubernetesApiServiceDiscovery.scala
+++ b/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/KubernetesApiServiceDiscovery.scala
@@ -62,6 +62,8 @@ object KubernetesApiServiceDiscovery {
           } yield Some(port.containerPort)
       }
     } yield {
+      // This host may not be resolvable, for example when 'pods disabled' is configured
+      // https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/#coredns-configmap-options
       val host = s"${ip.replace('.', '-')}.$podNamespace.pod.$podDomain"
       ResolvedTarget(
         host = host,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -153,8 +153,8 @@ object Dependencies {
       DependencyGroups.AkkaCluster ++
       DependencyGroups.AkkaDiscovery ++
       DependencyGroups.AkkaHttpCore ++
-      DependencyGroups.AkkaTesting ++
-      DependencyGroups.AkkaHttpTesting ++ Seq(
+      DependencyGroups.AkkaHttpTesting ++
+      DependencyGroups.AkkaTesting ++ Seq(
         "com.typesafe.akka" %% "akka-distributed-data" % AkkaVersion % "test"
       )
   )


### PR DESCRIPTION
I suspect this might be necessary when the DNS server is configured not to
issue DNS records for pods, which is possible with 'pods disabled'
https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/#coredns-configmap-options

Not yet tested outside of the unit test