### PR TITLE
Order addresses by address, then name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,12 @@ language: scala
 jdk:
   - oraclejdk8
 
+before_install:
+  - curl -sL https://raw.githubusercontent.com/shyiko/jabba/0.10.1/install.sh | bash && . ~/.jabba/jabba.sh
+
+install:
+  - $JABBA_HOME/bin/jabba install $TRAVIS_JDK && export JAVA_HOME="$JABBA_HOME/jdk/$TRAVIS_JDK" && export PATH="$JAVA_HOME/bin:$PATH" && java -Xmx32m -version
+
 before_cache:
   - find $HOME/.ivy2 -name "ivydata-*.properties" -print -delete
   - find $HOME/.sbt  -name "*.lock"               -print -delete
@@ -13,6 +19,10 @@ cache:
   directories:
     - $HOME/.ivy2/cache
     - $HOME/.sbt/boot
+    - $HOME/.jabba/jdk
+
+before_script:
+  - unset _JAVA_OPTIONS
 
 jobs:
   include:
@@ -46,6 +56,8 @@ deploy:
     
 env:
   global:
+    - TRAVIS_JDK=1.8.181
+    - JABBA_HOME=/home/travis/.jabba
     # encrypt with: travis encrypt WHITESOURCE_KEY=...
     - secure: "KK7AsqpqUBRl3vnPzVfmlfogl/HMq7Xb2t6EHHB9pi8QWmK25ufPAxF6G+vx0mIAAP7r6n/lkdVBnuZC1jp6G1/I4adsXJOkCF6YTSb9XmH9jK+YhI6xuqFx5vRqxb2faK+6VY6IJXQFD8/1gkdVr0hN3Hq4I5Yg0GAUxAaKKNWeh7VsFmrFiMCj7Q8s2U4+aGSgyKnptQ35JV63SPZV0rgPPIv1kZuqLi526fQMwOIfhpaRh763v7wgINJjZhvAjIbpicGmayZSnZPhs0+Z/jh9pK8sja1S+dUJSEe4IIfGMJINko58fKNPrxaenk05pwTJ+pWKmYWwxyEIiJrTkNHHUnXYCaJf7Qfiyv+sdZ9opGTs0xXS+/kaI9WPQ/vToyMTSjhZnCx0D9vJMuIVDM0OD+1GO66LqdBWK5nC+tgSstf79HK0gZP7hLzhxNj+4mXajECBlg+GucN6wmhrUB2UMGZ6/NvfIdzuXFFQCuSf3Hp+4z7yDV+FgqZeiedLLlZrvaE0IKrNaJ1CfzZ8jIzhjYXFFG9ERMeyGp7n8/7LW2NcHOI+BvKcaNOV4umRXWcXh7mQqzmZ+t3t+4IQFCR1lTrYj59KA4UI2Z9viZBefwIll1X2UNJ2uzbcCqdQSNrTi8LPfuqU39hdxYcw69it7K55Ktah6qiFwKpPlUc="
     # encrypt with: travis encrypt BINTRAY_USER=...

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/LowestAddressJoinDeciderSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/LowestAddressJoinDeciderSpec.scala
@@ -60,8 +60,16 @@ class LowestAddressJoinDeciderSpec extends WordSpecLike with Matchers with Scala
       port = None,
       address = Some(InetAddress.getByName("10.0.0.2"))
     )
-    val contactB = ResolvedTarget(host = "b", port = None, address = None)
-    val contactC = ResolvedTarget(host = "c", port = None, address = None)
+    val contactB = ResolvedTarget(
+      host = "10-0-0-3.default.pod.cluster.local",
+      port = None,
+      address = Some(InetAddress.getByName("10.0.0.3"))
+    )
+    val contactC = ResolvedTarget(
+      host = "10-0-0-4.default.pod.cluster.local",
+      port = None,
+      address = Some(InetAddress.getByName("10.0.0.4"))
+    )
 
     "sort ResolvedTarget by lowest hostname:port" in {
       List(ResolvedTarget("c", None, None), ResolvedTarget("a", None, None),
@@ -77,6 +85,21 @@ class LowestAddressJoinDeciderSpec extends WordSpecLike with Matchers with Scala
         ResolvedTarget("a", Some(3), None)).sorted should ===(
         List(ResolvedTarget("a", Some(1), None), ResolvedTarget("a", Some(2), None),
           ResolvedTarget("a", Some(3), None))
+      )
+    }
+
+    /**
+     * This may happen for example in case of #344
+     */
+    "when addresses are known, sort deterministically on address even when names are inconsistent" in {
+      val addr1 = InetAddress.getByName("127.0.0.1")
+      val addr2 = InetAddress.getByName("127.0.0.2")
+      val addr3 = InetAddress.getByName("127.0.0.3")
+
+      List(ResolvedTarget("c", None, Some(addr2)), ResolvedTarget("x", None, Some(addr1)),
+        ResolvedTarget("b", None, Some(addr3))).sorted should ===(
+        List(ResolvedTarget("x", None, Some(addr1)), ResolvedTarget("c", None, Some(addr2)),
+          ResolvedTarget("b", None, Some(addr3)))
       )
     }
 

--- a/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/KubernetesApiSimpleServiceDiscovery.scala
+++ b/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/KubernetesApiSimpleServiceDiscovery.scala
@@ -15,7 +15,6 @@ import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.FileIO
 import com.typesafe.sslconfig.akka.AkkaSSLConfig
 import com.typesafe.sslconfig.ssl.TrustStoreConfig
-import java.nio.file.Paths
 
 import scala.collection.immutable.Seq
 import scala.concurrent.Future

--- a/discovery/src/main/scala/akka/discovery/SimpleServiceDiscovery.scala
+++ b/discovery/src/main/scala/akka/discovery/SimpleServiceDiscovery.scala
@@ -34,11 +34,13 @@ object SimpleServiceDiscovery {
   }
 
   object ResolvedTarget {
-    implicit val addressOrdering: Ordering[ResolvedTarget] = Ordering.fromLessThan[ResolvedTarget] { (a, b) ⇒
-      if (a eq b) false
-      else if (a.host != b.host) a.host.compareTo(b.host) < 0
-      else if (a.port != b.port) a.port.getOrElse(0) < b.port.getOrElse(0)
-      else false
+    // Simply compare the bytes of the address.
+    // This may not work in exotic cases such as IPv4 addresses encoded as IPv6 addresses.
+    private implicit val inetAddressOrdering: Ordering[InetAddress] =
+      Ordering.by[InetAddress, Iterable[Byte]](_.getAddress)
+
+    implicit val addressOrdering: Ordering[ResolvedTarget] = Ordering.by { t =>
+      (t.address, t.host, t.port)
     }
 
     private val IPv4 = """^((?:[0-9]{1,3}\.){3}[0-9]{1,3})$""".r


### PR DESCRIPTION
Workaround for #344

This might not have the desired effect when there are multiple routers with
different IP addresses doing name-based routing, and the service discovery
returns those with unique names but also addresses that point to those routers.
Perhaps we should cross that bridge when we know it appears in practice though.