### PR TITLE
Replace `bootstrap-joining-demo` to `bootstrap-demo` 

### DIFF
--- a/bootstrap-demo/aws-api-ec2/README.md
+++ b/bootstrap-demo/aws-api-ec2/README.md
@@ -65,7 +65,7 @@ Compile and package the demo app.
 ```
 $ cd akka-management 
 $ sbt
-> project bootstrap-joining-demo-aws-api-ec2-tag-based
+> project bootstrap-demo-aws-api-ec2-tag-based
 > universal:packageBin
 ```
 
@@ -93,7 +93,7 @@ Unzip the package and run the app like this on each instance:
 $ unzip app.zip
 $ cd app/bin
 $ MY_IP=`curl -s http://169.254.169.254/latest/meta-data/local-ipv4`
-$ ./akka-management-bootstrap-joining-demo-aws-api-ec2-tag-based -Dakka.management.http.hostname=$MY_IP -Dakka.remote.netty.tcp.hostname=$MY_IP
+$ ./akka-management-bootstrap-demo-aws-api-ec2-tag-based -Dakka.management.http.hostname=$MY_IP -Dakka.remote.netty.tcp.hostname=$MY_IP
 ```
 
 Follow the logs and watch for signs of successful cluster formation (e.g., a welcome message from one of the nodes). 

--- a/bootstrap-demo/aws-api-ec2/src/main/resources/CloudFormation/akka-cluster.json
+++ b/bootstrap-demo/aws-api-ec2/src/main/resources/CloudFormation/akka-cluster.json
@@ -71,7 +71,7 @@
               "cd app\n",
               "cd bin\n",
               "MY_IP=`curl -s http://169.254.169.254/latest/meta-data/local-ipv4`\n",
-              "./akka-management-bootstrap-joining-demo-aws-api-ec2-tag-based -Dakka.management.http.hostname=$MY_IP -Dakka.remote.netty.tcp.hostname=$MY_IP &"
+              "./akka-management-bootstrap-demo-aws-api-ec2-tag-based -Dakka.management.http.hostname=$MY_IP -Dakka.remote.netty.tcp.hostname=$MY_IP &"
             ]]
           }
         }

--- a/bootstrap-demo/aws-api-ecs/README.md
+++ b/bootstrap-demo/aws-api-ecs/README.md
@@ -37,7 +37,7 @@ mechanisms will do this for us.
 # Step 2: Create the ECR repository
 
 You can do this manually via the web console by creating an ECR repository
-called `bootstrap-joining-demo-aws-api-ecs`, _or_ by running the included
+called `bootstrap-demo-aws-api-ecs`, _or_ by running the included
 CloudFormation wrapper script:
 
 `./scripts/deploy-infrastucture.sh create`

--- a/bootstrap-demo/aws-api-ecs/cfn-templates/ecs-bootstrap-demo-app.yaml
+++ b/bootstrap-demo/aws-api-ecs/cfn-templates/ecs-bootstrap-demo-app.yaml
@@ -68,7 +68,7 @@ Resources:
             Options:
               awslogs-group: !Ref LogGroup
               awslogs-region: !Ref AWS::Region
-              awslogs-stream-prefix: bootstrap-joining-demo-aws-api-ecs
+              awslogs-stream-prefix: bootstrap-demo-aws-api-ecs
           Environment:
             - Name: JAVA_OPTS
               Value: !Sub "-Dakka.management.cluster.bootstrap.\

--- a/bootstrap-demo/aws-api-ecs/scripts/publish.sh
+++ b/bootstrap-demo/aws-api-ecs/scripts/publish.sh
@@ -10,7 +10,7 @@ fi
 
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
-(cd $DIR/../../.. && sbt bootstrap-joining-demo-aws-api-ecs/docker:publishLocal)
+(cd $DIR/../../.. && sbt bootstrap-demo-aws-api-ecs/docker:publishLocal)
 
 eval $(
   aws ecr get-login \

--- a/bootstrap-demo/dns-api-mesos/README.md
+++ b/bootstrap-demo/dns-api-mesos/README.md
@@ -5,10 +5,10 @@ Build and publish docker image into the local repo.
 `sbt docker:publishLocal`
 
 Tag built image:
-`docker tag bootstrap-joining-demo-dns-api:1.0 <dockerhub-id>/bootstrap-joining-demo-dns-api:1.0`
+`docker tag bootstrap-demo-dns-api:1.0 <dockerhub-id>/bootstrap-demo-dns-api:1.0`
 
 Push image into DockerHub 
-`docker push <dockerhub-id>/bootstrap-joining-demo-dns-api:1.0`
+`docker push <dockerhub-id>/bootstrap-demo-dns-api:1.0`
 
 Mesosphere DC/OS
 ================

--- a/bootstrap-demo/dns-api-mesos/build.sbt
+++ b/bootstrap-demo/dns-api-mesos/build.sbt
@@ -1,5 +1,5 @@
 enablePlugins(JavaAppPackaging)
-name := "bootstrap-joining-demo-dns-api"
+name := "bootstrap-demo-dns-api"
 
 scalaVersion := "2.12.4"
 

--- a/bootstrap-demo/dns-api-mesos/marathon/app.bridge-mode.json
+++ b/bootstrap-demo/dns-api-mesos/marathon/app.bridge-mode.json
@@ -15,7 +15,7 @@
     "type": "DOCKER",
     "volumes": [],
     "docker": {
-      "image": "occo6er/bootstrap-joining-demo-dns-api:1.0",
+      "image": "occo6er/bootstrap-demo-dns-api:1.0",
       "network": "BRIDGE",
       "portMappings": [
         {

--- a/bootstrap-demo/dns-api-mesos/marathon/app.host-mode.json
+++ b/bootstrap-demo/dns-api-mesos/marathon/app.host-mode.json
@@ -15,7 +15,7 @@
     "type": "DOCKER",
     "volumes": [],
     "docker": {
-      "image": "occo6er/bootstrap-joining-demo-dns-api:1.0",
+      "image": "occo6er/bootstrap-demo-dns-api:1.0",
       "network": "HOST",
       "privileged": false,
       "parameters": [],

--- a/bootstrap-demo/marathon-api-docker/README.md
+++ b/bootstrap-demo/marathon-api-docker/README.md
@@ -10,7 +10,7 @@ a port name to identify Akka HTTP management port:
 
 Label need to be defined in two places. 
 First place is the application configuration:
-see `bootstrap-joining-demo/marathon-api-docker/src/main/resources/application.conf`:
+see `bootstrap-demo/marathon-api-docker/src/main/resources/application.conf`:
 ```
     akka.management.cluster.bootstrap.contact-point-discovery.effective-name = "marathon-api-docker-app-label"
 ```
@@ -71,7 +71,7 @@ How to Build
 
 2. In order to build and publish this example into your docker hub repo run next command from `akka-management` work folder
 
-`sbt bootstrap-joining-demo-marathon-api-docker/docker:publish`
+`sbt bootstrap-demo-marathon-api-docker/docker:publish`
 
 How to Deploy
 -------------

--- a/bootstrap-demo/marathon-api-docker/build.sbt
+++ b/bootstrap-demo/marathon-api-docker/build.sbt
@@ -1,6 +1,6 @@
 import com.typesafe.sbt.packager.docker._
 
-name := "bootstrap-joining-demo-marathon-api-docker"
+name := "bootstrap-demo-marathon-api-docker"
 
 version := "0.1.0"
 

--- a/bootstrap-demo/marathon-api-docker/marathon/marathon-api-docker-app.json
+++ b/bootstrap-demo/marathon-api-docker/marathon/marathon-api-docker-app.json
@@ -1,5 +1,5 @@
 {
-  "id": "/bootstrap-joining-demo-marathon-api-docker",
+  "id": "/bootstrap-demo-marathon-api-docker",
   "instances": 2,
   "labels": {
     "ACTOR_SYSTEM_NAME": "marathon-api-docker-app-label"
@@ -18,7 +18,7 @@
     "type": "DOCKER",
     "volumes": [],
     "docker": {
-      "image": "$DOCKER_USER/akka-management-bootstrap-joining-demo-marathon-api-docker:1.0",
+      "image": "$DOCKER_USER/akka-management-bootstrap-demo-marathon-api-docker:1.0",
       "network": "BRIDGE",
       "portMappings": [
         {

--- a/bootstrap-demo/marathon-api/README.md
+++ b/bootstrap-demo/marathon-api/README.md
@@ -19,18 +19,18 @@ sbt universal:packageZipTarball
 ```
 
 Now, in the `target/universal` folder, you should have a
-`bootstrap-joining-demo-marathon-api-0.1.0.tgz` file. 
+`bootstrap-demo-marathon-api-0.1.0.tgz` file.
 
 Step 2: Upload the App
 ----------------------
 
-Upload `bootstrap-joining-demo-marathon-api-0.1.0.tgz` to a webserver that your DC/OS cluster can access.
+Upload `bootstrap-demo-marathon-api-0.1.0.tgz` to a webserver that your DC/OS cluster can access.
 
 
 Step 3: Edit Config
 -------------------
 
-Edit `marathon/app.json`, replacing the value at `fetch[0].uri` ("http://yourwebserver.example.com/bootstrap-joining-demo-marathon-api-0.1.0.tgz")
+Edit `marathon/app.json`, replacing the value at `fetch[0].uri` ("http://yourwebserver.example.com/bootstrap-demo-marathon-api-0.1.0.tgz")
 with the URL of the packaged application.
 
 Step 4: Deploy the App
@@ -48,7 +48,7 @@ Step 5: Verify the cluster formation
 Using `dcos task log` you can watch the output of the application.
 
 ```bash
-dcos task log --follow bootstrap-joining-demo-marathon-api-0.1.0
+dcos task log --follow bootstrap-demo-marathon-api-0.1.0
 ```
 
 Successful log output will look something like the following:

--- a/bootstrap-demo/marathon-api/build.sbt
+++ b/bootstrap-demo/marathon-api/build.sbt
@@ -1,6 +1,6 @@
 enablePlugins(JavaServerAppPackaging)
 
-name := "bootstrap-joining-demo-marathon-api"
+name := "bootstrap-demo-marathon-api"
 
 version := "0.1.0"
 

--- a/bootstrap-demo/marathon-api/marathon/app.json
+++ b/bootstrap-demo/marathon-api/marathon/app.json
@@ -1,6 +1,6 @@
 {
-  "id": "/bootstrap-joining-demo-marathon-api-0.1.0",
-  "cmd": "./bootstrap-joining-demo-marathon-api-0.1.0/bin/bootstrap-joining-demo-marathon-api -java-home $(echo $(pwd)/jre*) -Dakka.remote.netty.tcp.hostname=$HOST -Dakka.remote.netty.tcp.port=$PORT_AKKAREMOTE -Dakka.management.http.hostname=$HOST -Dakka.management.http.port=$PORT_AKKAMGMTHTTP",
+  "id": "/bootstrap-demo-marathon-api-0.1.0",
+  "cmd": "./bootstrap-demo-marathon-api-0.1.0/bin/bootstrap-joining-demo-marathon-api -java-home $(echo $(pwd)/jre*) -Dakka.remote.netty.tcp.hostname=$HOST -Dakka.remote.netty.tcp.port=$PORT_AKKAREMOTE -Dakka.management.http.hostname=$HOST -Dakka.management.http.port=$PORT_AKKAMGMTHTTP",
   "cpus": 1.0,
   "mem": 512,
   "instances": 2,
@@ -50,7 +50,7 @@
   "killSelection": "YOUNGEST_FIRST",
   "fetch": [
     {
-      "uri": "http://yourwebserver.example.com/bootstrap-joining-demo-marathon-api-0.1.0.tgz",
+      "uri": "http://yourwebserver.example.com/bootstrap-demo-marathon-api-0.1.0.tgz",
       "extract": true,
       "executable": false,
       "cache": false

--- a/discovery-marathon-api/src/test/resources/docker-app.json
+++ b/discovery-marathon-api/src/test/resources/docker-app.json
@@ -26,7 +26,7 @@
         "type": "DOCKER",
         "volumes": [],
         "docker": {
-          "image": "occo6er/bootstrap-joining-demo-marathon-api:1.0",
+          "image": "occo6er/bootstrap-demo-marathon-api:1.0",
           "network": "BRIDGE",
           "portMappings": [
             {

--- a/docs/src/main/paradox/discovery/index.md
+++ b/docs/src/main/paradox/discovery/index.md
@@ -483,7 +483,7 @@ setting `akka.discovery.aws-api-ec2-tag-based.tag-key` to something else.
 
 Demo:
 
-* A working demo app is available in the [bootstrap-joining-demo](https://github.com/akka/akka-management/tree/master/bootstrap-demo/aws-api-ec2)
+* A working demo app is available in the [bootstrap-demo](https://github.com/akka/akka-management/tree/master/bootstrap-demo/aws-api-ec2)
 folder.
 
 
@@ -600,7 +600,7 @@ Notes:
 Demo:
 
 * A working demo app is available in the
-  [bootstrap-joining-demo](https://github.com/akka/akka-management/tree/master/bootstrap-demo/aws-api-ecs)
+  [bootstrap-demo](https://github.com/akka/akka-management/tree/master/bootstrap-demo/aws-api-ecs)
   folder. It includes CloudFormation templates with minimal permissions w.r.t to
   IAM policies and security group ingress, and so is a good starting point for
   any deployment that integrates the

--- a/integration-test-scripts/aws-api-ec2-tag-based.sh
+++ b/integration-test-scripts/aws-api-ec2-tag-based.sh
@@ -12,11 +12,11 @@ unzip awscli-bundle.zip
 ./awscli-bundle/install -b ~/bin/aws
 export PATH=~/bin:$PATH
 
-sbt bootstrap-joining-demo-aws-api-ec2-tag-based/universal:packageBin
+sbt bootstrap-demo-aws-api-ec2-tag-based/universal:packageBin
 # create bucket if it doesn't already exist
 aws s3api create-bucket --bucket $BUCKET --region us-east-1
-aws s3 cp bootstrap-joining-demo/aws-api-ec2/target/universal/app.zip s3://$BUCKET/$BUILD_ID/ --acl public-read
+aws s3 cp bootstrap-demo/aws-api-ec2/target/universal/app.zip s3://$BUCKET/$BUILD_ID/ --acl public-read
 # run the actual integration test
-sbt bootstrap-joining-demo-aws-api-ec2-tag-based/it:test
+sbt bootstrap-demo-aws-api-ec2-tag-based/it:test
 # delete file (save a few cents)
 aws s3 rm s3://$BUCKET/$BUILD_ID/app.zip


### PR DESCRIPTION
I started from find bad link in documentation. 
Found all places where "bootstrap-joining-demo" is set and fix names to "bootstrap-demo".

If you need any updates, please let me know. 