### PR TITLE
Discovery Service Additional Logging

### DIFF
--- a/discovery/src/main/scala/akka/discovery/ServiceDiscovery.scala
+++ b/discovery/src/main/scala/akka/discovery/ServiceDiscovery.scala
@@ -61,12 +61,12 @@ final class ServiceDiscovery(implicit system: ExtendedActorSystem) extends Exten
         .createInstanceFor[SimpleServiceDiscovery](clazzName, (classOf[ExtendedActorSystem] → system) :: Nil)
         .recoverWith {
           case e: Throwable ⇒
-            log.info(s"Failed to create discovery instance {}", e)
+            log.info("Failed to create discovery instance {}", e)
             dynamic.createInstanceFor[SimpleServiceDiscovery](clazzName, (classOf[ActorSystem] → system) :: Nil)
         }
         .recoverWith {
           case e: Throwable ⇒
-            log.info(s"Failed to create discovery instance {}", e)
+            log.info("Failed to create discovery instance {}", e)
             dynamic.createInstanceFor[SimpleServiceDiscovery](clazzName, Nil)
         }
     }

--- a/discovery/src/test/scala/akka/discovery/DiscoveryConfigurationSpec.scala
+++ b/discovery/src/test/scala/akka/discovery/DiscoveryConfigurationSpec.scala
@@ -165,7 +165,7 @@ class DiscoveryConfigurationSpec extends WordSpec with Matchers {
 
 class FakeTestDiscovery extends SimpleServiceDiscovery {
 
-  override def lookup(lookup: Lookup, resolveTimeout: FiniteDuration): Future[SimpleServiceDiscovery.Resolved] = ???
+  override def lookup(lookup: Lookup, resolveTimeout: FiniteDuration): Future[Resolved] = ???
 }
 
 class FakeTestDiscovery2 extends FakeTestDiscovery

--- a/discovery/src/test/scala/akka/discovery/DiscoveryConfigurationSpec.scala
+++ b/discovery/src/test/scala/akka/discovery/DiscoveryConfigurationSpec.scala
@@ -5,8 +5,8 @@ package akka.discovery
 
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
-
 import akka.actor.ActorSystem
+import akka.discovery.SimpleServiceDiscovery.Resolved
 import akka.testkit.TestKit
 import com.typesafe.config.ConfigFactory
 import org.scalatest.Matchers
@@ -130,6 +130,35 @@ class DiscoveryConfigurationSpec extends WordSpec with Matchers {
         ServiceDiscovery(sys).discovery should be theSameInstanceAs ServiceDiscovery(sys).loadServiceDiscovery("mock1")
       } finally TestKit.shutdownActorSystem(sys)
     }
+
+    "throw a specific discovery method exception" in {
+      val className = classOf[ExceptionThrowingDiscovery].getCanonicalName
+
+      val sys = ActorSystem("DiscoveryConfigurationSpec", ConfigFactory.parseString(s"""
+            akka.discovery {
+              method = "$className"
+            }
+        """).withFallback(ConfigFactory.load()))
+
+      try {
+        an[DiscoveryException] should be thrownBy ServiceDiscovery(sys).discovery
+      } finally TestKit.shutdownActorSystem(sys)
+    }
+
+    "throw an illegal argument exception for not existing method" in {
+      val className = "className"
+
+      val sys = ActorSystem("DiscoveryConfigurationSpec", ConfigFactory.parseString(s"""
+            akka.discovery {
+              method = "$className"
+            }
+        """).withFallback(ConfigFactory.load()))
+
+      try {
+        an[IllegalArgumentException] should be thrownBy ServiceDiscovery(sys).discovery
+      } finally TestKit.shutdownActorSystem(sys)
+    }
+
   }
 
 }
@@ -140,3 +169,13 @@ class FakeTestDiscovery extends SimpleServiceDiscovery {
 }
 
 class FakeTestDiscovery2 extends FakeTestDiscovery
+
+class DiscoveryException(message: String) extends Exception
+
+class ExceptionThrowingDiscovery extends SimpleServiceDiscovery {
+
+  def lookup(lookup: Lookup, resolveTimeout: FiniteDuration): Future[Resolved] = ???
+
+  throw new DiscoveryException("Test Exception")
+
+}


### PR DESCRIPTION
- the underlying discovery mechanisms can throw exception related to their configuration, the exception is swallowed in recover with, causing confusion

Addresses the issue: #165