### PR TITLE
Use Servicedisocvery.load in bootstrap

### DIFF
--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/ClusterBootstrap.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/ClusterBootstrap.scala
@@ -48,11 +48,8 @@ final class ClusterBootstrap(implicit system: ExtendedActorSystem) extends Exten
         discovery
 
       case otherDiscoveryMechanism ⇒
-        val implClazz = system.settings.config.getString(otherDiscoveryMechanism + ".class")
-        log.info("Bootstrap using [{}] discovery mechanism, instantiating [{}]", otherDiscoveryMechanism, implClazz)
-        system.dynamicAccess
-          .createInstanceFor[SimpleServiceDiscovery](implClazz, List(classOf[ActorSystem] → system))
-          .get
+        log.info("Bootstrap using `akka.discovery` mechanism: {}", otherDiscoveryMechanism)
+        ServiceDiscovery(system).loadServiceDiscovery(otherDiscoveryMechanism)
     }
 
   private val joinDecider: JoinDecider = {


### PR DESCRIPTION
Rather than duplicating the logic of loading a discovery mechanism

Fixes #368 