### PR TITLE
Note support status in docs

### DIFF
--- a/docs/src/main/paradox/index.md
+++ b/docs/src/main/paradox/index.md
@@ -21,4 +21,4 @@ Support for some protocols is provided out of the box and others are provided as
 This project does not yet have to obey the rule of staying binary compatible between releases that is common 
 for Akka libraries. Breaking API changes may be introduced without notice as we refine and simplify based on your feedback.
 
-Akka gRPC is currently *Incubating*. The Lightbend subscription does not yet cover support for this project.
+Akka Management is currently *Incubating*. The Lightbend subscription does not yet cover support for this project.

--- a/docs/src/main/paradox/index.md
+++ b/docs/src/main/paradox/index.md
@@ -14,3 +14,11 @@ Support for some protocols is provided out of the box and others are provided as
   - [Akka Cluster Management (JMX)](cluster-jmx-management.md)
 
 @@@
+
+
+## Compatibility & support
+
+This project does not yet have to obey the rule of staying binary compatible between releases that is common 
+for Akka libraries. Breaking API changes may be introduced without notice as we refine and simplify based on your feedback.
+
+Akka gRPC is currently *Incubating*. The Lightbend subscription does not yet cover support for this project.


### PR DESCRIPTION
Fixes #379 

Started out with only the support status, ideas where to add recommended service discovery mechanisms welcome.