### PR TITLE
Adds a parser to generate SRV Lookups from SRV strings

### DIFF
--- a/discovery/src/main/scala/akka/discovery/SimpleServiceDiscovery.scala
+++ b/discovery/src/main/scala/akka/discovery/SimpleServiceDiscovery.scala
@@ -123,32 +123,20 @@ case object Lookup {
    * (as specified by https://www.ietf.org/rfc/rfc2782.txt)
    *
    * If the passed string conforms with this format, a SRV Lookup is returned.
+   * The serviceName part must be a valid domain name.
    *
    * The string is parsed and dismembered to build a Lookup as following:
    * Lookup(serviceName).withPortName(portName).withProtocol(protocol)
    *
-   * The serviceName part must be a valid domain name.
-   *
    * If the string doesn't not conform with the SRV format, a simple A/AAAA Lookup is returned using the whole string as service name.
-   *
-   * @throws IllegalArgumentException if the service name extracted from the SRV string is not a valid domain name.
    */
-  def fromString(str: String): Lookup = {
-
-    def fromDomainName(name: String): Lookup = {
-      if (validDomainName(name))
-        Lookup(name)
-      else
-        throw new IllegalArgumentException(s"Illegal domain name lookup: $name")
-    }
-
+  def fromString(str: String): Lookup =
     str match {
-      case SrvQuery(portName, protocol, serviceName) =>
-        fromDomainName(serviceName).withPortName(portName).withProtocol(protocol)
+      case SrvQuery(portName, protocol, serviceName) if validDomainName(serviceName) =>
+        Lookup(serviceName).withPortName(portName).withProtocol(protocol)
 
       case _ => Lookup(str)
     }
-  }
 
   /**
    * Returns true if passed string conforms with SRV format. Otherwise returns false.

--- a/discovery/src/main/scala/akka/discovery/SimpleServiceDiscovery.scala
+++ b/discovery/src/main/scala/akka/discovery/SimpleServiceDiscovery.scala
@@ -124,7 +124,7 @@ case object Lookup {
    * The string is parsed and dismembered to build a Lookup as following:
    * Lookup(serviceName).withPortName(portName).withProtocol(protocol)
    *
-   * If the string doesn't not conform with the SRV format, a simple A/AAAA Lookup is returned.
+   * If the string doesn't not conform with the SRV format, a simple A/AAAA Lookup is returned using the whole string as service name.
    */
   def parseSrvString(srv: String): Lookup =
     srv match {

--- a/discovery/src/main/scala/akka/discovery/SimpleServiceDiscovery.scala
+++ b/discovery/src/main/scala/akka/discovery/SimpleServiceDiscovery.scala
@@ -112,6 +112,32 @@ case object Lookup {
    * and protocol
    */
   def create(serviceName: String): Lookup = new Lookup(serviceName, None, None)
+
+  private val SrvQuery = """^_(.+?)\._(.+?)\.(.+?)$""".r
+
+  /**
+   * Create a service Lookup from a string with format:
+   * _portName._protocol.serviceName.
+   *
+   * If the passed string conforms with this format, a SRV Lookup is returned.
+   *
+   * The string is parsed and dismembered to build a Lookup as following:
+   * Lookup(serviceName).withPortName(portName).withProtocol(protocol)
+   *
+   * If the string doesn't not conform with the SRV format, a simple A/AAAA Lookup is returned.
+   */
+  def parseSrvString(srv: String): Lookup =
+    srv match {
+      case SrvQuery(portName, protocol, serviceName) =>
+        Lookup(serviceName).withPortName(portName).withProtocol(protocol)
+      case _ => Lookup(srv)
+    }
+
+  /**
+   * Returns true if passed string conforms with SRV format. Otherwise returns false.
+   */
+  def isSrvString(srv: String): Boolean =
+    SrvQuery.pattern.asPredicate().test(srv)
 }
 
 /**

--- a/discovery/src/main/scala/akka/discovery/SimpleServiceDiscovery.scala
+++ b/discovery/src/main/scala/akka/discovery/SimpleServiceDiscovery.scala
@@ -126,7 +126,7 @@ case object Lookup {
    *
    * If the string doesn't not conform with the SRV format, a simple A/AAAA Lookup is returned using the whole string as service name.
    */
-  def parseSrvString(srv: String): Lookup =
+  def fromString(str: String): Lookup =
     srv match {
       case SrvQuery(portName, protocol, serviceName) =>
         Lookup(serviceName).withPortName(portName).withProtocol(protocol)

--- a/discovery/src/main/scala/akka/discovery/SimpleServiceDiscovery.scala
+++ b/discovery/src/main/scala/akka/discovery/SimpleServiceDiscovery.scala
@@ -3,7 +3,6 @@
  */
 package akka.discovery
 
-import java.lang.invoke.MethodHandles
 import java.net.InetAddress
 import java.util.Optional
 import java.util.concurrent.CompletionStage

--- a/discovery/src/main/scala/akka/discovery/SimpleServiceDiscovery.scala
+++ b/discovery/src/main/scala/akka/discovery/SimpleServiceDiscovery.scala
@@ -3,6 +3,7 @@
  */
 package akka.discovery
 
+import java.lang.invoke.MethodHandles
 import java.net.InetAddress
 import java.util.Optional
 import java.util.concurrent.CompletionStage
@@ -127,9 +128,11 @@ case object Lookup {
    * The string is parsed and dismembered to build a Lookup as following:
    * Lookup(serviceName).withPortName(portName).withProtocol(protocol)
    *
+   * The serviceName part must be a valid domain name.
+   *
    * If the string doesn't not conform with the SRV format, a simple A/AAAA Lookup is returned using the whole string as service name.
    *
-   * @throws IllegalArgumentException if the service name is not a valid domain name.
+   * @throws IllegalArgumentException if the service name extracted from the SRV string is not a valid domain name.
    */
   def fromString(str: String): Lookup = {
 
@@ -144,7 +147,7 @@ case object Lookup {
       case SrvQuery(portName, protocol, serviceName) =>
         fromDomainName(serviceName).withPortName(portName).withProtocol(protocol)
 
-      case _ => fromDomainName(str)
+      case _ => Lookup(str)
     }
   }
 

--- a/discovery/src/main/scala/akka/discovery/SimpleServiceDiscovery.scala
+++ b/discovery/src/main/scala/akka/discovery/SimpleServiceDiscovery.scala
@@ -129,7 +129,7 @@ case object Lookup {
    *
    * If the string doesn't not conform with the SRV format, a simple A/AAAA Lookup is returned using the whole string as service name.
    *
-   * @throws This method throws IllegalArgumentException if the service name is not a valid domain name.
+   * @throws IllegalArgumentException if the service name is not a valid domain name.
    */
   def fromString(str: String): Lookup = {
 

--- a/discovery/src/test/scala/akka/discovery/LookupSpec.scala
+++ b/discovery/src/test/scala/akka/discovery/LookupSpec.scala
@@ -13,7 +13,7 @@ class LookupSpec extends WordSpec with Matchers with OptionValues {
     "_portName._protocol.service_name.local",
     "_portName._protocol.servicename,local",
     "_portName._protocol.servicename.local-",
-    "_portName._protocol.-servicename.local",
+    "_portName._protocol.-servicename.local"
   )
 
   // No SRV that should result in simple A/AAAA lookups

--- a/discovery/src/test/scala/akka/discovery/LookupSpec.scala
+++ b/discovery/src/test/scala/akka/discovery/LookupSpec.scala
@@ -7,21 +7,35 @@ import org.scalatest.{ Matchers, OptionValues, WordSpec }
 
 class LookupSpec extends WordSpec with Matchers with OptionValues {
 
-  // some invalid SRV strings
+  // some invalid SRV strings, but valid domain names
+  // should result in A/AAAA Lookups
   val invalidSRVs = List(
-    "_portName.serviceName",
-    "portName.protocol.serviceName",
-    "_portName_protocol.serviceName",
-    "serviceName"
+    "portName.protocol.serviceName.local",
+    "serviceName.local"
   )
 
+  // SRV strings with invalid domain names
+  val srvWithInvalidDomainNames = List(
+    "_portName._protocol.service_name.local",
+    "_portName._protocol.servicename,local",
+    "_portName._protocol.servicename.local-",
+    "_portName._protocol.-servicename.local",
+  )
+  // some invalid domain names
+  val invalidDomainNames = List(
+    "_portName.serviceName",
+    "_serviceName.local",
+    "_serviceName,local",
+    "-serviceName.local",
+    "serviceName.local-",
+  ) ++ srvWithInvalidDomainNames
+
   "Lookup.parseSrvString" should {
+
     "generate a SRV Lookup from a SRV String" in {
-
-      val name = "_portName._protocol.serviceName"
-
-      val lookup = Lookup.parseSrvString(name)
-      lookup.serviceName shouldBe "serviceName"
+      val name = "_portName._protocol.serviceName.local"
+      val lookup = Lookup.fromString(name)
+      lookup.serviceName shouldBe "serviceName.local"
       lookup.portName.value shouldBe "portName"
       lookup.protocol.value shouldBe "protocol"
     }
@@ -29,24 +43,46 @@ class LookupSpec extends WordSpec with Matchers with OptionValues {
     "generate a A/AAAA from any non-conforming String  " in {
       invalidSRVs.map { str =>
         withClue(s"parsing '$str'") {
-          val lookup = Lookup.parseSrvString(str)
+          val lookup = Lookup.fromString(str)
           lookup.serviceName shouldBe str
           lookup.portName shouldBe empty
           lookup.protocol shouldBe empty
         }
       }
     }
+
+    "throw exception if domain part is an invalid domain name" in {
+      invalidDomainNames.foreach { str =>
+        withClue(s"parsing '$str'") {
+          try {
+            Lookup.fromString(str)
+            fail("should fail with exception")
+          } catch {
+            case _:IllegalArgumentException => // ass expected
+          }
+        }
+      }
+    }
   }
 
   "Lookup.isSrvString" should {
+
     "return true for any conforming SRV String" in {
-      Lookup.isSrvString("_portName._protocol.serviceName") shouldBe true
+      Lookup.isValidSrv("_portName._protocol.serviceName.local") shouldBe true
     }
 
     "return false for any non-conforming SRV String" in {
       invalidSRVs.map { str =>
         withClue(s"checking '$str'") {
-          Lookup.isSrvString(str) shouldBe false
+          Lookup.isValidSrv(str) shouldBe false
+        }
+      }
+    }
+
+    "return false for if domain part is an invalid domain name" in {
+      srvWithInvalidDomainNames.map { str =>
+        withClue(s"checking '$str'") {
+          Lookup.isValidSrv(str) shouldBe false
         }
       }
     }

--- a/discovery/src/test/scala/akka/discovery/LookupSpec.scala
+++ b/discovery/src/test/scala/akka/discovery/LookupSpec.scala
@@ -38,7 +38,7 @@ class LookupSpec extends WordSpec with Matchers with OptionValues {
     }
 
     "generate a A/AAAA from any non-conforming SRV String" in {
-      noSrvLookups.foreach { str =>
+      (noSrvLookups ++ srvWithInvalidDomainNames).foreach { str =>
         withClue(s"parsing '$str'") {
           val lookup = Lookup.fromString(str)
           lookup.serviceName shouldBe str

--- a/discovery/src/test/scala/akka/discovery/LookupSpec.scala
+++ b/discovery/src/test/scala/akka/discovery/LookupSpec.scala
@@ -50,7 +50,7 @@ class LookupSpec extends WordSpec with Matchers with OptionValues {
 
   }
 
-  "Lookup.isSrvString" should {
+  "Lookup.isValidSrv" should {
 
     "return true for any conforming SRV String" in {
       Lookup.isValidSrv("_portName._protocol.serviceName.local") shouldBe true

--- a/discovery/src/test/scala/akka/discovery/LookupSpec.scala
+++ b/discovery/src/test/scala/akka/discovery/LookupSpec.scala
@@ -27,7 +27,7 @@ class LookupSpec extends WordSpec with Matchers with OptionValues {
     "serviceName.local-",
   )
 
-  "Lookup.parseSrvString" should {
+  "Lookup.fromString" should {
 
     "generate a SRV Lookup from a SRV String" in {
       val name = "_portName._protocol.serviceName.local"

--- a/discovery/src/test/scala/akka/discovery/LookupSpec.scala
+++ b/discovery/src/test/scala/akka/discovery/LookupSpec.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.discovery
+
+import org.scalatest.{ Matchers, OptionValues, WordSpec }
+
+class LookupSpec extends WordSpec with Matchers with OptionValues {
+
+  // some invalid SRV strings
+  val invalidSRVs = List(
+    "_portName.serviceName",
+    "portName.protocol.serviceName",
+    "_portName_protocol.serviceName",
+    "serviceName"
+  )
+
+  "Lookup.parseSrvString" should {
+    "generate a SRV Lookup from a SRV String" in {
+
+      val name = "_portName._protocol.serviceName"
+
+      val lookup = Lookup.parseSrvString(name)
+      lookup.serviceName shouldBe "serviceName"
+      lookup.portName.value shouldBe "portName"
+      lookup.protocol.value shouldBe "protocol"
+    }
+
+    "generate a A/AAAA from any non-conforming String  " in {
+      invalidSRVs.map { str =>
+        withClue(s"parsing '$str'") {
+          val lookup = Lookup.parseSrvString(str)
+          lookup.serviceName shouldBe str
+          lookup.portName shouldBe empty
+          lookup.protocol shouldBe empty
+        }
+      }
+    }
+  }
+
+  "Lookup.isSrvString" should {
+    "true for any conforming SRV String" in {
+      Lookup.isSrvString("_portName._protocol.serviceName") shouldBe true
+    }
+
+    "false for any conforming SRV String" in {
+      invalidSRVs.map { str =>
+        withClue(s"checking '$str'") {
+          Lookup.isSrvString(str) shouldBe false
+        }
+      }
+    }
+
+  }
+}

--- a/discovery/src/test/scala/akka/discovery/LookupSpec.scala
+++ b/discovery/src/test/scala/akka/discovery/LookupSpec.scala
@@ -24,7 +24,7 @@ class LookupSpec extends WordSpec with Matchers with OptionValues {
     "_serviceName.local",
     "_serviceName,local",
     "-serviceName.local",
-    "serviceName.local-",
+    "serviceName.local-"
   )
 
   "Lookup.fromString" should {

--- a/discovery/src/test/scala/akka/discovery/LookupSpec.scala
+++ b/discovery/src/test/scala/akka/discovery/LookupSpec.scala
@@ -39,11 +39,11 @@ class LookupSpec extends WordSpec with Matchers with OptionValues {
   }
 
   "Lookup.isSrvString" should {
-    "true for any conforming SRV String" in {
+    "return true for any conforming SRV String" in {
       Lookup.isSrvString("_portName._protocol.serviceName") shouldBe true
     }
 
-    "false for any conforming SRV String" in {
+    "return false for any non-conforming SRV String" in {
       invalidSRVs.map { str =>
         withClue(s"checking '$str'") {
           Lookup.isSrvString(str) shouldBe false


### PR DESCRIPTION
This will be handy when creating a Lagom `ServiceLocator` backed by Akka `ServiceDiscovery`. 

Lagom's `ServiceLocator` doesn't support port name and protocol. An easy way to work this around is to configure Lagom to lookup for a full SRV string, eg: `_cassandra._tpc.my-cassandra-instance`.

Before calling the underlying `ServiceDiscovery`, Lagom's `ServiceLocator` can build a SRV Lookup using that string. 

This can obviously be used in other situations as well (not included in this PR). For instances, `SimpleServiceDiscovery.lookup(serviceName: String, resolveTimeout: FiniteDuration)` could use the parser automatically. 

Current impl: 

```scala 
def lookup(serviceName: String, resolveTimeout: FiniteDuration): Future[Resolved] =
    lookup(Lookup(serviceName), resolveTimeout)
```
 
Alternatively:

```scala 
def lookup(serviceName: String, resolveTimeout: FiniteDuration): Future[Resolved] =
    lookup(Lookup.parseSrvString(serviceName), resolveTimeout)
```

Though, that's debatable. SRV format is used by DNS and Kubernetes, but not necessarily makes sense for all ServiceDiscovery implementations.