### PR TITLE
 Improve logging for kubernetes API communication issues

### DIFF
--- a/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/KubernetesApiSimpleServiceDiscovery.scala
+++ b/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/KubernetesApiSimpleServiceDiscovery.scala
@@ -16,15 +16,15 @@ import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.FileIO
 import com.typesafe.sslconfig.akka.AkkaSSLConfig
 import com.typesafe.sslconfig.ssl.TrustStoreConfig
+
 import scala.collection.immutable.Seq
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
 import scala.util.Try
-
 import JsonFormat._
 import SimpleServiceDiscovery.{ Resolved, ResolvedTarget }
-import scala.util.control.NonFatal
 
+import scala.util.control.{ NoStackTrace, NonFatal }
 import akka.event.Logging
 
 object KubernetesApiSimpleServiceDiscovery {
@@ -51,6 +51,9 @@ object KubernetesApiSimpleServiceDiscovery {
         port = Some(port.containerPort),
         address = Some(InetAddress.getByName(ip))
       )
+
+  class KubernetesApiException(msg: String) extends RuntimeException(msg) with NoStackTrace
+
 }
 
 /**
@@ -58,6 +61,7 @@ object KubernetesApiSimpleServiceDiscovery {
  * you to define readiness/health checks that don't affect the bootstrap mechanism.
  */
 class KubernetesApiSimpleServiceDiscovery(system: ActorSystem) extends SimpleServiceDiscovery {
+
   import akka.discovery.kubernetes.KubernetesApiSimpleServiceDiscovery._
   import system.dispatcher
 
@@ -99,16 +103,28 @@ class KubernetesApiSimpleServiceDiscovery(system: ActorSystem) extends SimpleSer
       entity <- response.entity.toStrict(resolveTimeout)
 
       podList <- {
-        log.debug("Kubernetes API entity: [{}]", entity.data.utf8String)
 
-        val unmarshalled = Unmarshal(entity).to[PodList]
-
-        unmarshalled.failed.foreach { t =>
-          log.error(t, "Failed to unmarshal Kubernetes API response status [{}]; check RBAC settings",
-            response.status.value)
+        response.status match {
+          case StatusCodes.OK =>
+            log.debug("Kubernetes API entity: [{}]", entity.data.utf8String)
+            val unmarshalled = Unmarshal(entity).to[PodList]
+            unmarshalled.failed.foreach { t =>
+              log.error(t, "Failed to unmarshal Kubernetes API response.  Status code: [{}]; Response body: [{}]",
+                response.status.value, entity)
+            }
+            unmarshalled
+          case StatusCodes.Forbidden =>
+            log.error("Forbidden to communicate with Kubernetes API server; check RBAC settings. Response: [{}]",
+              entity)
+            Future.failed(
+                new KubernetesApiException(
+                    "Forbidden when communicating with the Kubernetes API. Check RBAC settings."))
+          case other =>
+            log.error("Non-200 when communicating with Kubernetes API server. Status code: [{}]. Response body: [{}]",
+              other, entity)
+            Future.failed(new KubernetesApiException(s"Non-200 from Kubernetes API server: $other"))
         }
 
-        unmarshalled
       }
 
     } yield {


### PR DESCRIPTION
* Don't unmarshal the response for non-200 status codes
* Specific log message for 403
* Log body at error for non-200 so users don't need to turn on DEBUG

Fixes #371