### PR TITLE
Expose routes so read only can be used in isolation

### DIFF
--- a/bootstrap-demo/kubernetes-api/src/main/scala/akka/cluster/bootstrap/DemoApp.scala
+++ b/bootstrap-demo/kubernetes-api/src/main/scala/akka/cluster/bootstrap/DemoApp.scala
@@ -10,7 +10,6 @@ import akka.http.scaladsl.Http
 import akka.management.AkkaManagement
 import akka.management.cluster.bootstrap.ClusterBootstrap
 import akka.stream.ActorMaterializer
-import com.typesafe.config.ConfigFactory
 
 object DemoApp extends App {
 

--- a/build.sbt
+++ b/build.sbt
@@ -29,11 +29,10 @@ lazy val `akka-management-root` = project
     docs
   )
   .settings(
-    parallelExecution in GlobalScope := false,
-    inThisBuild(List(
-      resolvers += Resolver.sonatypeRepo("comtypesafe-2189")
-
-    ))
+    parallelExecution in GlobalScope := false
+//    inThisBuild(List(
+//      resolvers += Resolver.sonatypeRepo("comtypesafe-2189")
+//    ))
   )
 
 // interfaces and extension for Discovery

--- a/build.sbt
+++ b/build.sbt
@@ -30,9 +30,6 @@ lazy val `akka-management-root` = project
   )
   .settings(
     parallelExecution in GlobalScope := false
-//    inThisBuild(List(
-//      resolvers += Resolver.sonatypeRepo("comtypesafe-2189")
-//    ))
   )
 
 // interfaces and extension for Discovery

--- a/cluster-http/src/main/scala/akka/management/cluster/ClusterHttpManagementProtocol.scala
+++ b/cluster-http/src/main/scala/akka/management/cluster/ClusterHttpManagementProtocol.scala
@@ -3,7 +3,6 @@
  */
 package akka.management.cluster
 
-import akka.cluster.Member
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import spray.json.DefaultJsonProtocol
 

--- a/cluster-http/src/main/scala/akka/management/cluster/ClusterHttpManagementRoutes.scala
+++ b/cluster-http/src/main/scala/akka/management/cluster/ClusterHttpManagementRoutes.scala
@@ -18,7 +18,7 @@ object ClusterHttpManagementRoutes extends ClusterHttpManagementJsonProtocol {
 
   import akka.http.scaladsl.server.Directives._
 
-  def routeGetMembers(cluster: Cluster): Route =
+  private def routeGetMembers(cluster: Cluster): Route =
     get {
       complete {
         val readView = ClusterReadViewAccess.internalReacView(cluster)
@@ -41,7 +41,7 @@ object ClusterHttpManagementRoutes extends ClusterHttpManagementJsonProtocol {
       }
     }
 
-  def routePostMembers(cluster: Cluster): Route =
+  private def routePostMembers(cluster: Cluster): Route =
     post {
       formField('address) { addressString ⇒
         complete {
@@ -52,14 +52,14 @@ object ClusterHttpManagementRoutes extends ClusterHttpManagementJsonProtocol {
       }
     }
 
-  def routeGetMember(cluster: Cluster, member: Member): Route =
+  private def routeGetMember(cluster: Cluster, member: Member): Route =
     get {
       complete {
         memberToClusterMember(member)
       }
     }
 
-  def routeDeleteMember(cluster: Cluster, member: Member): Route =
+  private def routeDeleteMember(cluster: Cluster, member: Member): Route =
     delete {
       complete {
         cluster.leave(member.uniqueAddress.address)
@@ -67,7 +67,7 @@ object ClusterHttpManagementRoutes extends ClusterHttpManagementJsonProtocol {
       }
     }
 
-  def routePutMember(cluster: Cluster, member: Member) =
+  private def routePutMember(cluster: Cluster, member: Member) =
     put {
       formField('operation) { operation ⇒
         ClusterHttpManagementOperation.fromString(operation) match {
@@ -125,8 +125,7 @@ object ClusterHttpManagementRoutes extends ClusterHttpManagementJsonProtocol {
 
   /**
    * Creates an instance of [[ClusterHttpManagementRoutes]] to manage the specified
-   * [[akka.cluster.Cluster]] instance. This version does not provide Basic Authentication. It uses
-   * the specified path `pathPrefixName`.
+   * [[akka.cluster.Cluster]] instance. This version does not provide Basic Authentication.
    */
   def apply(cluster: Cluster): Route =
     concat(
@@ -145,7 +144,6 @@ object ClusterHttpManagementRoutes extends ClusterHttpManagementJsonProtocol {
 
   /**
    * Creates an instance of [[ClusterHttpManagementRoutes]] with only the read only routes.
-   * the specified path `pathPrefixName`.
    */
   def readOnly(cluster: Cluster): Route =
     concat(

--- a/cluster-http/src/main/scala/akka/management/cluster/ClusterHttpManagementRoutes.scala
+++ b/cluster-http/src/main/scala/akka/management/cluster/ClusterHttpManagementRoutes.scala
@@ -89,7 +89,7 @@ object ClusterHttpManagementRoutes extends ClusterHttpManagementJsonProtocol {
         m ⇒ s"${m.uniqueAddress.address}" == memberAddress || m.uniqueAddress.address.hostPort == memberAddress)
   }
 
-  private def routeGetMember(cluster: Cluster) =
+  private def routeFindMember(cluster: Cluster) =
     path(Remaining) { memberAddress ⇒
       findMember(cluster, memberAddress) match {
         case Some(member) ⇒
@@ -134,7 +134,7 @@ object ClusterHttpManagementRoutes extends ClusterHttpManagementJsonProtocol {
           pathEndOrSingleSlash {
             routeGetMembers(cluster) ~ routePostMembers(cluster)
           },
-          routeGetMember(cluster)
+          routeFindMember(cluster)
         )
       },
       pathPrefix("cluster" / "shards" / Remaining) { shardRegionName =>
@@ -152,7 +152,7 @@ object ClusterHttpManagementRoutes extends ClusterHttpManagementJsonProtocol {
           pathEndOrSingleSlash {
             routeGetMembers(cluster)
           },
-          routeGetMember(cluster)
+          routeFindMember(cluster)
         )
       },
       pathPrefix("cluster" / "shards" / Remaining) { shardRegionName =>

--- a/cluster-http/src/main/scala/akka/management/cluster/ClusterHttpManagementRoutes.scala
+++ b/cluster-http/src/main/scala/akka/management/cluster/ClusterHttpManagementRoutes.scala
@@ -89,7 +89,7 @@ object ClusterHttpManagementRoutes extends ClusterHttpManagementJsonProtocol {
         m ⇒ s"${m.uniqueAddress.address}" == memberAddress || m.uniqueAddress.address.hostPort == memberAddress)
   }
 
-  private def routesMember(cluster: Cluster) =
+  private def routeGetMember(cluster: Cluster) =
     path(Remaining) { memberAddress ⇒
       findMember(cluster, memberAddress) match {
         case Some(member) ⇒
@@ -134,7 +134,7 @@ object ClusterHttpManagementRoutes extends ClusterHttpManagementJsonProtocol {
           pathEndOrSingleSlash {
             routeGetMembers(cluster) ~ routePostMembers(cluster)
           },
-          routesMember(cluster)
+          routeGetMember(cluster)
         )
       },
       pathPrefix("cluster" / "shards" / Remaining) { shardRegionName =>
@@ -152,7 +152,7 @@ object ClusterHttpManagementRoutes extends ClusterHttpManagementJsonProtocol {
           pathEndOrSingleSlash {
             routeGetMembers(cluster)
           },
-          routesMember(cluster)
+          routeGetMember(cluster)
         )
       },
       pathPrefix("cluster" / "shards" / Remaining) { shardRegionName =>

--- a/cluster-http/src/main/scala/akka/management/cluster/javadsl/ClusterHttpManagementRoutes.scala
+++ b/cluster-http/src/main/scala/akka/management/cluster/javadsl/ClusterHttpManagementRoutes.scala
@@ -1,6 +1,7 @@
 /*
- * Copyright (C) 2017 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2017-2018 Lightbend Inc. <http://www.lightbend.com>
  */
+
 package akka.management.cluster.javadsl
 import akka.cluster.Cluster
 import akka.http.javadsl.server.directives.RouteAdapter

--- a/cluster-http/src/main/scala/akka/management/cluster/javadsl/ClusterHttpManagementRoutes.scala
+++ b/cluster-http/src/main/scala/akka/management/cluster/javadsl/ClusterHttpManagementRoutes.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.management.cluster.javadsl
+import akka.cluster.Cluster
+import akka.http.javadsl.server.directives.RouteAdapter
+
+object ClusterHttpManagementRoutes {
+
+  /**
+   * Creates an instance of [[ClusterHttpManagementRoutes]] to manage the specified
+   * [[akka.cluster.Cluster]] instance. This version does not provide Basic Authentication. It uses
+   * the specified path `pathPrefixName`.
+   */
+  def all(cluster: Cluster): akka.http.javadsl.server.Route =
+    RouteAdapter(akka.management.cluster.ClusterHttpManagementRoutes(cluster))
+
+  /**
+   * Creates an instance of [[ClusterHttpManagementRoutes]] to manage the specified
+   * [[akka.cluster.Cluster]] instance. This version does not provide Basic Authentication. It uses
+   * the specified path `pathPrefixName`.
+   */
+  def readOnly(cluster: Cluster): akka.http.javadsl.server.Route =
+    RouteAdapter(akka.management.cluster.ClusterHttpManagementRoutes.readOnly(cluster))
+
+}

--- a/cluster-http/src/test/java/jdoc/akka/cluster/http/management/CompileOnlyTest.java
+++ b/cluster-http/src/test/java/jdoc/akka/cluster/http/management/CompileOnlyTest.java
@@ -4,13 +4,28 @@
 package jdoc.akka.cluster.http.management;
 
 import akka.actor.ActorSystem;
-import akka.management.cluster.ClusterHttpManagement;
+import akka.management.AkkaManagement;
+import akka.cluster.Cluster;
+//#imports
+import akka.http.javadsl.server.Route;
+import akka.management.cluster.javadsl.ClusterHttpManagementRoutes;
+//#imports
 
 public class CompileOnlyTest {
     public static void example() {
         //#loading
-        ActorSystem as = ActorSystem.create();
-        ClusterHttpManagement httpMgmt = ClusterHttpManagement.get(as);
+        ActorSystem system = ActorSystem.create();
+        AkkaManagement.get(system).start();
         //#loading
+
+
+        //#all
+        Cluster cluster = Cluster.get(system);
+        Route allRoutes = ClusterHttpManagementRoutes.all(cluster);
+        //#all
+
+        //#read-only
+        Route readOnlyRoutes = ClusterHttpManagementRoutes.readOnly(cluster);
+        //#read-only
     }
 }

--- a/cluster-http/src/test/scala/doc/akka/cluster/http/management/CompileOnlySpec.scala
+++ b/cluster-http/src/test/scala/doc/akka/cluster/http/management/CompileOnlySpec.scala
@@ -4,12 +4,26 @@
 package doc.akka.cluster.http.management
 
 import akka.actor.ActorSystem
-import akka.management.cluster.ClusterHttpManagement
+import akka.cluster.Cluster
+import akka.http.scaladsl.server.Route
+import akka.management.AkkaManagement
+import akka.management.cluster.{ClusterHttpManagement, ClusterHttpManagementRoutes}
 
 object CompileOnlySpec {
 
   //#loading
   val system = ActorSystem()
-  val httpMgmt = ClusterHttpManagement(system)
+  // Automatically loads Cluster Http Routes
+  AkkaManagement(system).start()
   //#loading
+
+
+  //#all
+  val cluster = Cluster(system)
+  val allRoutes: Route = ClusterHttpManagementRoutes(cluster)
+  //#all
+
+  //#read-only
+  val readOnlyRoutes: Route = ClusterHttpManagementRoutes.readOnly(cluster)
+  //#read-only
 }

--- a/cluster-http/src/test/scala/doc/akka/cluster/http/management/CompileOnlySpec.scala
+++ b/cluster-http/src/test/scala/doc/akka/cluster/http/management/CompileOnlySpec.scala
@@ -7,7 +7,7 @@ import akka.actor.ActorSystem
 import akka.cluster.Cluster
 import akka.http.scaladsl.server.Route
 import akka.management.AkkaManagement
-import akka.management.cluster.{ClusterHttpManagement, ClusterHttpManagementRoutes}
+import akka.management.cluster.{ ClusterHttpManagement, ClusterHttpManagementRoutes }
 
 object CompileOnlySpec {
 
@@ -16,7 +16,6 @@ object CompileOnlySpec {
   // Automatically loads Cluster Http Routes
   AkkaManagement(system).start()
   //#loading
-
 
   //#all
   val cluster = Cluster(system)

--- a/docs/src/main/paradox/cluster-http-management.md
+++ b/docs/src/main/paradox/cluster-http-management.md
@@ -149,7 +149,7 @@ Example response:
 
 ## Hosting the routes in an existing Akka HTTP server
 
-Starting `AkkaMangement` starts an Akka HTTP server and hosts the Cluster HTTP Routes. The routes instead can be added
+Starting `AkkaMangement` starts an Akka HTTP server and hosts the Cluster HTTP Routes. The routes can also be added
 to an existing Akka HTTP server. To access all the routes:
 
 Scala
@@ -158,7 +158,7 @@ Scala
 Java
 :  @@snip [CompileOnlyTest.java](/cluster-http/src/test/java/jdoc/akka/cluster/http/management/CompileOnlyTest.java) { #all }
 
-Or for just the read only when destructive operations such as downing members isn't required:
+Just the read only routes can be accessed:
 
 Scala
 :  @@snip [CompileOnlySpec.scala](/cluster-http/src/test/scala/doc/akka/cluster/http/management/CompileOnlySpec.scala) { #read-only }

--- a/docs/src/main/paradox/cluster-http-management.md
+++ b/docs/src/main/paradox/cluster-http-management.md
@@ -146,3 +146,23 @@ Example response:
          }
        ]
      }
+
+## Hosting the routes in an existing Akka HTTP server
+
+Starting `AkkaMangement` starts an Akka HTTP server and hosts the Cluster HTTP Routes. The routes instead can be added
+to an existing Akka HTTP server. To access all the routes:
+
+Scala
+:  @@snip [CompileOnlySpec.scala](/cluster-http/src/test/scala/doc/akka/cluster/http/management/CompileOnlySpec.scala) { #all }
+
+Java
+:  @@snip [CompileOnlyTest.java](/cluster-http/src/test/java/jdoc/akka/cluster/http/management/CompileOnlyTest.java) { #all }
+
+Or for just the read only when destructive operations such as downing members isn't required:
+
+Scala
+:  @@snip [CompileOnlySpec.scala](/cluster-http/src/test/scala/doc/akka/cluster/http/management/CompileOnlySpec.scala) { #read-only }
+
+Java
+:  @@snip [CompileOnlyTest.java](/cluster-http/src/test/java/jdoc/akka/cluster/http/management/CompileOnlyTest.java) { #read-only }
+


### PR DESCRIPTION
* Add javadsl for accessing the routes
* Correct how to use Cluster HTTP
* Document how to use the routes outside of Akka management