### PR TITLE
Useful error message if pod name misconfigured

### DIFF
--- a/bootstrap-demo/kubernetes-api/src/main/resources/application.conf
+++ b/bootstrap-demo/kubernetes-api/src/main/resources/application.conf
@@ -22,6 +22,7 @@ akka.management {
 
       # pick the discovery method you'd like to use:
       discovery-method = akka.discovery.kubernetes-api
+
     }
   }
 }

--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/ClusterBootstrap.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/ClusterBootstrap.scala
@@ -42,11 +42,11 @@ final class ClusterBootstrap(implicit system: ExtendedActorSystem) extends Exten
     settings.contactPointDiscovery.discoveryMethod match {
       case "akka.discovery" ⇒
         val discovery = ServiceDiscovery(system).discovery
-        log.info("Bootstrap using default `akka.discovery` mechanism: {}", Logging.simpleName(discovery))
+        log.info("Bootstrap using default `akka.discovery` method: {}", Logging.simpleName(discovery))
         discovery
 
       case otherDiscoveryMechanism ⇒
-        log.info("Bootstrap using `akka.discovery` mechanism: {}", otherDiscoveryMechanism)
+        log.info("Bootstrap using `akka.discovery` method: {}", otherDiscoveryMechanism)
         ServiceDiscovery(system).loadServiceDiscovery(otherDiscoveryMechanism)
     }
 


### PR DESCRIPTION
Closes #343 

Results in a log like:

```
11/23 10:08:50 INFO [Appka-akka.actor.default-dispatcher-2] a.d.k.KubernetesApiSimpleServiceDiscovery - Querying for pods with label selector: [app=akka-bootstrap-demo]. Namespace: [akka-bootstrap]. Port: [doh] (from lookup? true)                                                                                                                                                                                                   
11/23 10:08:51 INFO [Appka-akka.actor.default-dispatcher-18] a.d.k.KubernetesApiSimpleServiceDiscovery - No targets found from pod list. Is the correct port name configured? Current configuration: [doh]. Ports on pods: [Set(ContainerPort(Some(remoting),2552), ContainerPort(Some(management),8558), ContainerPort(Some(http),8080))]                                                                                               
11/23 10:08:51 INFO [Appka-akka.actor.default-dispatcher-3] a.m.c.b.i.BootstrapCoordinator - Located service members based on: [Lookup(akka-bootstrap-demo,Some(doh),Some(tcp))]: []
11/
```