### PR TITLE
Remove dependency on java-scala-compat

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -118,8 +118,7 @@ object Dependencies {
   val DiscoveryAwsApiAsync = Seq(
     libraryDependencies ++=
       DependencyGroups.AkkaActor ++ Seq(
-        "software.amazon.awssdk" % "ecs" % "2.0.0-preview-9",
-        "org.scala-lang.modules" %% "scala-java8-compat" % "0.8.0")
+        "software.amazon.awssdk" % "ecs" % "2.0.0-preview-9")
   )
 
   val ManagementHttp = Seq(


### PR DESCRIPTION
It is brought in by Akka in a binary compatible way

Closes #398