### PR TITLE
EC2 tag based discovery: no longer block on default dispatcher

### DIFF
--- a/bootstrap-demo/aws-api-ec2/README.md
+++ b/bootstrap-demo/aws-api-ec2/README.md
@@ -93,7 +93,7 @@ Unzip the package and run the app like this on each instance:
 $ unzip app.zip
 $ cd app/bin
 $ MY_IP=`curl -s http://169.254.169.254/latest/meta-data/local-ipv4`
-$ ./akka-management-bootstrap-demo-aws-api-ec2-tag-based -Dakka.management.http.hostname=$MY_IP -Dakka.remote.netty.tcp.hostname=$MY_IP
+$ ./bootstrap-demo-aws-api-ec2-tag-based -Dakka.management.http.hostname=$MY_IP -Dakka.remote.netty.tcp.hostname=$MY_IP
 ```
 
 Follow the logs and watch for signs of successful cluster formation (e.g., a welcome message from one of the nodes). 

--- a/bootstrap-demo/aws-api-ec2/src/main/resources/CloudFormation/akka-cluster.json
+++ b/bootstrap-demo/aws-api-ec2/src/main/resources/CloudFormation/akka-cluster.json
@@ -71,7 +71,7 @@
               "cd app\n",
               "cd bin\n",
               "MY_IP=`curl -s http://169.254.169.254/latest/meta-data/local-ipv4`\n",
-              "./akka-management-bootstrap-demo-aws-api-ec2-tag-based -Dakka.management.http.hostname=$MY_IP -Dakka.remote.netty.tcp.hostname=$MY_IP &"
+              "./bootstrap-demo-aws-api-ec2-tag-based -Dakka.management.http.hostname=$MY_IP -Dakka.remote.netty.tcp.hostname=$MY_IP &"
             ]]
           }
         }

--- a/discovery-aws-api/src/main/resources/reference.conf
+++ b/discovery-aws-api/src/main/resources/reference.conf
@@ -2,15 +2,6 @@
 # Akka Service Discovery AWS Config                  #
 ######################################################
 
-ec2-tag-based-blocking-dispatcher {
-  type = Dispatcher
-  executor = "thread-pool-executor"
-  thread-pool-executor {
-    fixed-pool-size = 4
-  }
-  throughput = 1
-}
-
 akka.discovery {
   # Set the following in your application.conf if you want to use this discovery mechanism:
   # method = aws-api-ec2-tag-based

--- a/discovery-aws-api/src/main/resources/reference.conf
+++ b/discovery-aws-api/src/main/resources/reference.conf
@@ -2,6 +2,15 @@
 # Akka Service Discovery AWS Config                  #
 ######################################################
 
+ec2-tag-based-blocking-dispatcher {
+  type = Dispatcher
+  executor = "thread-pool-executor"
+  thread-pool-executor {
+    fixed-pool-size = 4
+  }
+  throughput = 1
+}
+
 akka.discovery {
   # Set the following in your application.conf if you want to use this discovery mechanism:
   # method = aws-api-ec2-tag-based

--- a/discovery-aws-api/src/main/scala/akka/discovery/awsapi/ec2/Ec2TagBasedSimpleServiceDiscovery.scala
+++ b/discovery-aws-api/src/main/scala/akka/discovery/awsapi/ec2/Ec2TagBasedSimpleServiceDiscovery.scala
@@ -51,7 +51,7 @@ class Ec2TagBasedSimpleServiceDiscovery(system: ActorSystem) extends SimpleServi
     AmazonEC2ClientBuilder.standard().withClientConfiguration(clientConfiguration).build()
   }
 
-  private implicit val ec: ExecutionContext = system.dispatchers.lookup("ec2-tag-based-blocking-dispatcher")
+  private implicit val ec: ExecutionContext = system.dispatchers.lookup("akka.actor.default-blocking-io-dispatcher")
 
   private val config = system.settings.config.getConfig("akka.discovery.aws-api-ec2-tag-based")
 

--- a/discovery-aws-api/src/main/scala/akka/discovery/awsapi/ec2/Ec2TagBasedSimpleServiceDiscovery.scala
+++ b/discovery-aws-api/src/main/scala/akka/discovery/awsapi/ec2/Ec2TagBasedSimpleServiceDiscovery.scala
@@ -51,7 +51,7 @@ class Ec2TagBasedSimpleServiceDiscovery(system: ActorSystem) extends SimpleServi
     AmazonEC2ClientBuilder.standard().withClientConfiguration(clientConfiguration).build()
   }
 
-  private implicit val ec: ExecutionContext = system.dispatcher
+  private implicit val ec: ExecutionContext = system.dispatchers.lookup("ec2-tag-based-blocking-dispatcher")
 
   private val config = system.settings.config.getConfig("akka.discovery.aws-api-ec2-tag-based")
 


### PR DESCRIPTION
Hopefully, the proper fix for  #377

**Note**: Tested against real AWS environment via the integration testing script .