### PR TITLE
Don't specify travis JDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ sudo: required
 dist: xenial
 language: scala
 
-jdk:
-  - oraclejdk8
-
 before_install:
   - curl -sL https://raw.githubusercontent.com/shyiko/jabba/0.10.1/install.sh | bash && . ~/.jabba/jabba.sh
 


### PR DESCRIPTION
As we use the one from Jabba anyway, and openjdk8 is no longer available on the Xenial images

Should fix #340