### PR TITLE
Implemented Kubernetes namespace discovery

### DIFF
--- a/bootstrap-demo/kubernetes-api-java/kubernetes/akka-cluster.yml
+++ b/bootstrap-demo/kubernetes-api-java/kubernetes/akka-cluster.yml
@@ -39,13 +39,6 @@ spec:
         - name: management
           containerPort: 8558
           protocol: TCP
-#namespace
-        env:
-        - name: NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-#namespace
 
 ---
 kind: Role

--- a/bootstrap-demo/kubernetes-api/kubernetes/akka-cluster.yml
+++ b/bootstrap-demo/kubernetes-api/kubernetes/akka-cluster.yml
@@ -49,13 +49,6 @@ spec:
         - name: http
           containerPort: 8080
           protocol: TCP
-#namespace
-        env:
-        - name: NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-#namespace
 
 ---
 kind: Role

--- a/discovery-kubernetes-api/src/main/resources/reference.conf
+++ b/discovery-kubernetes-api/src/main/resources/reference.conf
@@ -15,18 +15,15 @@ akka.discovery {
     api-service-host-env-name = "KUBERNETES_SERVICE_HOST"
     api-service-port-env-name = "KUBERNETES_SERVICE_PORT"
 
-    # Namespace to query for pods
-    pod-namespace = "default"
+    # Namespace discovery path
+    #
+    # If this path doesn't exist, the namespace will default to "default".
+    pod-namespace-path = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
 
-    # Picks up namespace from $NAMESPACE env var if set. Add the following to the container spec to avoid having to
-    # hard code this
-    # env:
-    # - name: NAMESPACE
-    #   valueFrom:
-    #    fieldRef:
-    #     fieldPath: metadata.namespace
-    # Can be removed once https://github.com/akka/akka-management/issues/345 is implemented
-    pod-namespace = ${?NAMESPACE}
+    # Namespace to query for pods.
+    #
+    # Set this value to a specific string to override discovering the namespace using pod-namespace-path.
+    pod-namespace = "<pod-namespace>"
 
     # Domain of the k8s cluster
     pod-domain = "cluster.local"

--- a/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/KubernetesApiSimpleServiceDiscovery.scala
+++ b/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/KubernetesApiSimpleServiceDiscovery.scala
@@ -4,8 +4,9 @@
 
 package akka.discovery.kubernetes
 
+import java.io.File
 import java.net.InetAddress
-import java.nio.file.Paths
+import java.nio.file.{ Files, Paths }
 
 import akka.actor.ActorSystem
 import akka.discovery._
@@ -91,12 +92,10 @@ class KubernetesApiSimpleServiceDiscovery(system: ActorSystem) extends SimpleSer
       case None => settings.podPortName
     }
     log.info("Querying for pods with label selector: [{}]. Namespace: [{}]. Port: [{}] (from lookup? {})",
-      labelSelector, settings.podNamespace, portName, query.portName.isDefined)
+      labelSelector, podNamespace, portName, query.portName.isDefined)
 
     for {
-      token <- apiToken()
-
-      request <- optionToFuture(podRequest(token, settings.podNamespace, labelSelector),
+      request <- optionToFuture(podRequest(apiToken, podNamespace, labelSelector),
         s"Unable to form request; check Kubernetes environment (expecting env vars ${settings.apiServiceHostEnvName}, ${settings.apiServicePortEnvName})")
 
       response <- http.singleRequest(request, httpsContext)
@@ -138,7 +137,7 @@ class KubernetesApiSimpleServiceDiscovery(system: ActorSystem) extends SimpleSer
       }
 
     } yield {
-      val addresses = targets(podList, portName, settings.podNamespace, settings.podDomain)
+      val addresses = targets(podList, portName, podNamespace, settings.podDomain)
       if (addresses.isEmpty && podList.items.nonEmpty) {
         if (log.isInfoEnabled) {
           val containerPortNames = podList.items.flatMap(_.spec).flatMap(_.containers).flatMap(_.ports).flatten.toSet
@@ -156,8 +155,29 @@ class KubernetesApiSimpleServiceDiscovery(system: ActorSystem) extends SimpleSer
     }
   }
 
-  private def apiToken() =
-    FileIO.fromPath(Paths.get(settings.apiTokenPath)).runFold("")(_ + _.utf8String).recover { case NonFatal(_) => "" }
+  private val apiToken = readConfigVarFromFilesystem(settings.apiTokenPath, "api-token") getOrElse ""
+
+  private val podNamespace = settings.podNamespace orElse
+    readConfigVarFromFilesystem(settings.podNamespacePath, "pod-namespace") getOrElse "default"
+
+  /**
+   * This uses blocking IO, and so should only be used to read configuration at startup.
+   */
+  private def readConfigVarFromFilesystem(path: String, name: String): Option[String] = {
+    val file = Paths.get(path)
+    if (Files.exists(file)) {
+      try {
+        Some(new String(Files.readAllBytes(file), "utf-8"))
+      } catch {
+        case NonFatal(e) =>
+          log.error(e, "Error reading {} from {}", name, path)
+          None
+      }
+    } else {
+      log.warning("Unable to read {} from {} because it doesn't exist.", name, path)
+      None
+    }
+  }
 
   private def optionToFuture[T](option: Option[T], failMsg: String): Future[T] =
     option.fold(Future.failed[T](new NoSuchElementException(failMsg)))(Future.successful)

--- a/docs/src/main/paradox/bootstrap/kubernetes-api.md
+++ b/docs/src/main/paradox/bootstrap/kubernetes-api.md
@@ -18,11 +18,9 @@ The following configuration is required:
 
 @@snip [akka-cluster.yml](/bootstrap-demo/kubernetes-api/src/main/resources/application.conf) { #discovery-config }
 
-The lookup needs to know which namespace to look in. This can be configured with
-`akka.discovery.kubernetes-api.pod-namespace` or it will be picked up via the `NAMESPACE` environment
-variable that can be injected into the pod via:
-
-@@snip [akka-cluster.yml](/bootstrap-demo/kubernetes-api/kubernetes/akka-cluster.yml)  { #namespace }
+The lookup needs to know which namespace to look in. By default, this will be detected by reading the namespace
+from the service account secret, in `/var/run/secrets/kubernetes.io/serviceaccount/namespace`, but can be overridden by
+setting `akka.discovery.kubernetes-api.pod-namespace`.
 
 For more details on how to configure the Kubernetes deployment see @ref:[recipes](recipes.md).
 


### PR DESCRIPTION
Fixes #345

This also changes the api token lookup so it's read once using blocking
IO at startup, rather than on every request.

Rebased version of https://github.com/akka/akka-management/pull/413