### PR TITLE
Small improvements to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,16 +1,25 @@
-# Contributing to Akka Cluster Management
+# Welcome! Thank you for contributing to Akka Cluster Management!
+
+We follow the standard GitHub [fork & pull](https://help.github.com/articles/using-pull-requests/#fork--pull) approach to pull requests. Just fork the official repo, develop in a branch, and submit a PR!
+
+You're always welcome to submit your PR straight away and start the discussion (without reading the rest of this wonderful doc, or the README.md). The goal of these notes is to make your experience contributing to Akka Management as smooth and pleasant as possible. We're happy to guide you through the process once you've submitted your PR.
+
+# The Akka Community
+
+In case of questions about the contribution process or for discussion of specific issues please visit the [akka/dev gitter chat](https://gitter.im/akka/dev).
+
+You may also check out these [other resources](https://akka.io/get-involved/).
 
 ## General Workflow
 
 This is the process for committing code into master.
 
 1. Make sure you have signed the Lightbend CLA, if not, [sign it online](http://www.lightbend.com/contribute/cla).
-2. Before starting to work on a feature or a fix, make sure that there is a ticket for your work in the [issue tracker](https://github.com/akka/akka-management/issues). If not, create it first.
+2. Especially for bigger features it can be good to create or find a ticket for your work in the [issue tracker](https://github.com/akka/akka-management/issues) and discuss your proposed solution there. This is not a requirement, but can avoid disappointment later in the process.
 3. Perform your work according to the [pull request requirements](#pull-request-requirements).
 4. When the feature or fix is completed you should open a [Pull Request](https://help.github.com/articles/using-pull-requests) on [GitHub](https://github.com/akka/akka-management/pulls).
 5. The Pull Request should be reviewed by other maintainers (as many as feasible/practical). Note that the maintainers can consist of outside contributors, both within and outside Lightbend. Outside contributors are encouraged to participate in the review process, it is not a closed process.
 6. After the review you should fix the issues (review comments, CI failures) by pushing a new commit for new review, iterating until the reviewers give their thumbs up and CI tests pass.
-7. If the branch merge conflicts with its target, rebase your branch onto the target branch.
 
 In case of questions about the contribution process or for discussion of specific issues please visit the [akka/dev gitter chat](https://gitter.im/akka/dev).
 


### PR DESCRIPTION
Clarify that contributors are expected to fork the project, and clarify that
creating a ticket up-front is not a requirement but might be smart for larger
ideas.