### PR TITLE
Rename cluster.healthcheck to cluster.health-check

### DIFF
--- a/cluster-http/src/main/resources/reference.conf
+++ b/cluster-http/src/main/resources/reference.conf
@@ -11,7 +11,7 @@ akka.management {
   http.route-providers += "akka.management.cluster.ClusterHttpManagement"
 
   cluster {
-    healthcheck {
+    health-check {
       # Ready health check returns 200 when cluster membership is in the following states.
       # Intended to be used to indicate this node is ready for user traffic so Up/WeaklyUp
       # Valid values: "Joining", "WeaklyUp", "Up", "Leaving", "Exiting", "Down", "Removed"

--- a/cluster-http/src/main/scala/akka/management/cluster/scaladsl/ClusterMembershipCheck.scala
+++ b/cluster-http/src/main/scala/akka/management/cluster/scaladsl/ClusterMembershipCheck.scala
@@ -45,7 +45,7 @@ final class ClusterMembershipCheck @InternalApi private[akka] (system: ActorSyst
 
   def this(system: ActorSystem) =
     this(system, () => Cluster(system).selfMember.status,
-      ClusterMembershipCheckSettings(system.settings.config.getConfig("akka.management.cluster.healthcheck")))
+      ClusterMembershipCheckSettings(system.settings.config.getConfig("akka.management.cluster.health-check")))
 
   override def apply(): Future[Boolean] = {
     Future.successful(settings.readyStates.contains(selfStatus()))

--- a/docs/src/main/paradox/cluster-http-management.md
+++ b/docs/src/main/paradox/cluster-http-management.md
@@ -169,9 +169,8 @@ Java
 
 ## Health checks
 
-Two health checks are included in Cluster HTTP:
+A cluster membership @ref:[health check](healthchecks.md) is included that is designed to be used as a readiness check.
 
-* `/ready` - indicated that user traffic should be routed to the node. By defailt returns `200` when a node is either `Up` or `WeaklyUp`. Can be configured with `akka.management.cluster.http.heathcheck.ready-states`.
-* `/alive` - always returns 200. Can be used to check the process is running and responsive.
+By default the health check returns `true` when a node is either `Up` or `WeaklyUp`. Can be configured with `akka.management.cluster.heath-checks.ready-states`.
 
 


### PR DESCRIPTION
To keep is consistent with akka management property named
`health-checks`

This looked bad in the same reference.conf using healthcheck and health-check