### PR TITLE
Bump Akka to 2.5.20

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import Keys._
 
 object Dependencies {
 
-  val AkkaVersion = "2.5.19"
+  val AkkaVersion = "2.5.20"
   val AkkaHttpVersion = "10.1.7"
 
   val JUnitVersion = "4.12"


### PR DESCRIPTION
Related https://github.com/lagom/lagom-minimal-deployment-sample/pull/1

Note: some usages of Lagom clustering don't bring in sharding or ddata so there's not eviction. As a consequence the version in akka-management (`2.5.19`) is used.