### PR TITLE
Update spray-json dependency to 1.3.5

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val AkkaHttpVersion = "10.1.7"
 
   val JUnitVersion = "4.12"
-  val SprayJsonVersion = "1.3.3"
+  val SprayJsonVersion = "1.3.5"
 
   val Common = Seq(
     libraryDependencies ++= Seq(


### PR DESCRIPTION
It was already effectively using 1.3.5 in the build, due to a transitive dependency from akka-http-spray-json. However, the published POM included the 1.3.3 dependency, causing downstream artifacts depending on Akka Management to resolve this incorrectly.

See https://github.com/lagom/lagom/pull/1454 for example.