### PR TITLE
Renaming "ecs-bootstrap-demo-app" to "ecs-integration-test-app"

### DIFF
--- a/integration-test/aws-api-ecs/cfn-templates/ecs-integration-test-app-infrastructure.yaml
+++ b/integration-test/aws-api-ecs/cfn-templates/ecs-integration-test-app-infrastructure.yaml
@@ -3,4 +3,4 @@ Resources:
   Repository:
     Type: AWS::ECR::Repository
     Properties:
-      RepositoryName: "ecs-bootstrap-demo-app"
+      RepositoryName: "ecs-integration-test-app"

--- a/integration-test/aws-api-ecs/cfn-templates/ecs-integration-test-app.yaml
+++ b/integration-test/aws-api-ecs/cfn-templates/ecs-integration-test-app.yaml
@@ -6,7 +6,7 @@ Resources:
   Cluster:
     Type: AWS::ECS::Cluster
     Properties:
-      ClusterName: "ecs-bootstrap-demo-app"
+      ClusterName: "ecs-integration-test-app"
   LogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
@@ -59,9 +59,9 @@ Resources:
       ExecutionRoleArn: !GetAtt ExecutionRole.Arn
       TaskRoleArn: !GetAtt TaskRole.Arn
       ContainerDefinitions:
-        - Name: ecs-bootstrap-demo-app
+        - Name: ecs-integration-test-app
           Image:
-            !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/ecs-bootstrap-demo-app:1.0"
+            !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/ecs-integration-test-app:1.0"
           ReadonlyRootFilesystem: true
           LogConfiguration:
             LogDriver: awslogs
@@ -73,7 +73,7 @@ Resources:
             - Name: JAVA_OPTS
               Value: !Sub "-Dakka.management.cluster.bootstrap.\
                 contact-point-discovery.service-name=${AWS::StackName}
-                -Dakka.discovery.aws-api-ecs-async.cluster=ecs-bootstrap-demo-app"
+                -Dakka.discovery.aws-api-ecs-async.cluster=ecs-integration-test-app"
   ServiceSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:

--- a/integration-test/aws-api-ecs/scripts/deploy-infrastructure.sh
+++ b/integration-test/aws-api-ecs/scripts/deploy-infrastructure.sh
@@ -22,9 +22,9 @@ esac
 
 aws cloudformation $ACTION-stack \
   --region us-east-1 \
-  --stack-name ecs-bootstrap-demo-app-infrastructure \
-  --template-body file://$DIR/../cfn-templates/ecs-bootstrap-demo-app-infrastructure.yaml
+  --stack-name ecs-integration-test-app-infrastructure \
+  --template-body file://$DIR/../cfn-templates/ecs-integration-test-app-infrastructure.yaml
 
 aws cloudformation wait stack-$ACTION-complete \
   --region us-east-1 \
-  --stack-name ecs-bootstrap-demo-app-infrastructure
+  --stack-name ecs-integration-test-app-infrastructure

--- a/integration-test/aws-api-ecs/scripts/deploy.sh
+++ b/integration-test/aws-api-ecs/scripts/deploy.sh
@@ -42,12 +42,12 @@ SUBNETS=$(
 
 aws cloudformation $ACTION-stack \
   --region us-east-1 \
-  --stack-name ecs-bootstrap-demo-app \
-  --template-body file://$DIR/../cfn-templates/ecs-bootstrap-demo-app.yaml \
+  --stack-name ecs-integration-test-app \
+  --template-body file://$DIR/../cfn-templates/ecs-integration-test-app.yaml \
   --capabilities CAPABILITY_IAM \
   --parameters \
     ParameterKey=Subnets,ParameterValue=\"$SUBNETS\"
 
 aws cloudformation wait stack-$ACTION-complete \
   --region us-east-1 \
-  --stack-name ecs-bootstrap-demo-app
+  --stack-name ecs-integration-test-app

--- a/integration-test/aws-api-ecs/scripts/publish.sh
+++ b/integration-test/aws-api-ecs/scripts/publish.sh
@@ -10,7 +10,7 @@ fi
 
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
-(cd $DIR/../../.. && sbt bootstrap-demo-aws-api-ecs/docker:publishLocal)
+(cd $DIR/../../.. && sbt integration-test-aws-api-ecs/docker:publishLocal)
 
 eval $(
   aws ecr get-login \
@@ -26,14 +26,14 @@ AWS_ACCOUNT_ID=$(
 )
 
 docker tag \
-  ecs-bootstrap-demo-app:1.0 \
-  $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/ecs-bootstrap-demo-app:1.0
+  ecs-integration-test-app:1.0 \
+  $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/ecs-integration-test-app:1.0
 
 docker push \
-  $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/ecs-bootstrap-demo-app:1.0
+  $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/ecs-integration-test-app:1.0
 
 docker rmi \
-  ecs-bootstrap-demo-app:1.0
+  ecs-integration-test-app:1.0
 
 docker rmi \
-  $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/ecs-bootstrap-demo-app:1.0
+  $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/ecs-integration-test-app:1.0


### PR DESCRIPTION
There were issues running the `aws-api-ecs` integration test, because the application name wasn't modified correctly.
Added all the required changes, and tested it.