### PR TITLE
Allow setting base path with slashes

### DIFF
--- a/management/src/main/scala/akka/management/scaladsl/AkkaManagement.scala
+++ b/management/src/main/scala/akka/management/scaladsl/AkkaManagement.scala
@@ -31,6 +31,7 @@ import akka.http.scaladsl.server.Directives
 import akka.http.scaladsl.server.Directives.authenticateBasicAsync
 import akka.http.scaladsl.server.Directives.pathPrefix
 import akka.http.scaladsl.server.Directives.rawPathPrefix
+import akka.http.scaladsl.server.PathMatchers
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.server.RouteResult
 import akka.http.scaladsl.server.directives.Credentials
@@ -166,7 +167,11 @@ final class AkkaManagement(implicit private[akka] val system: ExtendedActorSyste
   private def prepareCombinedRoutes(providerSettings: ManagementRouteProviderSettings): Route = {
     val basePath: Directive[Unit] = {
       val pathPrefixName = settings.Http.BasePath.getOrElse("")
-      if (pathPrefixName.isEmpty) rawPathPrefix(pathPrefixName) else pathPrefix(pathPrefixName)
+      if (pathPrefixName.isEmpty) {
+        rawPathPrefix(pathPrefixName)
+      } else {
+        pathPrefix(PathMatchers.separateOnSlashes(pathPrefixName))
+      }
     }
 
     def wrapWithAuthenticatorIfPresent(inner: Route): Route = {


### PR DESCRIPTION
Currently Akka Management does not support specifying `base-path` with slashes. They are accepted (no exceptions are thrown), but URL-escaped to `%2F` under the hood. My company has specific rules, which determine how paths for internal service endpoints should look like. And these rules have slashes. So this PR adds possibility to define any `base-path`, with our without slashes, while maintaining full backwards compatibility.