### PR TITLE
Don't use akka-mgmt-http in tests anymore

### DIFF
--- a/discovery-kubernetes-api/src/test/resources/pods.json
+++ b/discovery-kubernetes-api/src/test/resources/pods.json
@@ -55,7 +55,7 @@
                 "protocol": "TCP"
               },
               {
-                "name": "akka-mgmt-http",
+                "name": "management",
                 "containerPort": 10001,
                 "protocol": "TCP"
               },
@@ -404,7 +404,7 @@
                 "protocol": "TCP"
               },
               {
-                "name": "akka-mgmt-http",
+                "name": "management",
                 "containerPort": 10001,
                 "protocol": "TCP"
               },
@@ -754,7 +754,7 @@
                 "protocol": "TCP"
               },
               {
-                "name": "akka-mgmt-http",
+                "name": "management",
                 "containerPort": 10001,
                 "protocol": "TCP"
               },

--- a/discovery-kubernetes-api/src/test/scala/akka/discovery/kubernetes/JsonFormatSpec.scala
+++ b/discovery-kubernetes-api/src/test/scala/akka/discovery/kubernetes/JsonFormatSpec.scala
@@ -25,7 +25,7 @@ class JsonFormatSpec extends WordSpec with Matchers {
                   List(
                     Container(
                       "akka-cluster-tooling-example",
-                      Some(List(ContainerPort(Some("akka-remote"), 10000), ContainerPort(Some("akka-mgmt-http"), 10001), ContainerPort(Some("http"), 10002))))))),
+                      Some(List(ContainerPort(Some("akka-remote"), 10000), ContainerPort(Some("management"), 10001), ContainerPort(Some("http"), 10002))))))),
                 Some(PodStatus(Some("172.17.0.4"))), Some(Metadata(deletionTimestamp = None))),
 
             Pod(
@@ -34,7 +34,7 @@ class JsonFormatSpec extends WordSpec with Matchers {
                   List(
                     Container(
                       "akka-cluster-tooling-example",
-                      Some(List(ContainerPort(Some("akka-remote"), 10000), ContainerPort(Some("akka-mgmt-http"), 10001), ContainerPort(Some("http"), 10002))))))),
+                      Some(List(ContainerPort(Some("akka-remote"), 10000), ContainerPort(Some("management"), 10001), ContainerPort(Some("http"), 10002))))))),
                 Some(PodStatus(Some("172.17.0.6"))), Some(Metadata(deletionTimestamp = None))),
 
             Pod(
@@ -43,7 +43,7 @@ class JsonFormatSpec extends WordSpec with Matchers {
                   List(
                     Container(
                       "akka-cluster-tooling-example",
-                      Some(List(ContainerPort(Some("akka-remote"), 10000), ContainerPort(Some("akka-mgmt-http"), 10001), ContainerPort(Some("http"), 10002))))))),
+                      Some(List(ContainerPort(Some("akka-remote"), 10000), ContainerPort(Some("management"), 10001), ContainerPort(Some("http"), 10002))))))),
                   Some(PodStatus(Some("172.17.0.7"))), Some(Metadata(deletionTimestamp = Some("2017-12-06T16:30:22Z"))))))
     }
   }

--- a/discovery-kubernetes-api/src/test/scala/akka/discovery/kubernetes/KubernetesApiServiceDiscoverySpec.scala
+++ b/discovery-kubernetes-api/src/test/scala/akka/discovery/kubernetes/KubernetesApiServiceDiscoverySpec.scala
@@ -15,15 +15,15 @@ class KubernetesApiServiceDiscoverySpec extends WordSpec with Matchers {
     "calculate the correct list of resolved targets" in {
       val podList =
         PodList(List(Pod(Some(PodSpec(List(Container("akka-cluster-tooling-example",
-                      Some(List(ContainerPort(Some("akka-remote"), 10000),
-                          ContainerPort(Some("akka-mgmt-http"), 10001), ContainerPort(Some("http"), 10002))))))),
-              Some(PodStatus(Some("172.17.0.4"))), Some(Metadata(deletionTimestamp = None))),
+                      Some(List(ContainerPort(Some("akka-remote"), 10000), ContainerPort(Some("management"), 10001),
+                          ContainerPort(Some("http"), 10002))))))), Some(PodStatus(Some("172.17.0.4"))),
+              Some(Metadata(deletionTimestamp = None))),
             Pod(Some(PodSpec(List(Container("akka-cluster-tooling-example",
-                      Some(List(ContainerPort(Some("akka-remote"), 10000),
-                          ContainerPort(Some("akka-mgmt-http"), 10001), ContainerPort(Some("http"), 10002))))))),
-              Some(PodStatus(None)), Some(Metadata(deletionTimestamp = None)))))
+                      Some(List(ContainerPort(Some("akka-remote"), 10000), ContainerPort(Some("management"), 10001),
+                          ContainerPort(Some("http"), 10002))))))), Some(PodStatus(None)),
+              Some(Metadata(deletionTimestamp = None)))))
 
-      KubernetesApiServiceDiscovery.targets(podList, "akka-mgmt-http", "default", "cluster.local") shouldBe List(
+      KubernetesApiServiceDiscovery.targets(podList, "management", "default", "cluster.local") shouldBe List(
           ResolvedTarget(
             host = "172-17-0-4.default.pod.cluster.local",
             port = Some(10001),
@@ -34,11 +34,11 @@ class KubernetesApiServiceDiscoverySpec extends WordSpec with Matchers {
     "ignore deleted pods" in {
       val podList =
         PodList(List(Pod(Some(PodSpec(List(Container("akka-cluster-tooling-example",
-                      Some(List(ContainerPort(Some("akka-remote"), 10000),
-                          ContainerPort(Some("akka-mgmt-http"), 10001), ContainerPort(Some("http"), 10002))))))),
-              Some(PodStatus(Some("172.17.0.4"))), Some(Metadata(deletionTimestamp = Some("2017-12-06T16:30:22Z"))))))
+                      Some(List(ContainerPort(Some("akka-remote"), 10000), ContainerPort(Some("management"), 10001),
+                          ContainerPort(Some("http"), 10002))))))), Some(PodStatus(Some("172.17.0.4"))),
+              Some(Metadata(deletionTimestamp = Some("2017-12-06T16:30:22Z"))))))
 
-      KubernetesApiServiceDiscovery.targets(podList, "akka-mgmt-http", "default", "cluster.local") shouldBe List.empty
+      KubernetesApiServiceDiscovery.targets(podList, "management", "default", "cluster.local") shouldBe List.empty
     }
   }
 }

--- a/discovery-marathon-api/src/test/resources/apps.json
+++ b/discovery-marathon-api/src/test/resources/apps.json
@@ -18,7 +18,7 @@
                         "containerPort": 0,
                         "hostPort": 0,
                         "labels": {},
-                        "name": "akka-mgmt-http",
+                        "name": "management",
                         "protocol": "tcp",
                         "servicePort": 10005
                     }
@@ -112,7 +112,7 @@
                 {
                     "port": 10000,
                     "protocol": "tcp",
-                    "name": "akka-mgmt-http"
+                    "name": "management"
                 },
                 {
                     "port": 10001,

--- a/discovery-marathon-api/src/test/scala/akka/discovery/marathon/MarathonApiServiceDiscoverySpec.scala
+++ b/discovery-marathon-api/src/test/scala/akka/discovery/marathon/MarathonApiServiceDiscoverySpec.scala
@@ -18,11 +18,10 @@ class MarathonApiServiceDiscoverySpec extends WordSpec with Matchers {
 
       val appList = JsonFormat.appListFormat.read(data.parseJson)
 
-      MarathonApiServiceDiscovery.targets(appList, "akka-mgmt-http") shouldBe List(
-          ResolvedTarget(host = "192.168.65.60", port = Some(23236),
-            address = Option(InetAddress.getByName("192.168.65.60"))),
-          ResolvedTarget(host = "192.168.65.111", port = Some(6850),
-            address = Option(InetAddress.getByName("192.168.65.111"))))
+      MarathonApiServiceDiscovery.targets(appList, "management") shouldBe List(ResolvedTarget(host = "192.168.65.60",
+          port = Some(23236), address = Option(InetAddress.getByName("192.168.65.60"))),
+        ResolvedTarget(host = "192.168.65.111", port = Some(6850),
+          address = Option(InetAddress.getByName("192.168.65.111"))))
     }
     "calculate the correct list of resolved targets for docker" in {
       val data = resourceAsString("docker-app.json")


### PR DESCRIPTION
We are now standardizing on 'management'. It should make no difference
for these tests, but might save some confusion.