### PR TITLE
Pass in bootstrap service name through environment variable

### DIFF
--- a/cluster-bootstrap/src/main/resources/reference.conf
+++ b/cluster-bootstrap/src/main/resources/reference.conf
@@ -25,8 +25,10 @@ akka.management {
     contact-point-discovery {
 
       # Define this name to be looked up in service discovery for "neighboring" nodes
-      # If undefined, the name will be extracted from the ActorSystem name
+      # If undefined, the name will be taken from the AKKA_CLUSTER_BOOTSTRAP_SERVICE_NAME
+      # environment variable or extracted from the ActorSystem name
       service-name = "<service-name>"
+      service-name = ${?AKKA_CLUSTER_BOOTSTRAP_SERVICE_NAME}
 
       # The portName passed to discovery. This should be set to the name of the port for Akka Management
       # If set to "" None is passed

--- a/integration-test/dns-api-mesos/src/main/resources/application.conf
+++ b/integration-test/dns-api-mesos/src/main/resources/application.conf
@@ -37,7 +37,8 @@ akka {
       contact-point-discovery {
 
         # Define this name to be looked up in service discovery for "neighboring" nodes
-        # If undefined, the name will be extracted from the ActorSystem name
+        # If undefined, the name will be taken from the AKKA_CLUSTER_BOOTSTRAP_SERVICE_NAME
+        # environment variable or extracted from the ActorSystem name
         service-name = ${MARATHON_APP_ID}
 
         # Added as suffix to the service-name to build the effective-service name used in the contact-point service lookups

--- a/integration-test/kubernetes-api-java/kubernetes/akka-cluster.yml
+++ b/integration-test/kubernetes-api-java/kubernetes/akka-cluster.yml
@@ -38,6 +38,15 @@ spec:
         - name: management
           containerPort: 8558
           protocol: TCP
+        env:
+        # The Kubernetes API discovery will use this service name to look for
+        # nodes with this value in the 'app' label
+        # This can be customized with the 'pod-label-selector' setting.
+        - name: AKKA_CLUSTER_BOOTSTRAP_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: "metadata.labels['app']"
 
 ---
 kind: Role

--- a/integration-test/kubernetes-api-java/src/main/resources/application.conf
+++ b/integration-test/kubernetes-api-java/src/main/resources/application.conf
@@ -8,21 +8,16 @@ akka {
 #discovery-config
 akka.discovery {
   kubernetes-api {
-    pod-label-selector = "app=%s" # same as the default
+    # in fact, this is already the default:
+    pod-label-selector = "app=%s"
   }
 }
 #discovery-config
 
-#management-config
 akka.management {
   cluster.bootstrap {
     contact-point-discovery {
-      # For the kubernetes API this value is substributed into the %s in pod-label-selector
-      service-name = "akka-bootstrap-demo"
-
-      # pick the discovery method you'd like to use:
       discovery-method = kubernetes-api
     }
   }
 }
-#management-config

--- a/integration-test/kubernetes-api-java/test.sh
+++ b/integration-test/kubernetes-api-java/test.sh
@@ -23,7 +23,7 @@ done
 
 if [ $i -eq 10 ]
 then
-  echo "Pods did not get ready"
+  echo "*** Pods did not get ready ***"
   exit -1
 fi
 
@@ -39,7 +39,7 @@ done
 
 if [ $i -eq 10 ]
 then
-  echo "No 3 MemberUp log events found"
+  echo "*** No 3 MemberUp log events found ***"
   kubectl get pods -n $NAMESPACE
   echo "=============================="
   for POD in $(kubectl get pods -n $NAMESPACE | grep akka-bootstrap-demo | grep Running | awk '{ print $1 }')

--- a/integration-test/kubernetes-api-java/test.sh
+++ b/integration-test/kubernetes-api-java/test.sh
@@ -29,7 +29,7 @@ fi
 
 POD=$(kubectl get pods -n $NAMESPACE | grep akka-bootstrap-demo | grep Running | head -n1 | awk '{ print $1 }')
 
-for i in {1..10}
+for i in {1..15}
 do
   echo "Checking for MemberUp logging..."
   kubectl logs $POD -n $NAMESPACE | grep MemberUp || true
@@ -37,7 +37,7 @@ do
   sleep 3
 done
 
-if [ $i -eq 10 ]
+if [ $i -eq 15 ]
 then
   echo "*** No 3 MemberUp log events found ***"
   kubectl get pods -n $NAMESPACE

--- a/integration-test/kubernetes-api/kubernetes/akka-cluster.yml
+++ b/integration-test/kubernetes-api/kubernetes/akka-cluster.yml
@@ -47,6 +47,15 @@ spec:
         - name: management
           containerPort: 8558
           protocol: TCP
+        env:
+        # The Kubernetes API discovery will use this service name to look for
+        # nodes with this value in the 'app' label.
+        # This can be customized with the 'pod-label-selector' setting.
+        - name: AKKA_CLUSTER_BOOTSTRAP_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: "metadata.labels['app']"
 #deployment
 ---
 #rbac

--- a/integration-test/kubernetes-api/src/main/resources/application.conf
+++ b/integration-test/kubernetes-api/src/main/resources/application.conf
@@ -8,22 +8,16 @@ akka {
 #discovery-config
 akka.discovery {
   kubernetes-api {
-    pod-label-selector = "app=%s" # same as the default
+    # in fact, this is already the default:
+    pod-label-selector = "app=%s"
   }
 }
 #discovery-config
 
-#management-config
 akka.management {
   cluster.bootstrap {
     contact-point-discovery {
-      # For the kubernetes API this value is substributed into the %s in pod-label-selector
-      service-name = "akka-bootstrap-demo"
-
-      # pick the discovery method you'd like to use:
       discovery-method = kubernetes-api
-
     }
   }
 }
-#management-config

--- a/integration-test/kubernetes-dns/kubernetes/akka-cluster.yml
+++ b/integration-test/kubernetes-dns/kubernetes/akka-cluster.yml
@@ -49,6 +49,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        # The DNS-based discovery will use this service name to look for the headless
+        # service defined below
+        - name: AKKA_CLUSTER_BOOTSTRAP_SERVICE_NAME
+          value: "integration-test-kubernetes-dns-internal"
 
 ---
 #headless

--- a/integration-test/kubernetes-dns/src/main/resources/application.conf
+++ b/integration-test/kubernetes-dns/src/main/resources/application.conf
@@ -14,11 +14,6 @@ akka {
 akka.management {
   cluster.bootstrap {
     contact-point-discovery {
-      port-name = "management"
-      protocol = "tcp"
-      service-name = "integration-test-kubernetes-dns-internal"
-      # Can be removed for Akka 2.5.20
-      service-namespace = ${NAMESPACE}".svc.cluster.local"
       discovery-method = akka-dns
     }
   }


### PR DESCRIPTION
By passing it in as an environment variable, the values that should line up for
bootstrap to be successful are all in the deployment .yml, instead of being
spread across the deployment .yml and the packaged application.conf.

Refs #411