### PR TITLE
Remove pod-port-name option from kubernetes-api discovery

### DIFF
--- a/discovery-kubernetes-api/src/main/resources/reference.conf
+++ b/discovery-kubernetes-api/src/main/resources/reference.conf
@@ -31,10 +31,5 @@ akka.discovery {
     # Selector value to query pod API with.
     # `%s` will be replaced with the configured effective name, which defaults to the actor system name
     pod-label-selector = "app=%s"
-
-    # Only used in the case that Lookup.portName is not set. Bootstrap sets this from
-    # akka.management.cluster.bootstrap.contact-point-discovery.port-name
-    # This name must match the ports name in the deployment resource YAML.
-    pod-port-name = "management"
   }
 }

--- a/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/KubernetesApiServiceDiscovery.scala
+++ b/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/KubernetesApiServiceDiscovery.scala
@@ -93,7 +93,7 @@ class KubernetesApiServiceDiscovery(system: ActorSystem) extends ServiceDiscover
     val labelSelector = settings.podLabelSelector(query.serviceName)
 
     log.info("Querying for pods with label selector: [{}]. Namespace: [{}]. Port: [{}]", labelSelector, podNamespace,
-      query.portName, query.portName.isDefined)
+      query.portName)
 
     for {
       request <- optionToFuture(podRequest(apiToken, podNamespace, labelSelector),

--- a/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/KubernetesApiServiceDiscovery.scala
+++ b/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/KubernetesApiServiceDiscovery.scala
@@ -8,6 +8,7 @@ import java.net.InetAddress
 import java.nio.file.{ Files, Paths }
 
 import akka.actor.ActorSystem
+import akka.annotation.InternalApi
 import akka.discovery._
 import akka.http.scaladsl._
 import akka.http.scaladsl.model._
@@ -30,9 +31,12 @@ import akka.event.Logging
 object KubernetesApiServiceDiscovery {
 
   /**
+   * INTERNAL API
+   *
    * Finds relevant targets given a pod list. Note that this doesn't filter by name as it is the job of the selector
    * to do that.
    */
+  @InternalApi
   private[kubernetes] def targets(podList: PodList,
                                   portName: Option[String],
                                   podNamespace: String,

--- a/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/Settings.scala
+++ b/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/Settings.scala
@@ -55,12 +55,9 @@ final class Settings(system: ExtendedActorSystem) extends Extension {
   def podLabelSelector(name: String): String =
     kubernetesApi.getString("pod-label-selector").format(name)
 
-  val podPortName: String =
-    kubernetesApi.getString("pod-port-name")
-
   override def toString =
     s"Settings($apiCaPath, $apiTokenPath, $apiServiceHostEnvName, $apiServicePortEnvName, " +
-    s"$podNamespacePath, $podNamespace, $podDomain, $podPortName)"
+    s"$podNamespacePath, $podNamespace, $podDomain)"
 }
 
 object Settings extends ExtensionId[Settings] with ExtensionIdProvider {

--- a/discovery-kubernetes-api/src/test/scala/akka/discovery/kubernetes/KubernetesApiServiceDiscoverySpec.scala
+++ b/discovery-kubernetes-api/src/test/scala/akka/discovery/kubernetes/KubernetesApiServiceDiscoverySpec.scala
@@ -23,7 +23,7 @@ class KubernetesApiServiceDiscoverySpec extends WordSpec with Matchers {
                           ContainerPort(Some("http"), 10002))))))), Some(PodStatus(None)),
               Some(Metadata(deletionTimestamp = None)))))
 
-      KubernetesApiServiceDiscovery.targets(podList, "management", "default", "cluster.local") shouldBe List(
+      KubernetesApiServiceDiscovery.targets(podList, Some("management"), "default", "cluster.local") shouldBe List(
           ResolvedTarget(
             host = "172-17-0-4.default.pod.cluster.local",
             port = Some(10001),
@@ -38,7 +38,8 @@ class KubernetesApiServiceDiscoverySpec extends WordSpec with Matchers {
                           ContainerPort(Some("http"), 10002))))))), Some(PodStatus(Some("172.17.0.4"))),
               Some(Metadata(deletionTimestamp = Some("2017-12-06T16:30:22Z"))))))
 
-      KubernetesApiServiceDiscovery.targets(podList, "management", "default", "cluster.local") shouldBe List.empty
+      KubernetesApiServiceDiscovery.targets(podList, Some("management"), "default",
+        "cluster.local") shouldBe List.empty
     }
   }
 }

--- a/docs/src/main/paradox/discovery/kubernetes.md
+++ b/docs/src/main/paradox/discovery/kubernetes.md
@@ -37,9 +37,6 @@ akka.discovery {
     # %s will be replaced with the configured effective name, which defaults to
     # the actor system name
     pod-label-selector = "app=%s"
-
-    # This name must match the ports name in the deployment resource YAML.
-    pod-port-name = "management"
   }
 }
 ```
@@ -72,9 +69,9 @@ spec:
         - name: remoting
           containerPort: 2552
           protocol: TCP
-        # akka-management bootstrap
-        # This name must match the name defined in
-        # akka.discovery.kubernetes-api.pod-port-name configuration
+        # When
+        # akka.management.cluster.bootstrap.contact-point-discovery.port-name
+        # is defined, it must correspond to this name:
         - name: management
           containerPort: 8558
           protocol: TCP

--- a/integration-test/scripts/kubernetes-test.sh
+++ b/integration-test/scripts/kubernetes-test.sh
@@ -19,7 +19,7 @@ fi
 
 POD=$(kubectl get pods -n $NAMESPACE | grep $APP_NAME | grep Running | head -n1 | awk '{ print $1 }')
 
-for i in {1..10}
+for i in {1..15}
 do
   echo "Checking for MemberUp logging..."
   kubectl logs $POD -n $NAMESPACE | grep MemberUp || true
@@ -36,7 +36,7 @@ do
 done
 
 
-if [ $i -eq 10 ]
+if [ $i -eq 15 ]
 then
   echo "No 3 MemberUp log events found"
   echo "=============================="


### PR DESCRIPTION
It does not make sense to configure a default at this level. It might make
sense to configure a default at the cluster-bootstrap level.

If no port name is specified in the query, return all ports.

Simplification triggered by the discussion in #464