### PR TITLE
By default assume akka-management.http.port for bootstrap

### DIFF
--- a/cluster-bootstrap/src/main/resources/reference.conf
+++ b/cluster-bootstrap/src/main/resources/reference.conf
@@ -101,8 +101,8 @@ akka.management {
 
       # If no port is discovered along with the host/ip of a contact point this port will be used as fallback
       # Also, when no port-name is used and multiple results are returned for a given service, this port is
-      # used to disambiguate. When 0, defaults to the value of akka.management.http.port
-      fallback-port = 0 # port pun, it "complements" 2552 which is often used for Akka remoting
+      # used to disambiguate. When set to <fallback-port>, defaults to the value of akka.management.http.port
+      fallback-port = "<fallback-port>" # port pun, it "complements" 2552 which is often used for Akka remoting
 
       # If some discovered seed node will keep failing to connect for specified period of time,
       # it will initiate rediscovery again instead of keep trying.

--- a/cluster-bootstrap/src/main/resources/reference.conf
+++ b/cluster-bootstrap/src/main/resources/reference.conf
@@ -100,7 +100,9 @@ akka.management {
     contact-point {
 
       # If no port is discovered along with the host/ip of a contact point this port will be used as fallback
-      fallback-port = 8558 # port pun, it "complements" 2552 which is often used for Akka remoting
+      # Also, when no port-name is used and multiple results are returned for a given service, this port is
+      # used to disambiguate. When 0, defaults to the value of akka.management.http.port
+      fallback-port = 0 # port pun, it "complements" 2552 which is often used for Akka remoting
 
       # If some discovered seed node will keep failing to connect for specified period of time,
       # it will initiate rediscovery again instead of keep trying.

--- a/cluster-bootstrap/src/main/resources/reference.conf
+++ b/cluster-bootstrap/src/main/resources/reference.conf
@@ -31,8 +31,8 @@ akka.management {
       service-name = ${?AKKA_CLUSTER_BOOTSTRAP_SERVICE_NAME}
 
       # The portName passed to discovery. This should be set to the name of the port for Akka Management
-      # If set to "" None is passed
-      port-name = "management"
+      # If set to "" None is passed and ${akka.management.http.port} is assumed.
+      port-name = ""
 
       # The protocol passed to discovery.
       # If set to "" None is passed.

--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/ClusterBootstrapSettings.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/ClusterBootstrapSettings.scala
@@ -123,7 +123,11 @@ final class ClusterBootstrapSettings(config: Config, log: LoggingAdapter) {
     private val contactPointConfig = bootConfig.getConfig("contact-point")
 
     // FIXME this has to be the same as the management one, we currently override this value when starting management, any better way?
-    val fallbackPort: Int = contactPointConfig.getInt("fallback-port")
+    val fallbackPort: Int =
+      contactPointConfig
+        .optDefinedValue("fallback-port")
+        .map(_.toInt)
+        .getOrElse(config.getInt("akka.management.http.port"))
 
     val probingFailureTimeout: FiniteDuration =
       contactPointConfig.getDuration("probing-failure-timeout", TimeUnit.MILLISECONDS).millis

--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/ClusterBootstrapSettings.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/ClusterBootstrapSettings.scala
@@ -122,7 +122,6 @@ final class ClusterBootstrapSettings(config: Config, log: LoggingAdapter) {
   object contactPoint {
     private val contactPointConfig = bootConfig.getConfig("contact-point")
 
-    // FIXME this has to be the same as the management one, we currently override this value when starting management, any better way?
     val fallbackPort: Int =
       contactPointConfig
         .optDefinedValue("fallback-port")

--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/internal/BootstrapCoordinator.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/internal/BootstrapCoordinator.scala
@@ -121,7 +121,6 @@ private[akka] final class BootstrapCoordinator(discovery: ServiceDiscovery,
 
   private val lookup = Lookup(settings.contactPointDiscovery.effectiveName(context.system),
     settings.contactPointDiscovery.portName, settings.contactPointDiscovery.protocol)
-  private val defaultManagementPort = new AkkaManagementSettings(context.system.settings.config).Http.Port
 
   private var lastContactsObservation: Option[ServiceContactsObservation] = None
   private var seedNodesObservations: Map[ResolvedTarget, SeedNodesObservation] = Map.empty
@@ -184,7 +183,7 @@ private[akka] final class BootstrapCoordinator(discovery: ServiceDiscovery,
             case (host, immutable.Seq(singleResult)) =>
               immutable.Seq(singleResult)
             case (host, multipleResults) =>
-              multipleResults.filter(_.port.contains(defaultManagementPort))
+              multipleResults.filter(_.port.contains(settings.contactPoint.fallbackPort))
           }
 
       log.info("Located service members based on: [{}]: [{}], filtered to [{}]", lookup, contactPoints.mkString(", "),

--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/internal/BootstrapCoordinator.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/internal/BootstrapCoordinator.scala
@@ -182,7 +182,6 @@ private[akka] class BootstrapCoordinator(discovery: ServiceDiscovery,
             case (host, immutable.Seq(singleResult)) =>
               immutable.Seq(singleResult)
             case (host, multipleResults) =>
-              println(s"Looking for ${settings.contactPoint.fallbackPort}")
               multipleResults.filter(_.port.contains(settings.contactPoint.fallbackPort))
           }
 

--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/internal/BootstrapCoordinator.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/internal/BootstrapCoordinator.scala
@@ -257,15 +257,15 @@ private[akka] final class BootstrapCoordinator(discovery: ServiceDiscovery,
       .map { resolved =>
         if (lookup.portName.isDefined)
           resolved
-        else if (resolved.addresses.flatMap(_.port).isEmpty)
-          Resolved(
-            resolved.serviceName,
-            resolved.addresses.map(target => ResolvedTarget(target.host, Some(defaultManagementPort), target.address))
-          )
         else
           Resolved(
             resolved.serviceName,
-            resolved.addresses.filter(_.port.contains(defaultManagementPort))
+            resolved.addresses match {
+              case immutable.Seq(singleResult) =>
+                immutable.Seq(singleResult)
+              case addresses =>
+                addresses.filter(_.port.contains(defaultManagementPort))
+            }
           )
       }
       .pipeTo(self)

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapBasePathIntegrationSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapBasePathIntegrationSpec.scala
@@ -70,7 +70,7 @@ class ClusterBootstrapBasePathIntegrationSpec extends WordSpecLike with Matchers
 
     // prepare the "mock DNS"
     val name = "basepathsystem.svc.cluster.local"
-    MockDiscovery.set(Lookup(name).withProtocol("tcp").withPortName("management"),
+    MockDiscovery.set(Lookup(name).withProtocol("tcp"),
       () =>
         Future.successful(
           Resolved(name,

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapDiscoveryBackoffIntegrationSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapDiscoveryBackoffIntegrationSpec.scala
@@ -70,6 +70,8 @@ class ClusterBootstrapDiscoveryBackoffIntegrationSpec
                 stable-margin = 4 seconds
 
                 interval = 500 ms
+
+                port-name = "management"
               }
             }
           }

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapRetryUnreachableContactPointIntegrationSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapRetryUnreachableContactPointIntegrationSpec.scala
@@ -62,6 +62,8 @@ class ClusterBootstrapRetryUnreachableContactPointIntegrationSpec extends WordSp
                 service-namespace = "svc.cluster.local"
 
                 stable-margin = 4 seconds
+
+                port-name = "management"
               }
             }
           }
@@ -86,7 +88,7 @@ class ClusterBootstrapRetryUnreachableContactPointIntegrationSpec extends WordSp
 
     val name = "systemunreachablenodes.svc.cluster.local"
 
-    MockDiscovery.set(Lookup(name).withPortName("management").withProtocol("tcp"), { () =>
+    MockDiscovery.set(Lookup(name).withProtocol("tcp").withPortName("management"), { () =>
       called += 1
 
       Future.successful(

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/internal/BootstrapCoordinatorSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/internal/BootstrapCoordinatorSpec.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2017-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.management.cluster.bootstrap.internal
+
+import java.util.concurrent.atomic.AtomicReference
+
+import akka.actor.{ ActorRef, ActorSystem, Props }
+import akka.discovery.ServiceDiscovery.{ Resolved, ResolvedTarget }
+import akka.discovery.{ Lookup, MockDiscovery }
+import akka.management.cluster.bootstrap.internal.BootstrapCoordinator.Protocol.InitiateBootstrapping
+import akka.management.cluster.bootstrap.{ ClusterBootstrapSettings, LowestAddressJoinDecider }
+import com.typesafe.config.ConfigFactory
+import org.scalatest.concurrent.Eventually
+import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpec }
+
+import scala.concurrent.{ Await, Future }
+import scala.concurrent.duration._
+
+class BootstrapCoordinatorSpec extends WordSpec with Matchers with BeforeAndAfterAll with Eventually {
+  val serviceName = "bootstrap-coordinator-test-service"
+  val system = ActorSystem("test", ConfigFactory.parseString(s"""
+      |akka.management.cluster.bootstrap {
+      | contact-point-discovery.service-name = $serviceName
+      |}
+    """.stripMargin).withFallback(ConfigFactory.load()))
+  val settings = ClusterBootstrapSettings(system.settings.config, system.log)
+  val joinDecider = new LowestAddressJoinDecider(system, settings)
+
+  val discovery = new MockDiscovery(system)
+
+  MockDiscovery.set(
+    Lookup(serviceName, portName = None, protocol = Some("tcp")),
+    () =>
+      Future.successful(Resolved(serviceName,
+          List(
+            ResolvedTarget("host1", Some(2552), None),
+            ResolvedTarget("host1", Some(8558), None),
+            ResolvedTarget("host2", Some(2552), None),
+            ResolvedTarget("host2", Some(8558), None)
+          )))
+  )
+
+  "The bootstrap coordinator, when avoiding named port lookups" should {
+
+    "probe only on the Akka Management port" in {
+      val targets = new AtomicReference[List[ResolvedTarget]](Nil)
+      val coordinator = system.actorOf(Props(new BootstrapCoordinator(discovery, joinDecider, settings) {
+        override def ensureProbing(contactPoint: ResolvedTarget): Option[ActorRef] = {
+          println(s"Resolving $contactPoint")
+          val targetsSoFar = targets.get
+          targets.compareAndSet(targetsSoFar, contactPoint +: targetsSoFar)
+          None
+        }
+      }))
+      coordinator ! InitiateBootstrapping
+      eventually {
+        val targetsToCheck = targets.get
+        targetsToCheck.length should be >= (2)
+        targetsToCheck.map(_.host) should contain("host1")
+        targetsToCheck.map(_.host) should contain("host2")
+        targetsToCheck.flatMap(_.port).toSet should be(Set(8558))
+      }
+    }
+  }
+
+  override def afterAll(): Unit = {
+    Await.result(system.terminate(), 10.seconds)
+    super.afterAll()
+  }
+}

--- a/integration-test/kubernetes-api-java/kubernetes/akka-cluster.yml
+++ b/integration-test/kubernetes-api-java/kubernetes/akka-cluster.yml
@@ -33,11 +33,12 @@ spec:
         - name: remoting
           containerPort: 2552
           protocol: TCP
-        # akka-management bootstrap
-        # must match up with contact-point-discovery.port-name for bootstrap
-        - name: management
-          containerPort: 8558
+        # akka-management
+        - containerPort: 8558
           protocol: TCP
+          # when contact-point-discovery.port-name is set for cluster bootstrap,
+          # the management port must be named accordingly:
+          # name: management
         env:
         # The Kubernetes API discovery will use this service name to look for
         # nodes with this value in the 'app' label
@@ -47,7 +48,6 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: "metadata.labels['app']"
-
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/integration-test/kubernetes-api/kubernetes/akka-cluster.yml
+++ b/integration-test/kubernetes-api/kubernetes/akka-cluster.yml
@@ -43,10 +43,11 @@ spec:
           containerPort: 2552
           protocol: TCP
         # akka-management bootstrap
-        # must match up with contact-point-discovery.port-name for bootstrap
-        - name: management
-          containerPort: 8558
+        - containerPort: 8558
           protocol: TCP
+          # when contact-point-discovery.port-name is set for cluster bootstrap,
+          # the management port must be named accordingly:
+          # name: management
         env:
         # The Kubernetes API discovery will use this service name to look for
         # nodes with this value in the 'app' label.

--- a/integration-test/kubernetes-dns/kubernetes/akka-cluster.yml
+++ b/integration-test/kubernetes-dns/kubernetes/akka-cluster.yml
@@ -40,7 +40,9 @@ spec:
         #health
         ports:
         - containerPort: 8558
-          name: management
+          # when contact-point-discovery.port-name is set for cluster bootstrap,
+          # the management port must be named accordingly:
+          # name: management
         - containerPort: 2552
           name: remoting
         env:

--- a/integration-test/local/src/test/scala/akka/management/LocalBootstrapTest.scala
+++ b/integration-test/local/src/test/scala/akka/management/LocalBootstrapTest.scala
@@ -30,7 +30,10 @@ object LocalBootstrapTest {
           port = 0
         }
       }
-      akka.management.http.hostname = "localhost"
+      akka.management {
+        http.hostname = "localhost"
+        cluster.bootstrap.contact-point-discovery.port-name = "management"
+      }
       akka.discovery {
         config.services = {
           local-cluster = {


### PR DESCRIPTION
Refs #464: Instead of discovering by port name 'management', avoid a
named port lookup.

When multiple results are found, disambiguate based on 
the `fallback-port` which by default is populated with
`akka-management.http.port`.

This arguably makes discovery on Kubernetes a bit easier, since the
akka-management port does not need to be named any specific way in the
deployment .yml.

On the other hand, it makes the actual bootstrap/discovery process a bit
more complicated and thus harder to explain or troubleshoot.

I'm not convinced the convenience of not having to declare the port name in
the Kubernetes case weighs up to the extra complexity in the
bootstrap/discovery logic.