### PR TITLE
Fix typo mananagement -> management

### DIFF
--- a/docs/src/main/paradox/migration.md
+++ b/docs/src/main/paradox/migration.md
@@ -16,13 +16,13 @@ Version requirements:
 
 ### Configuration changes
 
-* `akka.mananagement.cluster.http.healthcheck.ready-states` moved to `akka.mananagement.cluster.health-check.ready-states`
+* `akka.management.cluster.http.healthcheck.ready-states` moved to `akka.management.cluster.health-check.ready-states`
 * `akka.management.cluster.bootstrap.form-new-cluster` renamed to `akka.management.cluster.bootstrap.new-cluster-enabled`
 
 #### route-providers
 
-`akka.mananagement.cluster.route-providers` changed from being a list of fully qualified class names to
-a configuration object `akka.mananagement.cluster.routes` with named route providers. The reason for the
+`akka.management.cluster.route-providers` changed from being a list of fully qualified class names to
+a configuration object `akka.management.cluster.routes` with named route providers. The reason for the
 change was to be able to exclude a route provider that was included by a library (from reference.conf) by
 using `""` or `null` as the FQCN of the named entry, for example:
 


### PR DESCRIPTION
## Purpose

Fix typo in migration docs.