### PR TITLE
Akka design and latest plugins

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 // root
 lazy val `akka-management-root` = project
   .in(file("."))
-  .enablePlugins(NoPublish, ScalaUnidocPlugin)
+  .enablePlugins(ScalaUnidocPlugin)
   .disablePlugins(BintrayPlugin)
   .aggregate(
     // When this aggregate is updated the list of modules in ManifestInfo.checkSameVersion
@@ -24,7 +24,8 @@ lazy val `akka-management-root` = project
     docs
   )
   .settings(
-    parallelExecution in GlobalScope := false
+    parallelExecution in GlobalScope := false,
+    publish / skip := true,
   )
 
 lazy val `akka-discovery-kubernetes-api` = project
@@ -101,7 +102,6 @@ lazy val `cluster-bootstrap` = project
 
 lazy val `integration-test-kubernetes-api` = project
   .in(file("integration-test/kubernetes-api"))
-  .enablePlugins(NoPublish)
   .disablePlugins(BintrayPlugin)
   .enablePlugins(AutomateHeaderPlugin)
   .settings(
@@ -118,7 +118,6 @@ lazy val `integration-test-kubernetes-api` = project
 
 lazy val `integration-test-kubernetes-api-java` = project
   .in(file("integration-test/kubernetes-api-java"))
-  .enablePlugins(NoPublish)
   .disablePlugins(BintrayPlugin)
   .enablePlugins(AutomateHeaderPlugin)
   .settings(
@@ -135,7 +134,6 @@ lazy val `integration-test-kubernetes-api-java` = project
 
 lazy val `integration-test-kubernetes-dns` = project
   .in(file("integration-test/kubernetes-dns"))
-  .enablePlugins(NoPublish)
   .disablePlugins(BintrayPlugin)
   .enablePlugins(AutomateHeaderPlugin)
   .settings(
@@ -152,7 +150,6 @@ lazy val `integration-test-kubernetes-dns` = project
 lazy val `integration-test-aws-api-ec2-tag-based` = project
     .in(file("integration-test/aws-api-ec2"))
     .configs(IntegrationTest)
-    .enablePlugins(NoPublish)
     .disablePlugins(BintrayPlugin)
     .enablePlugins(AutomateHeaderPlugin)
     .settings(
@@ -169,7 +166,6 @@ lazy val `integration-test-aws-api-ec2-tag-based` = project
 
 lazy val `integration-test-marathon-api-docker` = project
   .in(file("integration-test/marathon-api-docker"))
-  .enablePlugins(NoPublish)
   .disablePlugins(BintrayPlugin)
   .enablePlugins(AutomateHeaderPlugin)
   .settings(
@@ -186,7 +182,6 @@ lazy val `integration-test-marathon-api-docker` = project
 
 lazy val `integration-test-aws-api-ecs` = project
   .in(file("integration-test/aws-api-ecs"))
-  .enablePlugins(NoPublish)
   .disablePlugins(BintrayPlugin)
   .enablePlugins(AutomateHeaderPlugin)
   .settings(
@@ -208,7 +203,6 @@ lazy val `integration-test-aws-api-ecs` = project
 
 lazy val `integration-test-local` = project
   .in(file("integration-test/local"))
-  .enablePlugins(NoPublish)
   .disablePlugins(BintrayPlugin)
   .enablePlugins(AutomateHeaderPlugin)
   .settings(
@@ -226,7 +220,7 @@ lazy val `integration-test-local` = project
 
 lazy val docs = project
   .in(file("docs"))
-  .enablePlugins(AkkaParadoxPlugin, NoPublish)
+  .enablePlugins(AkkaParadoxPlugin)
   .disablePlugins(BintrayPlugin)
   .settings(
     name := "Akka Management",

--- a/build.sbt
+++ b/build.sbt
@@ -226,15 +226,18 @@ lazy val `integration-test-local` = project
 
 lazy val docs = project
   .in(file("docs"))
-  .enablePlugins(ParadoxPlugin, NoPublish)
+  .enablePlugins(AkkaParadoxPlugin, NoPublish)
   .disablePlugins(BintrayPlugin)
   .settings(
     name := "Akka Management",
-    paradoxGroups := Map("Language" -> Seq("Scala", "Java")),
-    paradoxTheme := Some(builtinParadoxTheme("generic")),
-    paradox in Compile := (paradox in Compile).dependsOn(LocalRootProject / ScalaUnidoc / doc).value,
-    paradoxProperties ++= Map(
+    publish / skip := true,
+    whitesourceIgnore := true,
+    paradoxGroups := Map("Language" -> Seq("Java", "Scala")),
+    Compile / paradox := (Compile / paradox).dependsOn(LocalRootProject / ScalaUnidoc / doc).value,
+    Compile / paradoxProperties ++= Map(
       "version" -> version.value,
+      "project.url" -> "https://developer.lightbend.com/docs/akka-management/current/",
+      "canonical.base_url" -> "https://developer.lightbend.com/docs/akka-management/current/",
       "scala.binary_version" -> scalaBinaryVersion.value,
       "akka.version" -> Dependencies.AkkaVersion,
       "extref.akka-docs.base_url" -> s"https://doc.akka.io/docs/akka/${Dependencies.AkkaVersion}/%s",

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+ThisBuild / resolvers += Resolver.jcenterRepo
+
 // root
 lazy val `akka-management-root` = project
   .in(file("."))

--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/ClusterBootstrap.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/ClusterBootstrap.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management.cluster.bootstrap

--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/ClusterBootstrapSettings.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/ClusterBootstrapSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management.cluster.bootstrap

--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/JoinDecider.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/JoinDecider.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management.cluster.bootstrap

--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/LowestAddressJoinDecider.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/LowestAddressJoinDecider.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management.cluster.bootstrap

--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/SelfAwareJoinDecider.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/SelfAwareJoinDecider.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management.cluster.bootstrap

--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/contactpoint/HttpBootstrapJsonProtocol.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/contactpoint/HttpBootstrapJsonProtocol.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management.cluster.bootstrap.contactpoint

--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/contactpoint/HttpClusterBootstrapRoutes.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/contactpoint/HttpClusterBootstrapRoutes.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management.cluster.bootstrap.contactpoint

--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/internal/BootstrapCoordinator.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/internal/BootstrapCoordinator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management.cluster.bootstrap.internal

--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/internal/HttpContactPointBootstrap.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/internal/HttpContactPointBootstrap.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management.cluster.bootstrap.internal

--- a/cluster-bootstrap/src/test/java/akka/management/cluster/bootstrap/ClusterBootstrapJavaCompileTest.java
+++ b/cluster-bootstrap/src/test/java/akka/management/cluster/bootstrap/ClusterBootstrapJavaCompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management.cluster.bootstrap;

--- a/cluster-bootstrap/src/test/java/jdoc/akka/management/cluster/bootstrap/ClusterBootstrapCompileOnly.java
+++ b/cluster-bootstrap/src/test/java/jdoc/akka/management/cluster/bootstrap/ClusterBootstrapCompileOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package jdoc.akka.management.cluster.bootstrap;

--- a/cluster-bootstrap/src/test/scala/akka/discovery/MockDiscovery.scala
+++ b/cluster-bootstrap/src/test/scala/akka/discovery/MockDiscovery.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.discovery

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/AbstractBootstrapSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/AbstractBootstrapSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management.cluster.bootstrap

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/ClusterBootstrapSettingsSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/ClusterBootstrapSettingsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management.cluster.bootstrap

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/LowestAddressJoinDeciderSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/LowestAddressJoinDeciderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management.cluster.bootstrap

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapBasePathIntegrationSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapBasePathIntegrationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management.cluster.bootstrap.contactpoint

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapDiscoveryBackoffIntegrationSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapDiscoveryBackoffIntegrationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management.cluster.bootstrap.contactpoint

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapExistingSeedNodesSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapExistingSeedNodesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management.cluster.bootstrap.contactpoint

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapIntegrationSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapIntegrationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management.cluster.bootstrap.contactpoint

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapRetryUnreachableContactPointIntegrationSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapRetryUnreachableContactPointIntegrationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management.cluster.bootstrap.contactpoint

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/HttpContactPointRoutesSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/HttpContactPointRoutesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management.cluster.bootstrap.contactpoint

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/internal/BootstrapCoordinatorSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/internal/BootstrapCoordinatorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management.cluster.bootstrap.internal

--- a/cluster-bootstrap/src/test/scala/doc/akka/management/cluster/bootstrap/ClusterBootstrapCompileOnly.scala
+++ b/cluster-bootstrap/src/test/scala/doc/akka/management/cluster/bootstrap/ClusterBootstrapCompileOnly.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package doc.akka.management.cluster.bootstrap

--- a/cluster-http/src/main/java/akka/management/cluster/ClusterReadViewAccess.java
+++ b/cluster-http/src/main/java/akka/management/cluster/ClusterReadViewAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management.cluster;

--- a/cluster-http/src/main/scala/akka/management/cluster/ClusterHttpManagementHelper.scala
+++ b/cluster-http/src/main/scala/akka/management/cluster/ClusterHttpManagementHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management.cluster

--- a/cluster-http/src/main/scala/akka/management/cluster/ClusterHttpManagementProtocol.scala
+++ b/cluster-http/src/main/scala/akka/management/cluster/ClusterHttpManagementProtocol.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management.cluster

--- a/cluster-http/src/main/scala/akka/management/cluster/ClusterHttpManagementRouteProvider.scala
+++ b/cluster-http/src/main/scala/akka/management/cluster/ClusterHttpManagementRouteProvider.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management.cluster

--- a/cluster-http/src/main/scala/akka/management/cluster/ClusterHttpManagementSettings.scala
+++ b/cluster-http/src/main/scala/akka/management/cluster/ClusterHttpManagementSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management.cluster

--- a/cluster-http/src/main/scala/akka/management/cluster/javadsl/ClusterHttpManagementRoutes.scala
+++ b/cluster-http/src/main/scala/akka/management/cluster/javadsl/ClusterHttpManagementRoutes.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management.cluster.javadsl

--- a/cluster-http/src/main/scala/akka/management/cluster/javadsl/ClusterMembershipCheck.scala
+++ b/cluster-http/src/main/scala/akka/management/cluster/javadsl/ClusterMembershipCheck.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management.cluster.javadsl

--- a/cluster-http/src/main/scala/akka/management/cluster/scaladsl/ClusterHttpManagementRoutes.scala
+++ b/cluster-http/src/main/scala/akka/management/cluster/scaladsl/ClusterHttpManagementRoutes.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management.cluster.scaladsl

--- a/cluster-http/src/main/scala/akka/management/cluster/scaladsl/ClusterMembershipCheck.scala
+++ b/cluster-http/src/main/scala/akka/management/cluster/scaladsl/ClusterMembershipCheck.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management.cluster.scaladsl

--- a/cluster-http/src/test/java/akka/management/http/ClusterHttpManagementJavaCompileTest.java
+++ b/cluster-http/src/test/java/akka/management/http/ClusterHttpManagementJavaCompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management.http;

--- a/cluster-http/src/test/java/akka/management/http/javadsl/ClusterReadinessCheckTest.java
+++ b/cluster-http/src/test/java/akka/management/http/javadsl/ClusterReadinessCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management.http.javadsl;

--- a/cluster-http/src/test/java/jdoc/akka/cluster/http/management/CompileOnlyTest.java
+++ b/cluster-http/src/test/java/jdoc/akka/cluster/http/management/CompileOnlyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package jdoc.akka.cluster.http.management;

--- a/cluster-http/src/test/scala/akka/cluster/http/management/scaladsl/ClusterHttpManagementRoutesSpec.scala
+++ b/cluster-http/src/test/scala/akka/cluster/http/management/scaladsl/ClusterHttpManagementRoutesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.cluster.http.management.scaladsl

--- a/cluster-http/src/test/scala/akka/management/cluster/ClusterHttpManagementHelperSpec.scala
+++ b/cluster-http/src/test/scala/akka/management/cluster/ClusterHttpManagementHelperSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.cluster.management

--- a/cluster-http/src/test/scala/akka/management/cluster/ClusterHttpManagementRouteProviderSpec.scala
+++ b/cluster-http/src/test/scala/akka/management/cluster/ClusterHttpManagementRouteProviderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management.cluster

--- a/cluster-http/src/test/scala/akka/management/cluster/MultiDcSpec.scala
+++ b/cluster-http/src/test/scala/akka/management/cluster/MultiDcSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management.cluster

--- a/cluster-http/src/test/scala/akka/management/cluster/scaladsl/ClusterMembershipCheckSettingsSpec.scala
+++ b/cluster-http/src/test/scala/akka/management/cluster/scaladsl/ClusterMembershipCheckSettingsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management.cluster.scaladsl

--- a/cluster-http/src/test/scala/akka/management/cluster/scaladsl/ClusterMembershipCheckSpec.scala
+++ b/cluster-http/src/test/scala/akka/management/cluster/scaladsl/ClusterMembershipCheckSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management.cluster.scaladsl

--- a/cluster-http/src/test/scala/doc/akka/cluster/http/management/CompileOnlySpec.scala
+++ b/cluster-http/src/test/scala/doc/akka/cluster/http/management/CompileOnlySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package doc.akka.cluster.http.management

--- a/discovery-aws-api-async/src/main/scala/akka/discovery/awsapi/ecs/AsyncEcsServiceDiscovery.scala
+++ b/discovery-aws-api-async/src/main/scala/akka/discovery/awsapi/ecs/AsyncEcsServiceDiscovery.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.discovery.awsapi.ecs

--- a/discovery-aws-api/src/main/scala/akka/discovery/awsapi/ec2/Ec2TagBasedServiceDiscovery.scala
+++ b/discovery-aws-api/src/main/scala/akka/discovery/awsapi/ec2/Ec2TagBasedServiceDiscovery.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.discovery.awsapi.ec2

--- a/discovery-aws-api/src/main/scala/akka/discovery/awsapi/ecs/EcsServiceDiscovery.scala
+++ b/discovery-aws-api/src/main/scala/akka/discovery/awsapi/ecs/EcsServiceDiscovery.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.discovery.awsapi.ecs

--- a/discovery-aws-api/src/test/java/akka/discovery/awsapi/ec2/MyConfiguration.java
+++ b/discovery-aws-api/src/test/java/akka/discovery/awsapi/ec2/MyConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.discovery.awsapi.ec2;

--- a/discovery-aws-api/src/test/scala/akka/discovery/awsapi/ec2/Docs.scala
+++ b/discovery-aws-api/src/test/scala/akka/discovery/awsapi/ec2/Docs.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.discovery.awsapi.ec2

--- a/discovery-aws-api/src/test/scala/akka/discovery/awsapi/ec2/Ec2TagBasedSimpleServiceDiscoveryTest.scala
+++ b/discovery-aws-api/src/test/scala/akka/discovery/awsapi/ec2/Ec2TagBasedSimpleServiceDiscoveryTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.discovery.awsapi.ec2

--- a/discovery-consul/src/main/scala/akka/discovery/consul/ConsulServiceDiscovery.scala
+++ b/discovery-consul/src/main/scala/akka/discovery/consul/ConsulServiceDiscovery.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.discovery.consul

--- a/discovery-consul/src/main/scala/akka/discovery/consul/ConsulSettings.scala
+++ b/discovery-consul/src/main/scala/akka/discovery/consul/ConsulSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.discovery.consul

--- a/discovery-consul/src/test/scala/akka/cluster/bootstrap/discovery/ConsulDiscoverySpec.scala
+++ b/discovery-consul/src/test/scala/akka/cluster/bootstrap/discovery/ConsulDiscoverySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.cluster.bootstrap.discovery

--- a/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/JsonFormat.scala
+++ b/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/JsonFormat.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.discovery.kubernetes

--- a/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/KubernetesApiServiceDiscovery.scala
+++ b/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/KubernetesApiServiceDiscovery.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.discovery.kubernetes

--- a/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/PodList.scala
+++ b/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/PodList.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.discovery.kubernetes

--- a/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/Settings.scala
+++ b/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/Settings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.discovery.kubernetes

--- a/discovery-kubernetes-api/src/test/java/docs/KubernetesApiDiscoveryDocsTest.java
+++ b/discovery-kubernetes-api/src/test/java/docs/KubernetesApiDiscoveryDocsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs;

--- a/discovery-kubernetes-api/src/test/scala/akka/discovery/kubernetes/JsonFormatSpec.scala
+++ b/discovery-kubernetes-api/src/test/scala/akka/discovery/kubernetes/JsonFormatSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.discovery.kubernetes

--- a/discovery-kubernetes-api/src/test/scala/akka/discovery/kubernetes/KubernetesApiServiceDiscoverySpec.scala
+++ b/discovery-kubernetes-api/src/test/scala/akka/discovery/kubernetes/KubernetesApiServiceDiscoverySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.discovery.kubernetes

--- a/discovery-marathon-api/src/main/scala/akka/discovery/marathon/AppList.scala
+++ b/discovery-marathon-api/src/main/scala/akka/discovery/marathon/AppList.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.discovery.marathon

--- a/discovery-marathon-api/src/main/scala/akka/discovery/marathon/JsonFormat.scala
+++ b/discovery-marathon-api/src/main/scala/akka/discovery/marathon/JsonFormat.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.discovery.marathon

--- a/discovery-marathon-api/src/main/scala/akka/discovery/marathon/MarathonApiServiceDiscovery.scala
+++ b/discovery-marathon-api/src/main/scala/akka/discovery/marathon/MarathonApiServiceDiscovery.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.discovery.marathon

--- a/discovery-marathon-api/src/main/scala/akka/discovery/marathon/Settings.scala
+++ b/discovery-marathon-api/src/main/scala/akka/discovery/marathon/Settings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.discovery.marathon

--- a/discovery-marathon-api/src/test/scala/akka/discovery/marathon/MarathonApiServiceDiscoverySpec.scala
+++ b/discovery-marathon-api/src/test/scala/akka/discovery/marathon/MarathonApiServiceDiscoverySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.discovery.marathon

--- a/docs/src/main/paradox/_template/projectSpecificFooter.st
+++ b/docs/src/main/paradox/_template/projectSpecificFooter.st
@@ -1,0 +1,4 @@
+<script type="text/javascript" src="$page.base$assets/js/warnOldVersion.js"></script>
+<script type="text/javascript">//<![CDATA[
+jQuery(function(jq){initOldVersionWarnings(jq, '$page.properties.("project.version")$', '$page.properties.("project.url")$')});
+//]]></script>

--- a/docs/src/main/paradox/assets/js/warnOldVersion.js
+++ b/docs/src/main/paradox/assets/js/warnOldVersion.js
@@ -1,0 +1,23 @@
+function initOldVersionWarnings($, thisVersion, projectUrl) {
+    if (projectUrl && projectUrl !== "") {
+        var schemeLessUrl = projectUrl;
+        if (projectUrl.startsWith("http://")) projectUrl = schemeLessUrl.substring(5);
+        else if (projectUrl.startsWith("https://")) projectUrl = schemeLessUrl.substring(6);
+        const url = schemeLessUrl + (schemeLessUrl.endsWith("\/") ? "" : "/") + "paradox.json";
+        $.get(url, function (versionData) {
+            const currentVersion = versionData.version;
+            if (thisVersion !== currentVersion) {
+                showVersionWarning(thisVersion, currentVersion, projectUrl);
+            }
+        });
+    }
+}
+
+function showVersionWarning(thisVersion, currentVersion, projectUrl) {
+    $('#docs').prepend(
+        '<div class="callout warning" style="margin-top: 16px">' +
+        '<p><span style="font-weight: bold">This documentation regards version ' + thisVersion + ', ' +
+        'however the current version is <a href="' + projectUrl + '">' + currentVersion + '</a>.</span></p>' +
+        '</div>'
+    );
+}

--- a/integration-test/aws-api-ec2/src/main/scala/akka/cluster/bootstrap/Ec2DemoApp.scala
+++ b/integration-test/aws-api-ec2/src/main/scala/akka/cluster/bootstrap/Ec2DemoApp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.cluster.bootstrap

--- a/integration-test/aws-api-ecs/src/main/scala/akka/cluster/bootstrap/EcsApiDemoApp.scala
+++ b/integration-test/aws-api-ecs/src/main/scala/akka/cluster/bootstrap/EcsApiDemoApp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.cluster.bootstrap

--- a/integration-test/kubernetes-api-java/src/main/java/akka/cluster/bootstrap/demo/ClusterWatcher.java
+++ b/integration-test/kubernetes-api-java/src/main/java/akka/cluster/bootstrap/demo/ClusterWatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.cluster.bootstrap.demo;

--- a/integration-test/kubernetes-api-java/src/main/java/akka/cluster/bootstrap/demo/DemoApp.java
+++ b/integration-test/kubernetes-api-java/src/main/java/akka/cluster/bootstrap/demo/DemoApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.cluster.bootstrap.demo;

--- a/integration-test/kubernetes-api/src/main/scala/akka/cluster/bootstrap/DemoApp.scala
+++ b/integration-test/kubernetes-api/src/main/scala/akka/cluster/bootstrap/DemoApp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.cluster.bootstrap

--- a/integration-test/kubernetes-dns/src/main/scala/akka/cluster/bootstrap/ClusterApp.scala
+++ b/integration-test/kubernetes-dns/src/main/scala/akka/cluster/bootstrap/ClusterApp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.cluster.bootstrap

--- a/integration-test/kubernetes-dns/src/main/scala/akka/cluster/bootstrap/NoisySingleton.scala
+++ b/integration-test/kubernetes-dns/src/main/scala/akka/cluster/bootstrap/NoisySingleton.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.cluster.bootstrap

--- a/integration-test/local/src/main/scala/akka/cluster/bootstrap/Main.scala
+++ b/integration-test/local/src/main/scala/akka/cluster/bootstrap/Main.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.cluster.bootstrap

--- a/integration-test/local/src/test/scala/akka/management/LocalBootstrapTest.scala
+++ b/integration-test/local/src/test/scala/akka/management/LocalBootstrapTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management

--- a/integration-test/marathon-api-docker/src/main/scala/akka/cluster/bootstrap/MarathonApiDockerDemoApp.scala
+++ b/integration-test/marathon-api-docker/src/main/scala/akka/cluster/bootstrap/MarathonApiDockerDemoApp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.cluster.bootstrap

--- a/management/src/main/scala/akka/management/AkkaManagementSettings.scala
+++ b/management/src/main/scala/akka/management/AkkaManagementSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management

--- a/management/src/main/scala/akka/management/HealthCheckRoutes.scala
+++ b/management/src/main/scala/akka/management/HealthCheckRoutes.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management

--- a/management/src/main/scala/akka/management/HealthCheckSettings.scala
+++ b/management/src/main/scala/akka/management/HealthCheckSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management

--- a/management/src/main/scala/akka/management/InvalidHealthCheckException.scala
+++ b/management/src/main/scala/akka/management/InvalidHealthCheckException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management

--- a/management/src/main/scala/akka/management/internal/HealthChecksImpl.scala
+++ b/management/src/main/scala/akka/management/internal/HealthChecksImpl.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management.internal

--- a/management/src/main/scala/akka/management/javadsl/AkkaManagement.scala
+++ b/management/src/main/scala/akka/management/javadsl/AkkaManagement.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management.javadsl

--- a/management/src/main/scala/akka/management/javadsl/HealthChecks.scala
+++ b/management/src/main/scala/akka/management/javadsl/HealthChecks.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management.javadsl

--- a/management/src/main/scala/akka/management/javadsl/ManagementRouteProvider.scala
+++ b/management/src/main/scala/akka/management/javadsl/ManagementRouteProvider.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management.javadsl

--- a/management/src/main/scala/akka/management/javadsl/ManagementRouteProviderSettings.scala
+++ b/management/src/main/scala/akka/management/javadsl/ManagementRouteProviderSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management.javadsl

--- a/management/src/main/scala/akka/management/scaladsl/AkkaManagement.scala
+++ b/management/src/main/scala/akka/management/scaladsl/AkkaManagement.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management.scaladsl

--- a/management/src/main/scala/akka/management/scaladsl/HealthChecks.scala
+++ b/management/src/main/scala/akka/management/scaladsl/HealthChecks.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management.scaladsl

--- a/management/src/main/scala/akka/management/scaladsl/ManagementRouteProvider.scala
+++ b/management/src/main/scala/akka/management/scaladsl/ManagementRouteProvider.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management.scaladsl

--- a/management/src/main/scala/akka/management/scaladsl/ManagementRouteProviderSettings.scala
+++ b/management/src/main/scala/akka/management/scaladsl/ManagementRouteProviderSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management.scaladsl

--- a/management/src/test/java/akka/management/CodeExamples.java
+++ b/management/src/test/java/akka/management/CodeExamples.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management;

--- a/management/src/test/java/akka/management/HealthCheckTest.java
+++ b/management/src/test/java/akka/management/HealthCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management;

--- a/management/src/test/java/jdoc/akka/management/BasicHealthCheck.java
+++ b/management/src/test/java/jdoc/akka/management/BasicHealthCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package jdoc.akka.management;

--- a/management/src/test/java/jdoc/akka/management/ClusterCheck.java
+++ b/management/src/test/java/jdoc/akka/management/ClusterCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package jdoc.akka.management;

--- a/management/src/test/scala/akka/management/AkkaManagementHttpEndpointSpec.scala
+++ b/management/src/test/scala/akka/management/AkkaManagementHttpEndpointSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management

--- a/management/src/test/scala/akka/management/CompileOnly.scala
+++ b/management/src/test/scala/akka/management/CompileOnly.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management

--- a/management/src/test/scala/akka/management/HealthCheckRoutesSpec.scala
+++ b/management/src/test/scala/akka/management/HealthCheckRoutesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management

--- a/management/src/test/scala/akka/management/HealthCheckSettingsSpec.scala
+++ b/management/src/test/scala/akka/management/HealthCheckSettingsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management

--- a/management/src/test/scala/akka/management/HealthChecksSpec.scala
+++ b/management/src/test/scala/akka/management/HealthChecksSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.management

--- a/management/src/test/scala/doc/akka/management/ExampleHealthCheck.scala
+++ b/management/src/test/scala/doc/akka/management/ExampleHealthCheck.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package doc.akka.management

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -10,15 +10,16 @@ object Common extends AutoPlugin {
 
   override lazy val projectSettings =
     Dependencies.Common ++ Seq(
-    organization := "com.lightbend.akka.management", // FIXME proposing this change, then we can have "com.lightbend.akka.management|discovery" etc; we'd do management.commercial for example later
+    organization := "com.lightbend.akka.management",
     organizationName := "Lightbend Inc.",
+    organizationHomepage := Some(url("https://www.lightbend.com/")),
     startYear := Some(2017),
-    homepage := Some(url("https://github.com/akka/akka-management")),
+    homepage := Some(url("https://akka.io/")),
     scmInfo := Some(ScmInfo(url("https://github.com/akka/akka-management"), "git@github.com:akka/akka-management.git")),
     developers += Developer("contributors", "Contributors", "https://gitter.im/akka/dev", url("https://github.com/akka/akka-management/graphs/contributors")),
 
     licenses := Seq(("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0"))),
-    headerLicense := Some(HeaderLicense.Custom("Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>")),
+    headerLicense := Some(HeaderLicense.Custom("Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>")),
 
     crossScalaVersions := Seq("2.11.12", "2.12.8", "2.13.0-M5"),
 

--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -1,18 +1,5 @@
 import sbt._, Keys._
 
-/**
- * For projects that are not to be published.
- */
-object NoPublish extends AutoPlugin {
-  override def requires = plugins.JvmPlugin
-
-  override def projectSettings = Seq(
-    publishArtifact := false,
-    publish := {},
-    publishLocal := {}
-  )
-}
-
 object Publish extends AutoPlugin {
   import bintray.BintrayPlugin
   import bintray.BintrayPlugin.autoImport._

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,12 +1,12 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.1")
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.21")
 
-addSbtPlugin("de.heikoseeberger"                 % "sbt-header"       % "5.0.0")
+addSbtPlugin("de.heikoseeberger"                 % "sbt-header"       % "5.2.0")
 addSbtPlugin("org.scalameta"                      % "sbt-scalafmt"     % "2.0.0-RC5")
-addSbtPlugin("com.dwijnand"                      % "sbt-dynver"       % "3.1.0")
-addSbtPlugin("com.lightbend.paradox"             % "sbt-paradox"      % "0.5.3")
+addSbtPlugin("com.dwijnand"                      % "sbt-dynver"       % "3.3.0")
+addSbtPlugin("com.lightbend.akka"                % "sbt-paradox-akka" % "0.18")
 addSbtPlugin("com.eed3si9n"                      % "sbt-unidoc"       % "0.4.2")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.0")
 addSbtPlugin("org.foundweekends"                 % "sbt-bintray"      % "0.5.4")
 addSbtPlugin("com.lightbend"                     % "sbt-whitesource"  % "0.1.14")
-addSbtPlugin("com.typesafe.sbt"                  % "sbt-git"          % "0.9.3")
+addSbtPlugin("com.typesafe.sbt"                  % "sbt-git"          % "1.0.0")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,3 +10,4 @@ addSbtPlugin("org.foundweekends"                 % "sbt-bintray"      % "0.5.4")
 addSbtPlugin("com.lightbend"                     % "sbt-whitesource"  % "0.1.14")
 addSbtPlugin("com.typesafe.sbt"                  % "sbt-git"          % "1.0.0")
 
+resolvers += Resolver.jcenterRepo

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.21")
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.1")
 
 addSbtPlugin("de.heikoseeberger"                 % "sbt-header"       % "5.2.0")
 addSbtPlugin("org.scalameta"                      % "sbt-scalafmt"     % "2.0.0-RC5")


### PR DESCRIPTION
## Purpose

Put Akka design on the Akka Management docs.
Use the latest sbt-plugin versions.

## Changes

* Akka Paradox template
* more https
* Version warning support
* Canonical URLs
* reordered Paradox groups so the default will be Java
* extended copyright