### PR TITLE
Add description (which ends up in docs headers)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -240,6 +240,7 @@ lazy val docs = project
       "extref.akka-http-docs.base_url" -> s"https://doc.akka.io/docs/akka-http/${Dependencies.AkkaHttpVersion}/%s.html",
       "extref.java-api.base_url" -> "https://docs.oracle.com/javase/8/docs/api/index.html?%s.html",
       "scaladoc.akka.base_url" -> s"https://doc.akka.io/api/akka/${Dependencies.AkkaVersion}",
+      "scaladoc.akka.http.base_url" -> s"https://doc.akka.io/api/akka-http/${Dependencies.AkkaHttpVersion}/",
       "scaladoc.akka.management.http.base_url" -> s"https://developer.lightbend.com/docs/api/akka-management/${if (isSnapshot.value) "snapshot" else version.value}",
       "scaladoc.version" -> "2.12.0"
     )

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -20,6 +20,7 @@ object Common extends AutoPlugin {
     developers += Developer("contributors", "Contributors", "https://gitter.im/akka/dev", url("https://github.com/akka/akka-management/graphs/contributors")),
 
     licenses := Seq(("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0"))),
+    description := "Akka Management is a suite of tools for operating Akka Clusters.",
     headerLicense := Some(HeaderLicense.Custom("Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>")),
 
     crossScalaVersions := Seq("2.11.12", "2.12.8", "2.13.0-M5"),


### PR DESCRIPTION
## Purpose

Add a meaningfu project description.
Add Scaladoc link support for Akka HTTP.

## References

https://github.com/akka/akka.github.com/issues/568