### PR TITLE
WIP - Cluster bootstrap remoting probe method

### DIFF
--- a/cluster-bootstrap/src/main/resources/reference.conf
+++ b/cluster-bootstrap/src/main/resources/reference.conf
@@ -99,9 +99,14 @@ akka.management {
     # Configured how we communicate with the contact point once it is discovered
     contact-point {
 
+      # The probe method. Valid values are akka-management and remoting. If akka-management, will use akka-management
+      # HTTP interface to discover seed nodes. If remoting, will use Akka remoting to discover seed nodes.
+      probe-method = "akka-management"
+
       # If no port is discovered along with the host/ip of a contact point this port will be used as fallback
       # Also, when no port-name is used and multiple results are returned for a given service, this port is
-      # used to disambiguate. When set to <fallback-port>, defaults to the value of akka.management.http.port
+      # used to disambiguate. When set to <fallback-port>, defaults to the value of akka.management.http.port.
+      # Only used by http probe method, for remoting, the cluster remoting port is used.
       fallback-port = "<fallback-port>" # port pun, it "complements" 2552 which is often used for Akka remoting
 
       # If some discovered seed node will keep failing to connect for specified period of time,
@@ -125,4 +130,17 @@ akka.management {
     }
   }
 
+}
+
+akka.actor {
+  serializers {
+    akka-management-cluster-bootstrap = "akka.management.cluster.bootstrap.internal.BootstrapProtocolSerializer"
+  }
+  serialization-bindings {
+    "akka.management.cluster.bootstrap.contactpoint.HttpBootstrapJsonProtocol$SeedNodes" = akka-management-cluster-bootstrap
+    "akka.management.cluster.bootstrap.internal.RemotingContactPoint$GetSeedNodes$" = akka-management-cluster-bootstrap
+  }
+  serialization-identifiers {
+    "akka.management.cluster.bootstrap.internal.BootstrapProtocolSerializer" = 8788
+  }
 }

--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/ClusterBootstrapSettings.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/ClusterBootstrapSettings.scala
@@ -10,8 +10,10 @@ import java.util.concurrent.TimeUnit
 
 import akka.actor.ActorSystem
 import akka.event.LoggingAdapter
+import akka.management.cluster.bootstrap.internal.BootstrapCoordinator
 import com.typesafe.config.Config
-import scala.concurrent.duration.{ FiniteDuration, _ }
+
+import scala.concurrent.duration.{FiniteDuration, _}
 import scala.compat.java8.OptionConverters._
 import akka.util.JavaDurationConverters._
 
@@ -121,6 +123,10 @@ final class ClusterBootstrapSettings(config: Config, log: LoggingAdapter) {
 
   object contactPoint {
     private val contactPointConfig = bootConfig.getConfig("contact-point")
+
+    val probeMethod: String = contactPointConfig.getString("probe-method")
+
+    require(BootstrapCoordinator.ValidProbeMethods.contains(probeMethod), "Probe method must be one of: " + BootstrapCoordinator.ValidProbeMethods.mkString(", "))
 
     val fallbackPort: Int =
       contactPointConfig

--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/contactpoint/HttpClusterBootstrapRoutes.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/contactpoint/HttpClusterBootstrapRoutes.scala
@@ -5,10 +5,7 @@
 package akka.management.cluster.bootstrap.contactpoint
 
 import scala.concurrent.duration._
-
 import akka.actor.ActorSystem
-import akka.cluster.Cluster
-import akka.cluster.Member
 import akka.event.Logging
 import akka.event.LoggingAdapter
 import akka.http.javadsl.server.directives.RouteAdapter
@@ -16,8 +13,7 @@ import akka.http.scaladsl.model.HttpRequest
 import akka.http.scaladsl.model.Uri
 import akka.http.scaladsl.server.Route
 import akka.management.cluster.bootstrap.ClusterBootstrapSettings
-import akka.management.cluster.bootstrap.contactpoint.HttpBootstrapJsonProtocol.ClusterMember
-import akka.management.cluster.bootstrap.contactpoint.HttpBootstrapJsonProtocol.SeedNodes
+import akka.management.cluster.bootstrap.internal.ContactPoint
 
 final class HttpClusterBootstrapRoutes(settings: ClusterBootstrapSettings) extends HttpBootstrapJsonProtocol {
 
@@ -25,26 +21,8 @@ final class HttpClusterBootstrapRoutes(settings: ClusterBootstrapSettings) exten
 
   private def routeGetSeedNodes: Route = extractClientIP { clientIp ⇒
     extractActorSystem { implicit system ⇒
-      import akka.cluster.MemberStatus
-      val cluster = Cluster(system)
-
-      def memberToClusterMember(m: Member): ClusterMember =
-        ClusterMember(m.uniqueAddress.address, m.uniqueAddress.longUid, m.status.toString, m.roles)
-
-      val state = cluster.state
-
-      // TODO shuffle the members so in a big deployment nodes start joining different ones and not all the same?
-      val members = state.members
-        .diff(state.unreachable)
-        .filter(
-            m => m.status == MemberStatus.up || m.status == MemberStatus.weaklyUp || m.status == MemberStatus.joining)
-        .take(settings.contactPoint.httpMaxSeedNodesToExpose)
-        .map(memberToClusterMember)
-
-      val info = SeedNodes(cluster.selfMember.uniqueAddress.address, members)
-      log.info("Bootstrap request from {}: Contact Point returning {} seed-nodes ([{}])", clientIp, members.size,
-        members)
-      complete(info)
+      val contactPoint = new ContactPoint(system, settings, log)
+      complete(contactPoint.seedNodes(clientIp.toString))
     }
   }
 

--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/internal/AbstractContactPointBootstrap.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/internal/AbstractContactPointBootstrap.scala
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.management.cluster.bootstrap.internal
+
+import java.time.LocalDateTime
+import java.util.concurrent.ThreadLocalRandom
+
+import akka.actor.{Actor, ActorLogging, DeadLetterSuppression, Status, Timers}
+import akka.annotation.InternalApi
+import akka.discovery.ServiceDiscovery.ResolvedTarget
+import akka.management.cluster.bootstrap.ClusterBootstrapSettings
+import akka.util.Timeout
+import akka.pattern.pipe
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+@InternalApi
+private[bootstrap] object AbstractContactPointBootstrap {
+
+  private case object ProbeTick extends DeadLetterSuppression
+  private val ProbingTimerKey = "probing-key"
+}
+
+
+/**
+  * Intended to be spawned as child actor by a higher-level Bootstrap coordinator that manages obtaining of the URIs.
+  *
+  * This additional step may at-first seem superficial -- after all, we already have some addresses of the nodes
+  * that we'll want to join -- however it is not optional. By communicating with the actual nodes before joining their
+  * cluster we're able to inquire about their status, double-check if perhaps they are part of an existing cluster already
+  * that we should join, or even coordinate rolling upgrades or more advanced patterns.
+  */
+@InternalApi
+private[bootstrap] abstract class AbstractContactPointBootstrap(
+  settings: ClusterBootstrapSettings,
+  contactPoint: ResolvedTarget
+) extends Actor
+  with ActorLogging
+  with Timers {
+
+  import AbstractContactPointBootstrap.ProbeTick
+  import AbstractContactPointBootstrap.ProbingTimerKey
+  import akka.management.cluster.bootstrap.contactpoint.HttpBootstrapJsonProtocol._
+  import context.dispatcher
+
+  private val probeInterval = settings.contactPoint.probeInterval
+  private implicit val probingFailureTimeout: Timeout = Timeout(settings.contactPoint.probingFailureTimeout)
+
+  /**
+    * If probing keeps failing until the deadline triggers, we notify the parent,
+    * such that it rediscover again.
+    */
+  private var probingKeepFailingDeadline: Deadline = settings.contactPoint.probingFailureTimeout.fromNow
+
+  private def resetProbingKeepFailingWithinDeadline(): Unit =
+    probingKeepFailingDeadline = settings.contactPoint.probingFailureTimeout.fromNow
+
+  override final def preStart(): Unit =
+    self ! ProbeTick
+
+  override final def receive: Receive = {
+    case ProbeTick ⇒
+      log.debug("Probing [{}] for seed nodes...", uri)
+      probe() pipeTo self
+
+    case Status.Failure(cause) =>
+      log.warning("Probing [{}] failed due to: {}", uri, cause.getMessage)
+      if (probingKeepFailingDeadline.isOverdue()) {
+        log.error("Overdue of probing-failure-timeout, stop probing, signaling that it's failed")
+        context.parent ! BootstrapCoordinator.Protocol.ProbingFailed(contactPoint, cause)
+        context.stop(self)
+      } else {
+        // keep probing, hoping the request will eventually succeed
+        scheduleNextContactPointProbing()
+      }
+
+    case response: SeedNodes ⇒
+      notifyParentAboutSeedNodes(response)
+      resetProbingKeepFailingWithinDeadline()
+      // we keep probing and looking if maybe a cluster does form after all
+      // (technically could be long polling or web-sockets, but that would need reconnect logic, so this is simpler)
+      scheduleNextContactPointProbing()
+  }
+
+  /**
+    * Probe the contact point.
+    *
+    * @param probingFailureTimeout A timeout, if not replied within this timeout, the returned Future should fail.
+    * @return A future of the seed nodes.
+    */
+  protected def probe()(implicit probingFailureTimeout: Timeout): Future[SeedNodes]
+
+  /**
+    * Render the URI of the contact point as a string.
+    *
+    * This is used for logging purposes.
+    */
+  protected def uri: String
+
+  private def notifyParentAboutSeedNodes(members: SeedNodes): Unit = {
+    val seedAddresses = members.seedNodes.map(_.node)
+    context.parent ! BootstrapCoordinator.Protocol.ObtainedHttpSeedNodesObservation(timeNow(), contactPoint,
+      members.selfNode, seedAddresses)
+  }
+
+  private def scheduleNextContactPointProbing(): Unit =
+    timers.startSingleTimer(ProbingTimerKey, ProbeTick, effectiveProbeInterval())
+
+  /** Duration with configured jitter applied */
+  private def effectiveProbeInterval(): FiniteDuration =
+    probeInterval + jitter(probeInterval)
+
+  def jitter(d: FiniteDuration): FiniteDuration =
+    (d.toMillis * settings.contactPoint.probeIntervalJitter * ThreadLocalRandom.current().nextDouble()).millis
+
+  protected def timeNow(): LocalDateTime =
+    LocalDateTime.now()
+
+}

--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/internal/BootstrapProtocolSerializer.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/internal/BootstrapProtocolSerializer.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.management.cluster.bootstrap.internal
+
+import java.io.NotSerializableException
+
+import akka.actor.ExtendedActorSystem
+import akka.management.cluster.bootstrap.contactpoint.HttpBootstrapJsonProtocol.SeedNodes
+import akka.management.cluster.bootstrap.contactpoint.HttpBootstrapJsonProtocol
+import akka.management.cluster.bootstrap.internal.RemotingContactPoint.GetSeedNodes
+import akka.serialization.{BaseSerializer, SerializerWithStringManifest}
+import spray.json._
+
+class BootstrapProtocolSerializer(val system: ExtendedActorSystem) extends SerializerWithStringManifest
+  with BaseSerializer with HttpBootstrapJsonProtocol {
+
+  override def toBinary(obj: AnyRef): Array[Byte] = obj match {
+    case seedNodes: SeedNodes => seedNodes.toJson.compactPrint.getBytes("utf-8")
+    case GetSeedNodes => Array.emptyByteArray
+  }
+
+  override def manifest(obj: AnyRef): String = obj match {
+    case _: SeedNodes => "A"
+    case GetSeedNodes => "B"
+    case _ => throw new IllegalArgumentException(s"Can't serialize object of type ${obj.getClass} in [${getClass.getName}]")
+  }
+
+  override def fromBinary(bytes: Array[Byte], manifest: String): AnyRef = manifest match {
+    case "A" => new String(bytes, "utf-8").parseJson.convertTo[SeedNodes]
+    case "B" => GetSeedNodes
+    case _ => throw new NotSerializableException(
+      s"Unimplemented deserialization of message with manifest [$manifest] in [${getClass.getName}]")
+
+  }
+}

--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/internal/ContactPoint.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/internal/ContactPoint.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.management.cluster.bootstrap.internal
+
+import akka.actor.ActorSystem
+import akka.annotation.InternalApi
+import akka.cluster.{Cluster, Member, MemberStatus}
+import akka.event.LoggingAdapter
+import akka.management.cluster.bootstrap.ClusterBootstrapSettings
+import akka.management.cluster.bootstrap.contactpoint.HttpBootstrapJsonProtocol.{ClusterMember, SeedNodes}
+
+@InternalApi
+private[bootstrap] class ContactPoint(system: ActorSystem, settings: ClusterBootstrapSettings, log: LoggingAdapter) {
+
+  private val cluster = Cluster(system)
+
+  def seedNodes(clientAddress: String): SeedNodes = {
+    def memberToClusterMember(m: Member): ClusterMember =
+      ClusterMember(m.uniqueAddress.address, m.uniqueAddress.longUid, m.status.toString, m.roles)
+
+    val state = cluster.state
+
+    // TODO shuffle the members so in a big deployment nodes start joining different ones and not all the same?
+    val members = state.members
+      .diff(state.unreachable)
+      .filter(
+        m => m.status == MemberStatus.up || m.status == MemberStatus.weaklyUp || m.status == MemberStatus.joining)
+      .take(settings.contactPoint.httpMaxSeedNodesToExpose)
+      .map(memberToClusterMember)
+
+    val info = SeedNodes(cluster.selfMember.uniqueAddress.address, members)
+    log.info("Bootstrap request from {}: Contact Point returning {} seed-nodes ([{}])", clientAddress, members.size,
+      members)
+    info
+  }
+}

--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/internal/HttpContactPointBootstrap.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/internal/HttpContactPointBootstrap.scala
@@ -4,18 +4,11 @@
 
 package akka.management.cluster.bootstrap.internal
 
-import java.time.LocalDateTime
-import java.util.concurrent.ThreadLocalRandom
 import java.util.concurrent.TimeoutException
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import akka.actor.Actor
-import akka.actor.ActorLogging
-import akka.actor.DeadLetterSuppression
 import akka.actor.Props
-import akka.actor.Status
-import akka.actor.Timers
 import akka.annotation.InternalApi
 import akka.cluster.Cluster
 import akka.discovery.ServiceDiscovery.ResolvedTarget
@@ -26,21 +19,17 @@ import akka.http.scaladsl.model.Uri
 import akka.http.scaladsl.settings.ConnectionPoolSettings
 import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.management.cluster.bootstrap.ClusterBootstrapSettings
-import akka.management.cluster.bootstrap.contactpoint.ClusterBootstrapRequests
-import akka.management.cluster.bootstrap.contactpoint.HttpBootstrapJsonProtocol
-import akka.management.cluster.bootstrap.contactpoint.HttpBootstrapJsonProtocol.SeedNodes
+import akka.management.cluster.bootstrap.contactpoint.{ ClusterBootstrapRequests, HttpBootstrapJsonProtocol }
 import akka.pattern.after
 import akka.pattern.pipe
 import akka.stream.ActorMaterializer
+import akka.util.Timeout
 
 @InternalApi
 private[bootstrap] object HttpContactPointBootstrap {
 
-  def props(settings: ClusterBootstrapSettings, contactPoint: ResolvedTarget, baseUri: Uri): Props =
-    Props(new HttpContactPointBootstrap(settings, contactPoint, baseUri))
-
-  private case object ProbeTick extends DeadLetterSuppression
-  private val ProbingTimerKey = "probing-key"
+  def props(settings: ClusterBootstrapSettings, contactPoint: ResolvedTarget): Props =
+    Props(new HttpContactPointBootstrap(settings, contactPoint))
 }
 
 /**
@@ -54,73 +43,41 @@ private[bootstrap] object HttpContactPointBootstrap {
 @InternalApi
 private[bootstrap] class HttpContactPointBootstrap(
     settings: ClusterBootstrapSettings,
-    contactPoint: ResolvedTarget,
-    baseUri: Uri
-) extends Actor
-    with ActorLogging
-    with Timers
-    with HttpBootstrapJsonProtocol {
+    contactPoint: ResolvedTarget
+) extends AbstractContactPointBootstrap(settings, contactPoint) with HttpBootstrapJsonProtocol {
 
-  import HttpContactPointBootstrap.ProbeTick
-  import HttpContactPointBootstrap.ProbingTimerKey
+  import HttpBootstrapJsonProtocol._
 
   private val cluster = Cluster(context.system)
-
-  if (baseUri.authority.host.address() == cluster.selfAddress.host.getOrElse("---") &&
-      baseUri.authority.port == cluster.selfAddress.port.getOrElse(-1)) {
-    throw new IllegalArgumentException(
-        "Requested base Uri to be probed matches local remoting address, bailing out! " +
-        s"Uri: $baseUri, this node's remoting address: ${cluster.selfAddress}")
-  }
 
   private implicit val mat = ActorMaterializer()(context.system)
   private val http = Http()(context.system)
   private val connectionPoolWithoutRetries = ConnectionPoolSettings(context.system).withMaxRetries(0)
   import context.dispatcher
 
-  private val probeInterval = settings.contactPoint.probeInterval
-  private val probeRequest = ClusterBootstrapRequests.bootstrapSeedNodes(baseUri)
-  private val replyTimeout = Future.failed(new TimeoutException(s"Probing timeout of [$baseUri]"))
+  private val probeRequest = {
+    val targetPort = contactPoint.port.getOrElse(settings.contactPoint.fallbackPort)
+    val rawBaseUri = Uri("http", Uri.Authority(Uri.Host(contactPoint.host), targetPort))
+    val baseUri = settings.managementBasePath.fold(rawBaseUri)(prefix => rawBaseUri.withPath(Uri.Path(s"/$prefix")))
 
-  /**
-   * If probing keeps failing until the deadline triggers, we notify the parent,
-   * such that it rediscover again.
-   */
-  private var probingKeepFailingDeadline: Deadline = settings.contactPoint.probingFailureTimeout.fromNow
+    if (baseUri.authority.host.address() == cluster.selfAddress.host.getOrElse("---") &&
+      baseUri.authority.port == cluster.selfAddress.port.getOrElse(-1)) {
+      throw new IllegalArgumentException(
+        "Requested base Uri to be probed matches local remoting address, bailing out! " +
+          s"Uri: $baseUri, this node's remoting address: ${cluster.selfAddress}")
+    }
 
-  private def resetProbingKeepFailingWithinDeadline(): Unit =
-    probingKeepFailingDeadline = settings.contactPoint.probingFailureTimeout.fromNow
+    ClusterBootstrapRequests.bootstrapSeedNodes(baseUri)
+  }
+  private val replyTimeout = Future.failed(new TimeoutException(s"Probing timeout of [${probeRequest.uri}]"))
 
-  override def preStart(): Unit =
-    self ! ProbeTick
+  override val uri: String = probeRequest.uri.toString
 
-  override def receive = {
-    case ProbeTick ⇒
-      val req = ClusterBootstrapRequests.bootstrapSeedNodes(baseUri)
-      log.debug("Probing [{}] for seed nodes...", req.uri)
+  override protected def probe()(implicit probingFailureTimeout: Timeout): Future[SeedNodes] = {
+    val reply = http.singleRequest(probeRequest, settings = connectionPoolWithoutRetries).flatMap(handleResponse)
 
-      val reply = http.singleRequest(probeRequest, settings = connectionPoolWithoutRetries).flatMap(handleResponse)
-
-      val afterTimeout = after(settings.contactPoint.probingFailureTimeout, context.system.scheduler)(replyTimeout)
-      Future.firstCompletedOf(List(reply, afterTimeout)).pipeTo(self)
-
-    case Status.Failure(cause) =>
-      log.warning("Probing [{}] failed due to: {}", probeRequest.uri, cause.getMessage)
-      if (probingKeepFailingDeadline.isOverdue()) {
-        log.error("Overdue of probing-failure-timeout, stop probing, signaling that it's failed")
-        context.parent ! BootstrapCoordinator.Protocol.ProbingFailed(contactPoint, cause)
-        context.stop(self)
-      } else {
-        // keep probing, hoping the request will eventually succeed
-        scheduleNextContactPointProbing()
-      }
-
-    case response: SeedNodes ⇒
-      notifyParentAboutSeedNodes(response)
-      resetProbingKeepFailingWithinDeadline()
-      // we keep probing and looking if maybe a cluster does form after all
-      // (technically could be long polling or web-sockets, but that would need reconnect logic, so this is simpler)
-      scheduleNextContactPointProbing()
+    val afterTimeout = after(settings.contactPoint.probingFailureTimeout, context.system.scheduler)(replyTimeout)
+    Future.firstCompletedOf(List(reply, afterTimeout)).pipeTo(self)
   }
 
   private def handleResponse(response: HttpResponse): Future[SeedNodes] = {
@@ -135,24 +92,4 @@ private[bootstrap] class HttpContactPointBootstrap(
             new IllegalStateException(s"Expected response '200 OK' but found ${response.status}. Body: '$body'"))
       }
   }
-
-  private def notifyParentAboutSeedNodes(members: SeedNodes): Unit = {
-    val seedAddresses = members.seedNodes.map(_.node)
-    context.parent ! BootstrapCoordinator.Protocol.ObtainedHttpSeedNodesObservation(timeNow(), contactPoint,
-      members.selfNode, seedAddresses)
-  }
-
-  private def scheduleNextContactPointProbing(): Unit =
-    timers.startSingleTimer(ProbingTimerKey, ProbeTick, effectiveProbeInterval())
-
-  /** Duration with configured jitter applied */
-  private def effectiveProbeInterval(): FiniteDuration =
-    probeInterval + jitter(probeInterval)
-
-  def jitter(d: FiniteDuration): FiniteDuration =
-    (d.toMillis * settings.contactPoint.probeIntervalJitter * ThreadLocalRandom.current().nextDouble()).millis
-
-  protected def timeNow(): LocalDateTime =
-    LocalDateTime.now()
-
 }

--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/internal/RemotingContactPoint.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/internal/RemotingContactPoint.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.management.cluster.bootstrap.internal
+
+import akka.actor.{Actor, ActorLogging, Props}
+import akka.annotation.InternalApi
+import akka.management.cluster.bootstrap.ClusterBootstrapSettings
+
+@InternalApi
+private[bootstrap] object RemotingContactPoint {
+  case object GetSeedNodes
+
+  val RemotingContactPointActorName = "remotingContactPoint"
+  def props(settings: ClusterBootstrapSettings): Props = Props(new RemotingContactPoint(settings))
+}
+
+@InternalApi
+private[bootstrap] final class RemotingContactPoint(settings: ClusterBootstrapSettings) extends Actor with ActorLogging {
+
+  private val contactPoint = new ContactPoint(context.system, settings, log)
+
+  import RemotingContactPoint.GetSeedNodes
+
+  override def receive: Receive = {
+    case GetSeedNodes =>
+      sender() ! contactPoint.seedNodes(sender().path.address.toString)
+  }
+}

--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/internal/RemotingContactPointBootstrap.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/internal/RemotingContactPointBootstrap.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.management.cluster.bootstrap.internal
+import akka.actor.Props
+import akka.annotation.InternalApi
+import akka.cluster.Cluster
+import akka.discovery.ServiceDiscovery.ResolvedTarget
+import akka.management.cluster.bootstrap.ClusterBootstrapSettings
+import akka.management.cluster.bootstrap.contactpoint.HttpBootstrapJsonProtocol
+import akka.pattern.ask
+import akka.util.Timeout
+
+import scala.concurrent.Future
+
+@InternalApi
+private[bootstrap] object RemotingContactPointBootstrap {
+  def props(settings: ClusterBootstrapSettings, contactPoint: ResolvedTarget): Props =
+    Props(new RemotingContactPointBootstrap(settings, contactPoint))
+}
+
+@InternalApi
+private[bootstrap] final class RemotingContactPointBootstrap(
+  settings: ClusterBootstrapSettings,
+  contactPoint: ResolvedTarget
+) extends AbstractContactPointBootstrap(settings, contactPoint) {
+
+  override protected val uri: String = {
+    val cluster = Cluster(context.system)
+    val targetPort = contactPoint.port
+      .orElse(cluster.selfAddress.port)
+      .getOrElse(throw new IllegalArgumentException("Cannot infer port for contact point"))
+    val address = cluster.selfAddress.copy(host = Some(contactPoint.host), port = Some(targetPort))
+    (self.path.parent.parent / RemotingContactPoint.RemotingContactPointActorName).toStringWithAddress(address)
+  }
+
+  private val remoteContactPoint = context.system.actorSelection(uri)
+
+  /**
+    * Probe the contact point.
+    *
+    * @param probingFailureTimeout A timeout, if not replied within this timeout, the returned Future should fail.
+    * @return A future of the seed nodes.
+    */
+  override protected def probe()(implicit probingFailureTimeout: Timeout): Future[HttpBootstrapJsonProtocol.SeedNodes] = {
+    (remoteContactPoint ? RemotingContactPoint.GetSeedNodes).mapTo[HttpBootstrapJsonProtocol.SeedNodes]
+  }
+}

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/HttpClusterBootstrapIntegrationSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/HttpClusterBootstrapIntegrationSpec.scala
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.management.cluster.bootstrap.contactpoint
+
+import java.net.InetAddress
+
+import akka.actor.ActorSystem
+import akka.cluster.Cluster
+import akka.cluster.ClusterEvent.{ CurrentClusterState, MemberUp }
+import akka.discovery.ServiceDiscovery.{ Resolved, ResolvedTarget }
+import akka.discovery.{ Lookup, MockDiscovery }
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.server.RouteResult
+import akka.management.cluster.bootstrap.ClusterBootstrap
+import akka.stream.ActorMaterializer
+import akka.testkit.{ SocketUtil, TestKit, TestProbe }
+import com.typesafe.config.{ Config, ConfigFactory }
+import org.scalatest.{ Matchers, WordSpecLike }
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+class HttpClusterBootstrapIntegrationSpec extends WordSpecLike with Matchers {
+
+  "Cluster Bootstrap with HTTP probing" should {
+
+    var remotingPorts = Map.empty[String, Int]
+    var contactPointPorts = Map.empty[String, Int]
+
+    def config(id: String): Config = {
+      val Vector(managementPort, remotingPort) =
+        SocketUtil.temporaryServerAddresses(2, "127.0.0.1").map(_.getPort)
+
+      info(s"System [$id]: management port: $managementPort")
+      info(s"System [$id]:   remoting port: $remotingPort")
+
+      contactPointPorts = contactPointPorts.updated(id, managementPort)
+      remotingPorts = remotingPorts.updated(id, remotingPort)
+
+      ConfigFactory.parseString(s"""
+        akka {
+          loglevel = INFO
+
+          cluster.jmx.multi-mbeans-in-same-jvm = on
+
+          # this can be referred to in tests to use the mock discovery implementation
+          discovery.mock-dns.class = "akka.discovery.MockDiscovery"
+
+          cluster.http.management.port = $managementPort
+          remote.netty.tcp.port = $remotingPort
+
+          management {
+
+            cluster.bootstrap {
+              contact-point-discovery {
+                discovery-method = mock-dns
+
+                service-name = "service"
+                port-name = "management2"
+                protocol = "tcp2"
+
+                service-namespace = "svc.cluster.local"
+
+                stable-margin = 4 seconds
+              }
+            }
+          }
+        }
+        """.stripMargin).withFallback(ConfigFactory.load())
+    }
+
+    val systemA = ActorSystem("System", config("A"))
+    val systemB = ActorSystem("System", config("B"))
+    val systemC = ActorSystem("System", config("C"))
+
+    val clusterA = Cluster(systemA)
+    val clusterB = Cluster(systemB)
+    val clusterC = Cluster(systemC)
+
+    val bootstrapA = ClusterBootstrap(systemA)
+    val bootstrapB = ClusterBootstrap(systemB)
+    val bootstrapC = ClusterBootstrap(systemC)
+
+    // prepare the "mock DNS"
+    val name = "service.svc.cluster.local"
+    MockDiscovery.set(Lookup(name, Some("management2"), Some("tcp2")),
+      () =>
+        Future.successful(
+          Resolved(name,
+            List(
+              ResolvedTarget(
+                host = clusterA.selfAddress.host.get,
+                port = contactPointPorts.get("A"),
+                address = Option(InetAddress.getByName(clusterA.selfAddress.host.get))
+              ),
+              ResolvedTarget(
+                host = clusterB.selfAddress.host.get,
+                port = contactPointPorts.get("B"),
+                address = Option(InetAddress.getByName(clusterB.selfAddress.host.get))
+              ),
+              ResolvedTarget(
+                host = clusterC.selfAddress.host.get,
+                port = contactPointPorts.get("C"),
+                address = Option(InetAddress.getByName(clusterC.selfAddress.host.get))
+              )
+            ))
+      ))
+
+    "start listening with the http contact-points on 3 systems" in {
+      def start(system: ActorSystem, contactPointPort: Int) = {
+        import system.dispatcher
+        implicit val sys = system
+        implicit val mat = ActorMaterializer()(system)
+
+        val bootstrap = ClusterBootstrap(system)
+        val routes = new HttpClusterBootstrapRoutes(bootstrap.settings).routes
+        bootstrap.setSelfContactPoint(s"http://127.0.0.1:$contactPointPort")
+        Http().bindAndHandle(RouteResult.route2HandlerFlow(routes), "127.0.0.1", contactPointPort)
+      }
+
+      start(systemA, contactPointPorts("A"))
+      start(systemB, contactPointPorts("B"))
+      start(systemC, contactPointPorts("C"))
+    }
+
+    "join three DNS discovered nodes by forming new cluster (happy path)" in {
+      bootstrapA.discovery.getClass should ===(classOf[MockDiscovery])
+
+      bootstrapA.start()
+      bootstrapB.start()
+      bootstrapC.start()
+
+      val pA = TestProbe()(systemA)
+      clusterA.subscribe(pA.ref, classOf[MemberUp])
+
+      pA.expectMsgType[CurrentClusterState]
+      val up1 = pA.expectMsgType[MemberUp](30.seconds)
+      info("" + up1)
+    }
+
+    "terminate all systems" in {
+      try TestKit.shutdownActorSystem(systemA, 3.seconds)
+      finally try TestKit.shutdownActorSystem(systemB, 3.seconds)
+      finally TestKit.shutdownActorSystem(systemC, 3.seconds)
+    }
+
+  }
+
+}


### PR DESCRIPTION
Some initial work on #453. This has been done in an effort to try and slim down cluster bootstrap, both in terms of complexity and the amount of resources it uses.

This works, but there are a few things to think about.

1. With this in place, we could decouple cluster bootstrap and Akka management HTTP. This would require pulling the HTTP probing method out into its own module, which would effectively make remoting the default.
2. Currently the serializer for the seed nodes reuses the JSON serializers - we might need to reconsider this and use protobuf instead, this would in particular be a good idea if we decouple from Akka management HTTP as the JSON serialization means keeping a dependency on spray-json which could otherwise be dropped.
3. While I've implemented unit tests that show that bootstrapping a cluster of 3 actor systems in the one process works, I haven't implemented any integration tests, eg on k8s, yet.

One nice thing is that remoting doesn't need the same hack that is used to discover the Akka management HTTP bind address.