### PR TITLE
Multiple ecs containers

### DIFF
--- a/discovery-aws-api-async/src/main/resources/reference.conf
+++ b/discovery-aws-api-async/src/main/resources/reference.conf
@@ -12,5 +12,7 @@ akka.discovery {
 
     cluster = "default"
 
+    container-name = ""
+
   }
 }

--- a/discovery-aws-api/src/main/resources/reference.conf
+++ b/discovery-aws-api/src/main/resources/reference.conf
@@ -34,5 +34,7 @@ akka.discovery {
 
     cluster = "default"
 
+    container-name = ""
+
   }
 }

--- a/docs/src/main/paradox/discovery/aws.md
+++ b/docs/src/main/paradox/discovery/aws.md
@@ -131,6 +131,12 @@ you'll do so by setting the value of
 `akka.management.cluster.bootstrap.contact-point-discovery.service-name` to that of the
 ECS service itself.
 
+**NOTE:** If there are multiple containers within a single ECS task definition, 
+the AWS discovery API cannot narrow down the container running Akka application, 
+hence discovery API failed to form cluster properly. Please see the example in
+[integration-test](https://github.com/akka/akka-management/tree/master/integration-test/aws-api-ecs) 
+for how to initialize your cluster properly in this scenario.
+
 Screenshot of two ECS task instances (the service name is
 `liquidity-application`):
 
@@ -164,10 +170,12 @@ akka.discovery {
   aws-api-ecs {
     # Defaults to "default" to match the AWS default cluster name if not overridden
     cluster = "your-ecs-cluster-name"
+    
+    # Defaults to empty string if not overriden. The name of the container in the task definition
+    container-name = ""
   }
 }
 ```
-
 
 ##### akka-discovery-aws-api-async
 
@@ -194,10 +202,12 @@ akka.discovery {
   aws-api-ecs-async {
     # Defaults to "default" to match the AWS default cluster name if not overridden
     cluster = "your-ecs-cluster-name"
+    
+    # Defaults to empty string if not overriden. The name of the container in the task definition
+    container-name = ""
   }
 }
 ```
-
 
 Notes:
 
@@ -227,6 +237,11 @@ Notes:
   too) you'll need to set
   `akka.management.cluster.bootstrap.contact-point.fallback-port = 8558`, where
   8558 is whatever port you choose to bind akka-management to.
+  
+* As mentioned earlier since ECS service discovery doesn't work when there are multiple containers
+  within a single task definition, you need to set either of `akka.discovery.aws-api-ecs-async.container-name` 
+  or `akka.discovery.aws-api-ecs.container-name` (depends on whether you are using async or non-async) to name of
+  the container.
 
 * The current implementation only supports discovery of service task instances
   within the same region.

--- a/integration-test/aws-api-ecs/README.md
+++ b/integration-test/aws-api-ecs/README.md
@@ -65,6 +65,16 @@ just delegates to `aws cloudformation create-stack`):
 
 `./scripts/deploy.sh create`
 
+## Create the cluster with multiple containers in `TaskDefinition` (Optional)
+
+In case the `TaskDefinition` has multiple `ContainerDefinitions` along with `Akka` 
+application (e.g., sidecar), the `ECSServiceDiscovery` can't narrow it down to container 
+running `Akka` application. In this scenario the container name needs to passed 
+to service discovery:
+
+```-Dakka.discovery.aws-api-ecs-async.container-name=ecs-integration-test-app```
+
+`./scripts/deploy-multiple-containers.sh create`
 
 ## Watch it form
 

--- a/integration-test/aws-api-ecs/cfn-templates/ecs-integration-test-app-multiple-containers.yaml
+++ b/integration-test/aws-api-ecs/cfn-templates/ecs-integration-test-app-multiple-containers.yaml
@@ -1,0 +1,132 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Parameters:
+  Subnets:
+    Type: List<AWS::EC2::Subnet::Id>
+Resources:
+  Cluster:
+    Type: AWS::ECS::Cluster
+    Properties:
+      ClusterName: "ecs-integration-test-app"
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Ref AWS::StackName
+      RetentionInDays: 30
+  ExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              Service:
+                - "ecs-tasks.amazonaws.com"
+            Action:
+              - "sts:AssumeRole"
+      ManagedPolicyArns:
+        - "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+  TaskRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              Service:
+                - "ecs-tasks.amazonaws.com"
+            Action:
+              - "sts:AssumeRole"
+      Policies:
+        - PolicyName: "EcsServiceDiscovery"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: "Allow"
+                Action:
+                  - "ecs:ListTasks"
+                  - "ecs:DescribeTasks"
+                Resource: "*"
+  TaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Cpu: 256
+      Memory: 512
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+        - FARGATE
+      ExecutionRoleArn: !GetAtt ExecutionRole.Arn
+      TaskRoleArn: !GetAtt TaskRole.Arn
+      ContainerDefinitions:
+        - Name: ecs-integration-test-app
+          Image:
+            !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/ecs-integration-test-app:1.0"
+          ReadonlyRootFilesystem: true
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref LogGroup
+              awslogs-region: !Ref AWS::Region
+              awslogs-stream-prefix: bootstrap-demo-aws-api-ecs
+          Environment:
+            - Name: JAVA_OPTS
+              Value: !Sub "-Dakka.management.cluster.bootstrap.\
+                contact-point-discovery.service-name=${AWS::StackName}
+                -Dakka.discovery.aws-api-ecs-async.cluster=ecs-integration-test-app
+                -Dakka.discovery.aws-api-ecs-async.container-name=ecs-integration-test-app"
+        - Name: proxy
+          Image: kitematic/hello-world-nginx
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref LogGroup
+              awslogs-region: !Ref AWS::Region
+              awslogs-stream-prefix: bootstrap-demo-aws-api-ecs
+  ServiceSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: !Sub "${AWS::StackName}-service"
+      VpcId: vpc-03ad2b67
+      SecurityGroupIngress:
+        - IpProtocol: "tcp"
+          FromPort: 8558
+          ToPort: 8558
+          CidrIp: "0.0.0.0/0"
+        - IpProtocol: "tcp"
+          FromPort: 8558
+          ToPort: 8558
+          CidrIpv6: "::/0"
+  ServiceSecurityGroupAkkaManagementSelfIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt ServiceSecurityGroup.GroupId
+      IpProtocol: "tcp"
+      FromPort: 8558
+      ToPort: 8558
+      SourceSecurityGroupId: !GetAtt ServiceSecurityGroup.GroupId
+  ServiceSecurityGroupAkkaClusterSelfIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt ServiceSecurityGroup.GroupId
+      IpProtocol: "tcp"
+      FromPort: 2552
+      ToPort: 2552
+      SourceSecurityGroupId: !GetAtt ServiceSecurityGroup.GroupId
+  Service:
+    Type: AWS::ECS::Service
+    Properties:
+      Cluster: !Ref Cluster
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          Subnets: !Ref Subnets
+          AssignPublicIp: ENABLED
+          SecurityGroups:
+            - !GetAtt ServiceSecurityGroup.GroupId
+      LaunchType: FARGATE
+      ServiceName: !Ref AWS::StackName
+      DesiredCount: 5
+      DeploymentConfiguration:
+        MinimumHealthyPercent: 100
+        MaximumPercent: 200
+      TaskDefinition: !Ref TaskDefinition

--- a/integration-test/aws-api-ecs/cfn-templates/ecs-integration-test-app-multiple-containers.yaml
+++ b/integration-test/aws-api-ecs/cfn-templates/ecs-integration-test-app-multiple-containers.yaml
@@ -2,11 +2,19 @@ AWSTemplateFormatVersion: '2010-09-09'
 Parameters:
   Subnets:
     Type: List<AWS::EC2::Subnet::Id>
+  AppName:
+    Type: String
+    Description: "Name of the application"
+    Default: "ecs-integration-test-app"
+  ClusterStackName:
+    Type: String
+    Description: ""
+    Default: "ecs-integration-test-cluster"
 Resources:
   Cluster:
     Type: AWS::ECS::Cluster
     Properties:
-      ClusterName: "ecs-integration-test-app"
+      ClusterName: !Ref ClusterStackName
   LogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
@@ -59,7 +67,7 @@ Resources:
       ExecutionRoleArn: !GetAtt ExecutionRole.Arn
       TaskRoleArn: !GetAtt TaskRole.Arn
       ContainerDefinitions:
-        - Name: ecs-integration-test-app
+        - Name: !Ref AppName
           Image:
             !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/ecs-integration-test-app:1.0"
           ReadonlyRootFilesystem: true
@@ -73,8 +81,8 @@ Resources:
             - Name: JAVA_OPTS
               Value: !Sub "-Dakka.management.cluster.bootstrap.\
                 contact-point-discovery.service-name=${AWS::StackName}
-                -Dakka.discovery.aws-api-ecs-async.cluster=ecs-integration-test-app
-                -Dakka.discovery.aws-api-ecs-async.container-name=ecs-integration-test-app"
+                -Dakka.discovery.aws-api-ecs-async.cluster=${ClusterStackName}
+                -Dakka.discovery.aws-api-ecs-async.container-name=${AppName}"
         - Name: proxy
           Image: kitematic/hello-world-nginx
           LogConfiguration:

--- a/integration-test/aws-api-ecs/scripts/deploy-multiple-containers.sh
+++ b/integration-test/aws-api-ecs/scripts/deploy-multiple-containers.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [ $# -ne 1 ]
+  then
+    echo "Usage: $0 <create|update>"
+    exit 1
+fi
+
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+case $1 in
+  create | update)
+    ACTION=$1
+    ;;
+  *)
+    echo "Usage: $0 <create|update>"
+   exit 1
+    ;;
+esac
+
+VPC_ID=$(
+  aws ec2 describe-vpcs \
+    --region us-east-1 \
+    --filters \
+      Name=isDefault,Values=true \
+    --output text \
+    --query \
+      "Vpcs[0].VpcId"
+)
+SUBNETS=$(
+  aws ec2 describe-subnets \
+    --region us-east-1 \
+    --filter \
+      Name=vpcId,Values=$VPC_ID \
+      Name=defaultForAz,Values=true \
+    --output text \
+    --query \
+      "Subnets[].SubnetId | join(',', @)"
+)
+
+aws cloudformation $ACTION-stack \
+  --region us-east-1 \
+  --stack-name ecs-integration-test-app \
+  --template-body file://$DIR/../cfn-templates/ecs-integration-test-app-multiple-containers.yaml \
+  --capabilities CAPABILITY_IAM \
+  --parameters \
+    ParameterKey=Subnets,ParameterValue=\"$SUBNETS\"
+
+aws cloudformation wait stack-$ACTION-complete \
+  --region us-east-1 \
+  --stack-name ecs-integration-test-app


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [Y ] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [ Y] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [Y ] Have you updated the documentation?
* [ Y] Have you added tests for any changed functionality?
-->
## Purpose

To allow ECS service discovery to work with multiple containers in ECS task definition.

## References

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please DON`T use `Fixes` notation.
-->
References #542

## Changes

Introduced optional `akka.discovery.aws-api-ecs.container-name` config to provide container name
if there are multiple containers in ECS task definition to allow ECS service discovery to narrow down
the container running Akka application.

## Background Context

As mentioned in issue #542 with multiple containers in ECS task definition the service discovery failed form cluster, by providing `container-name` service discovery can filter container running Akka application.
