### PR TITLE
Use ServiceAccount subject kind rather than user

### DIFF
--- a/docs/src/main/paradox/bootstrap/kubernetes-api.md
+++ b/docs/src/main/paradox/bootstrap/kubernetes-api.md
@@ -15,7 +15,7 @@ An example deployment (used for integration testing):
 
 An example role and rolebinding to allow the nodes to query the Kubernetes API server:
 
-@@snip [akka-cluster.yml](/integration-test/kubernetes-api/kubernetes/akka-cluster.yml) { #rbac}
+@@snip [akka-cluster.yml](/integration-test/kubernetes-api/kubernetes/akka-cluster.yml) { #rbac }
 
 The User name includes the namespace, this will need updated for your namespace.
 

--- a/docs/src/main/paradox/discovery/kubernetes.md
+++ b/docs/src/main/paradox/discovery/kubernetes.md
@@ -102,8 +102,8 @@ Adjust as necessary.
 ---
 #
 # Create a role, `pod-reader`, that can list pods and
-# bind the default service account in the `default` namespace
-# to that role.
+# bind the default service account in the namespace
+# that the binding is deployed to to that role.
 #
 
 kind: Role
@@ -120,10 +120,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: read-pods
 subjects:
-# Note the `name` line below. The first default refers to the namespace. The second refers to the service account name.
-# For instance, `name: system:serviceaccount:myns:default` would refer to the default service account in namespace `myns`
-- kind: User
-  name: system:serviceaccount:default:default
+- kind: ServiceAccount
+  name: default
 roleRef:
   kind: Role
   name: pod-reader

--- a/docs/src/main/paradox/discovery/kubernetes.md
+++ b/docs/src/main/paradox/discovery/kubernetes.md
@@ -98,32 +98,4 @@ Adjust as necessary.
 
 > Using Google Kubernetes Engine? Your user will need permission to grant roles. See [Google's Documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control#prerequisites_for_using_role-based_access_control) for more information.
 
-```yaml
----
-#
-# Create a role, `pod-reader`, that can list pods and
-# bind the default service account in the namespace
-# that the binding is deployed to to that role.
-#
-
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: pod-reader
-rules:
-- apiGroups: [""] # "" indicates the core API group
-  resources: ["pods"]
-  verbs: ["get", "watch", "list"]
----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: read-pods
-subjects:
-- kind: ServiceAccount
-  name: default
-roleRef:
-  kind: Role
-  name: pod-reader
-  apiGroup: rbac.authorization.k8s.io
-```
+@@snip [akka-cluster.yml](/integration-test/kubernetes-api/kubernetes/akka-cluster.yml) { #rbac }

--- a/integration-test/kubernetes-api-java/kubernetes/akka-cluster.yml
+++ b/integration-test/kubernetes-api-java/kubernetes/akka-cluster.yml
@@ -49,6 +49,12 @@ spec:
               apiVersion: v1
               fieldPath: "metadata.labels['app']"
 ---
+#
+# Create a role, `pod-reader`, that can list pods and
+# bind the default service account in the namespace
+# that the binding is deployed to to that role.
+#
+
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -63,9 +69,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: read-pods
 subjects:
-  # Creates the default user for the akka-bootstrap-demo-ns namespace, change for your namespace
-- kind: User
-  name: system:serviceaccount:akka-bootstrap-demo-ns:default
+  # Uses the default service account.
+  # Consider creating a dedicated service account to run your
+  # Akka Cluster services and binding the role to that one.
+- kind: ServiceAccount
+  name: default
 roleRef:
   kind: Role
   name: pod-reader

--- a/integration-test/kubernetes-api/kubernetes/akka-cluster.yml
+++ b/integration-test/kubernetes-api/kubernetes/akka-cluster.yml
@@ -60,6 +60,12 @@ spec:
 #deployment
 ---
 #rbac
+#
+# Create a role, `pod-reader`, that can list pods and
+# bind the default service account in the namespace
+# that the binding is deployed to to that role.
+#
+
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -74,9 +80,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: read-pods
 subjects:
-  # Create the default user for the 'akka-bootstrap-demo-ns' namespace, update for the namespace you are running in
-- kind: User
-  name: system:serviceaccount:akka-bootstrap-demo-ns:default
+  # Uses the default service account.
+  # Consider creating a dedicated service account to run your
+  # Akka Cluster services and binding the role to that one.
+- kind: ServiceAccount
+  name: default
 roleRef:
   kind: Role
   name: pod-reader


### PR DESCRIPTION
This is much simpler from a configuration perspective as it doesn't require understanding the service account user name string format, and it also allows the namespace to default to the namespace that the role binding is deployed to, which is usually what you want, and so means that role binding yaml specs can be used as is regardless of which namespace they are deployed to.

One caveat, I could not find any documentation on what should happen when no namespace is specified. Intuitively, it should use the namespace the role binding is deployed to, and I have confirmed through experimentation that this appears to be the case. I've raised this issue to get this documented:

https://github.com/kubernetes/website/issues/14624