### PR TITLE
Be more flexible in what jabba jdk to use for whitesource

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ jobs:
 
   - stage: whitesource
     script:
-      - jabba use "adopt@1.8.192-12"
+      - jabba use "adopt@~1.8.192-12"
       - git branch -f "$TRAVIS_BRANCH" && git checkout "$TRAVIS_BRANCH" && sbt 'set credentials += Credentials("whitesource", "whitesourcesoftware.com", "", System.getenv("WHITESOURCE_KEY"))' whitesourceCheckPolicies whitesourceUpdate
     name: "Check licenses with WhiteSource"
 


### PR DESCRIPTION
should fix failure seen at https://travis-ci.org/akka/akka-management/builds/546627026