### PR TITLE
Fix links to discovery methods from the AWS document

### DIFF
--- a/docs/src/main/paradox/discovery/aws.md
+++ b/docs/src/main/paradox/discovery/aws.md
@@ -10,18 +10,18 @@ This module is community maintained and the Lightbend subscription doesn't cover
 
 If you're using EC2 directly _or_ you're using ECS with host mode networking
 _and_ you're deploying one container per cluster member, continue to
-@ref:[Discovery Method: AWS API - EC2 Tag-Based Discovery](index.md#discovery-method-aws-api-ec2-tag-based-discovery).
+@ref:[Discovery Method: AWS API - EC2 Tag-Based Discovery](aws.md#discovery-method-aws-api-ec2-tag-based-discovery).
 
 If you're using ECS with
 [awsvpcs](https://aws.amazon.com/blogs/compute/introducing-cloud-native-networking-for-ecs-containers/)
 mode networking (whether on EC2 or with
 [Fargate](https://aws.amazon.com/fargate/)), continue to
-@ref:[Discovery Method: AWS API - ECS Discovery](index.md#discovery-method-aws-api-ecs-discovery).
+@ref:[Discovery Method: AWS API - ECS Discovery](aws.md#discovery-method-aws-api-ecs-discovery).
 
 ECS with bridge mode networking is not supported.
 
 If you're using EKS, then you may want to use the
-@ref:['Kubernetes API'-based discovery method](index.md#discovery-method-kubernetes-api)
+@ref:['Kubernetes API'-based discovery method](kubernetes.md)
 instead.
 
 


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?
-->
## Purpose/Changes

Fix broken links in the AWS discovery document.

## Background Context

<!-- Why did you take this approach? -->
Each API type has its own page now.
