### PR TITLE
Uniform URL scheme for bootstrap URLs

### DIFF
--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/ClusterBootstrap.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/ClusterBootstrap.scala
@@ -86,8 +86,9 @@ final class ClusterBootstrap(implicit system: ExtendedActorSystem) extends Exten
       val bootstrapProps = BootstrapCoordinator.props(discovery, joinDecider, settings)
       val bootstrap = system.systemActorOf(bootstrapProps, "bootstrapCoordinator")
       // Bootstrap already logs in several other execution points when it can't form a cluster, and why.
-      val initiateBootstrapping = selfContactPoint.map(BootstrapCoordinator.Protocol.InitiateBootstrapping)
-      initiateBootstrapping pipeTo bootstrap
+      selfContactPoint.foreach {
+        uri => bootstrap ! BootstrapCoordinator.Protocol.InitiateBootstrapping(uri)
+      }
     } else log.warning("Bootstrap already initiated, yet start() method was called again. Ignoring.")
 
   /**

--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/ClusterBootstrap.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/ClusterBootstrap.scala
@@ -8,7 +8,7 @@ import java.util.concurrent.atomic.AtomicReference
 
 import akka.AkkaVersion
 
-import scala.concurrent.{Future, Promise, TimeoutException}
+import scala.concurrent.{ Future, Promise, TimeoutException }
 import scala.concurrent.duration._
 import akka.actor.ActorSystem
 import akka.actor.ExtendedActorSystem
@@ -17,7 +17,7 @@ import akka.actor.ExtensionId
 import akka.actor.ExtensionIdProvider
 import akka.annotation.InternalApi
 import akka.cluster.Cluster
-import akka.discovery.{Discovery, ServiceDiscovery}
+import akka.discovery.{ Discovery, ServiceDiscovery }
 import akka.event.Logging
 import akka.http.scaladsl.model.Uri
 import akka.http.scaladsl.server.Route
@@ -55,8 +55,10 @@ final class ClusterBootstrap(implicit system: ExtendedActorSystem) extends Exten
 
   private val joinDecider: JoinDecider = {
     system.dynamicAccess
-      .createInstanceFor[JoinDecider](settings.joinDecider.implClass,
-        List((classOf[ActorSystem], system), (classOf[ClusterBootstrapSettings], settings)))
+      .createInstanceFor[JoinDecider](
+        settings.joinDecider.implClass,
+        List((classOf[ActorSystem], system), (classOf[ClusterBootstrapSettings], settings))
+      )
       .get
   }
 
@@ -72,10 +74,11 @@ final class ClusterBootstrap(implicit system: ExtendedActorSystem) extends Exten
   def start(): Unit =
     if (Cluster(system).settings.SeedNodes.nonEmpty) {
       log.warning(
-          "Application is configured with specific `akka.cluster.seed-nodes`: {}, bailing out of the bootstrap process! " +
-          "If you want to use the automatic bootstrap mechanism, make sure to NOT set explicit seed nodes in the configuration. " +
-          "This node will attempt to join the configured seed nodes.",
-          Cluster(system).settings.SeedNodes.mkString("[", ", ", "]"))
+        "Application is configured with specific `akka.cluster.seed-nodes`: {}, bailing out of the bootstrap process! " +
+        "If you want to use the automatic bootstrap mechanism, make sure to NOT set explicit seed nodes in the configuration. " +
+        "This node will attempt to join the configured seed nodes.",
+        Cluster(system).settings.SeedNodes.mkString("[", ", ", "]")
+      )
     } else if (bootstrapStep.compareAndSet(NotRunning, Initializing)) {
       log.info("Initiating bootstrap procedure using {} method...", settings.contactPointDiscovery.discoveryMethod)
 

--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/ClusterBootstrap.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/ClusterBootstrap.scala
@@ -25,6 +25,7 @@ import akka.management.cluster.bootstrap.contactpoint.HttpClusterBootstrapRoutes
 import akka.management.cluster.bootstrap.internal.BootstrapCoordinator
 import akka.management.scaladsl.ManagementRouteProviderSettings
 import akka.management.scaladsl.ManagementRouteProvider
+import akka.pattern.pipe
 
 final class ClusterBootstrap(implicit system: ExtendedActorSystem) extends Extension with ManagementRouteProvider {
 
@@ -81,7 +82,8 @@ final class ClusterBootstrap(implicit system: ExtendedActorSystem) extends Exten
       val bootstrapProps = BootstrapCoordinator.props(discovery, joinDecider, settings)
       val bootstrap = system.systemActorOf(bootstrapProps, "bootstrapCoordinator")
       // Bootstrap already logs in several other execution points when it can't form a cluster, and why.
-      bootstrap ! BootstrapCoordinator.Protocol.InitiateBootstrapping
+      val initiateBootstrapping = selfContactPoint.map(BootstrapCoordinator.Protocol.InitiateBootstrapping)
+      initiateBootstrapping pipeTo bootstrap
     } else log.warning("Bootstrap already initiated, yet start() method was called again. Ignoring.")
 
   /**
@@ -91,18 +93,13 @@ final class ClusterBootstrap(implicit system: ExtendedActorSystem) extends Exten
    * This allows us to "reverse lookup" from a lowest-address sorted contact point list,
    * that we discover via discovery, if a given contact point corresponds to our remoting address,
    * and if so, we may opt to join ourselves using the address.
-   *
-   * @return true if successfully set, false otherwise (i.e. was set already)
    */
   @InternalApi
   private[akka] def setSelfContactPoint(baseUri: Uri): Unit =
     _selfContactPointUri.success(baseUri)
 
   /** INTERNAL API */
-  @InternalApi private[akka] def selfContactPoint: Future[(String, Int)] =
-    _selfContactPointUri.future.map { uri =>
-      (uri.authority.host.toString, uri.authority.port)
-    }
+  @InternalApi private[akka] def selfContactPoint: Future[Uri] = _selfContactPointUri.future
 }
 
 object ClusterBootstrap extends ExtensionId[ClusterBootstrap] with ExtensionIdProvider {

--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/ClusterBootstrap.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/ClusterBootstrap.scala
@@ -7,9 +7,9 @@ package akka.management.cluster.bootstrap
 import java.util.concurrent.atomic.AtomicReference
 
 import akka.AkkaVersion
-import scala.concurrent.Future
-import scala.concurrent.Promise
 
+import scala.concurrent.{Future, Promise, TimeoutException}
+import scala.concurrent.duration._
 import akka.actor.ActorSystem
 import akka.actor.ExtendedActorSystem
 import akka.actor.Extension
@@ -17,7 +17,7 @@ import akka.actor.ExtensionId
 import akka.actor.ExtensionIdProvider
 import akka.annotation.InternalApi
 import akka.cluster.Cluster
-import akka.discovery.{ Discovery, ServiceDiscovery }
+import akka.discovery.{Discovery, ServiceDiscovery}
 import akka.event.Logging
 import akka.http.scaladsl.model.Uri
 import akka.http.scaladsl.server.Route
@@ -79,12 +79,28 @@ final class ClusterBootstrap(implicit system: ExtendedActorSystem) extends Exten
     } else if (bootstrapStep.compareAndSet(NotRunning, Initializing)) {
       log.info("Initiating bootstrap procedure using {} method...", settings.contactPointDiscovery.discoveryMethod)
 
+      ensureSelfContactPoint()
       val bootstrapProps = BootstrapCoordinator.props(discovery, joinDecider, settings)
       val bootstrap = system.systemActorOf(bootstrapProps, "bootstrapCoordinator")
       // Bootstrap already logs in several other execution points when it can't form a cluster, and why.
       val initiateBootstrapping = selfContactPoint.map(BootstrapCoordinator.Protocol.InitiateBootstrapping)
       initiateBootstrapping pipeTo bootstrap
     } else log.warning("Bootstrap already initiated, yet start() method was called again. Ignoring.")
+
+  /**
+   * INTERNAL API
+   *
+   * We give the required selfContactPoint some time to be set asynchronously, or else log an error.
+   */
+  @InternalApi private[bootstrap] def ensureSelfContactPoint(): Unit = system.scheduler.scheduleOnce(10.seconds) {
+    if (!selfContactPoint.isCompleted) {
+      _selfContactPointUri.failure(new TimeoutException("Awaiting Bootstrap.selfContactPoint timed out."))
+      log.error(
+        "'Bootstrap.selfContactPoint' was NOT set, but is required for the bootstrap to work " +
+        "if binding bootstrap routes manually and not via akka-management."
+      )
+    }
+  }
 
   /**
    * INTERNAL API

--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/SelfAwareJoinDecider.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/SelfAwareJoinDecider.scala
@@ -20,7 +20,7 @@ import akka.event.Logging
  * leveraging self host logic.
  */
 @InternalApi private[bootstrap] abstract class SelfAwareJoinDecider(system: ActorSystem,
-                                                                    settings: ClusterBootstrapSettings)
+    settings: ClusterBootstrapSettings)
     extends JoinDecider {
 
   protected val log = Logging(system, getClass)
@@ -34,10 +34,13 @@ import akka.event.Logging
    * during [[akka.management.scaladsl.AkkaManagement.start()]], hence we accept blocking on
    * this initialization.
    */
-  private[bootstrap] def selfContactPoint: (String, Int) =
-    Try(Await.result(ClusterBootstrap(system).selfContactPoint, 10.seconds)).getOrElse(throw new IllegalStateException(
+  private[bootstrap] def selfContactPoint: (String, Int) = {
+    Try(Await.result(ClusterBootstrap(system).selfContactPoint, 10.seconds))
+        .map(uri => (uri.authority.host.toString, uri.authority.port))
+        .getOrElse(throw new IllegalStateException(
           "'Bootstrap.selfContactPoint' was NOT set, but is required for the bootstrap to work " +
-          "if binding bootstrap routes manually and not via akka-management."))
+              "if binding bootstrap routes manually and not via akka-management."))
+  }
 
   /**
    * Determines whether it has the need and ability to join self and create a new cluster.

--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/SelfAwareJoinDecider.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/SelfAwareJoinDecider.scala
@@ -18,9 +18,10 @@ import scala.concurrent.duration._
  * Class for further behavior in a [[akka.management.cluster.bootstrap.JoinDecider]]
  * leveraging self host logic.
  */
-@InternalApi private[bootstrap] abstract class SelfAwareJoinDecider(system: ActorSystem,
-    settings: ClusterBootstrapSettings)
-    extends JoinDecider {
+@InternalApi private[bootstrap] abstract class SelfAwareJoinDecider(
+    system: ActorSystem,
+    settings: ClusterBootstrapSettings
+) extends JoinDecider {
 
   protected val log = Logging(system, getClass)
 
@@ -36,9 +37,8 @@ import scala.concurrent.duration._
    */
   private[bootstrap] def selfContactPoint: (String, Int) =
     Await.result(
-      ClusterBootstrap(system)
-          .selfContactPoint
-          .map(uri => (uri.authority.host.toString, uri.authority.port))(system.dispatcher),
+      ClusterBootstrap(system).selfContactPoint
+        .map(uri => (uri.authority.host.toString, uri.authority.port))(system.dispatcher),
       Duration.Inf // the future has a timeout
     )
 
@@ -50,8 +50,11 @@ import scala.concurrent.duration._
     if (matchesSelf(target, self)) true
     else {
       if (!info.contactPoints.exists(matchesSelf(_, self))) {
-        log.warning("Self contact point [{}] not found in targets {}", contactPointString(selfContactPoint),
-          info.contactPoints.mkString(", "))
+        log.warning(
+          "Self contact point [{}] not found in targets {}",
+          contactPointString(selfContactPoint),
+          info.contactPoints.mkString(", ")
+        )
       }
       false
     }

--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/internal/HttpContactPointBootstrap.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/internal/HttpContactPointBootstrap.scala
@@ -96,11 +96,8 @@ private[bootstrap] class HttpContactPointBootstrap(
 
   override def receive = {
     case ProbeTick =>
-      val req = ClusterBootstrapRequests.bootstrapSeedNodes(baseUri)
-      log.debug("Probing [{}] for seed nodes...", req.uri)
-
+      log.debug("Probing [{}] for seed nodes...", probeRequest.uri)
       val reply = http.singleRequest(probeRequest, settings = connectionPoolWithoutRetries).flatMap(handleResponse)
-
       val afterTimeout = after(settings.contactPoint.probingFailureTimeout, context.system.scheduler)(replyTimeout)
       Future.firstCompletedOf(List(reply, afterTimeout)).pipeTo(self)
 

--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/internal/HttpContactPointBootstrap.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/internal/HttpContactPointBootstrap.scala
@@ -69,8 +69,9 @@ private[bootstrap] class HttpContactPointBootstrap(
   if (baseUri.authority.host.address() == cluster.selfAddress.host.getOrElse("---") &&
       baseUri.authority.port == cluster.selfAddress.port.getOrElse(-1)) {
     throw new IllegalArgumentException(
-        "Requested base Uri to be probed matches local remoting address, bailing out! " +
-        s"Uri: $baseUri, this node's remoting address: ${cluster.selfAddress}")
+      "Requested base Uri to be probed matches local remoting address, bailing out! " +
+      s"Uri: $baseUri, this node's remoting address: ${cluster.selfAddress}"
+    )
   }
 
   private implicit val mat = ActorMaterializer()(context.system)
@@ -129,14 +130,19 @@ private[bootstrap] class HttpContactPointBootstrap(
       strictEntity.flatMap { entity =>
         val body = entity.data.utf8String
         Future.failed(
-            new IllegalStateException(s"Expected response '200 OK' but found ${response.status}. Body: '$body'"))
+          new IllegalStateException(s"Expected response '200 OK' but found ${response.status}. Body: '$body'")
+        )
       }
   }
 
   private def notifyParentAboutSeedNodes(members: SeedNodes): Unit = {
     val seedAddresses = members.seedNodes.map(_.node)
-    context.parent ! BootstrapCoordinator.Protocol.ObtainedHttpSeedNodesObservation(timeNow(), contactPoint,
-      members.selfNode, seedAddresses)
+    context.parent ! BootstrapCoordinator.Protocol.ObtainedHttpSeedNodesObservation(
+      timeNow(),
+      contactPoint,
+      members.selfNode,
+      seedAddresses
+    )
   }
 
   private def scheduleNextContactPointProbing(): Unit =

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/internal/BootstrapCoordinatorSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/internal/BootstrapCoordinatorSpec.scala
@@ -6,21 +6,23 @@ package akka.management.cluster.bootstrap.internal
 
 import java.util.concurrent.atomic.AtomicReference
 
-import akka.actor.{ ActorRef, ActorSystem, Props }
-import akka.discovery.ServiceDiscovery.{ Resolved, ResolvedTarget }
-import akka.discovery.{ Lookup, MockDiscovery }
+import akka.actor.{ActorRef, ActorSystem, Props}
+import akka.discovery.ServiceDiscovery.{Resolved, ResolvedTarget}
+import akka.discovery.{Lookup, MockDiscovery}
+import akka.http.scaladsl.model.Uri
 import akka.management.cluster.bootstrap.internal.BootstrapCoordinator.Protocol.InitiateBootstrapping
-import akka.management.cluster.bootstrap.{ ClusterBootstrapSettings, LowestAddressJoinDecider }
+import akka.management.cluster.bootstrap.{ClusterBootstrapSettings, LowestAddressJoinDecider}
 import com.typesafe.config.ConfigFactory
 import org.scalatest.concurrent.Eventually
-import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpec }
-import org.scalatest.time.{ Span, Seconds, Millis }
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+import org.scalatest.time.{Millis, Seconds, Span}
 
-import scala.concurrent.{ Await, Future }
+import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
 
 class BootstrapCoordinatorSpec extends WordSpec with Matchers with BeforeAndAfterAll with Eventually {
   val serviceName = "bootstrap-coordinator-test-service"
+  val selfUri = Uri("http://localhost:8558/")
   val system = ActorSystem("test", ConfigFactory.parseString(s"""
       |akka.management.cluster.bootstrap {
       | contact-point-discovery.service-name = $serviceName
@@ -58,7 +60,7 @@ class BootstrapCoordinatorSpec extends WordSpec with Matchers with BeforeAndAfte
           None
         }
       }))
-      coordinator ! InitiateBootstrapping
+      coordinator ! InitiateBootstrapping(selfUri)
       eventually {
         val targetsToCheck = targets.get
         targetsToCheck.length should be >= (2)

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/internal/BootstrapCoordinatorSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/internal/BootstrapCoordinatorSpec.scala
@@ -11,7 +11,10 @@ import akka.discovery.ServiceDiscovery.{Resolved, ResolvedTarget}
 import akka.discovery.{Lookup, MockDiscovery}
 import akka.http.scaladsl.model.Uri
 import akka.management.cluster.bootstrap.internal.BootstrapCoordinator.Protocol.InitiateBootstrapping
-import akka.management.cluster.bootstrap.{ClusterBootstrapSettings, LowestAddressJoinDecider}
+import akka.management.cluster.bootstrap.{
+  ClusterBootstrapSettings,
+  LowestAddressJoinDecider
+}
 import com.typesafe.config.ConfigFactory
 import org.scalatest.concurrent.Eventually
 import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
@@ -20,7 +23,11 @@ import org.scalatest.time.{Millis, Seconds, Span}
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
 
-class BootstrapCoordinatorSpec extends WordSpec with Matchers with BeforeAndAfterAll with Eventually {
+class BootstrapCoordinatorSpec
+    extends WordSpec
+    with Matchers
+    with BeforeAndAfterAll
+    with Eventually {
   val serviceName = "bootstrap-coordinator-test-service"
   val selfUri = Uri("http://localhost:8558/")
   val system = ActorSystem("test", ConfigFactory.parseString(s"""
@@ -33,7 +40,8 @@ class BootstrapCoordinatorSpec extends WordSpec with Matchers with BeforeAndAfte
 
   val discovery = new MockDiscovery(system)
 
-  override implicit val patienceConfig = PatienceConfig(timeout = Span(5, Seconds), interval = Span(100, Millis))
+  override implicit val patienceConfig =
+    PatienceConfig(timeout = Span(5, Seconds), interval = Span(100, Millis))
 
   "The bootstrap coordinator, when avoiding named port lookups" should {
 
@@ -52,14 +60,18 @@ class BootstrapCoordinatorSpec extends WordSpec with Matchers with BeforeAndAfte
       )
 
       val targets = new AtomicReference[List[ResolvedTarget]](Nil)
-      val coordinator = system.actorOf(Props(new BootstrapCoordinator(discovery, joinDecider, settings) {
-        override def ensureProbing(contactPoint: ResolvedTarget): Option[ActorRef] = {
-          println(s"Resolving $contactPoint")
-          val targetsSoFar = targets.get
-          targets.compareAndSet(targetsSoFar, contactPoint +: targetsSoFar)
-          None
-        }
-      }))
+      val coordinator = system.actorOf(
+        Props(new BootstrapCoordinator(discovery, joinDecider, settings) {
+          override def ensureProbing(
+            contactPoint: ResolvedTarget
+          ): Option[ActorRef] = {
+            println(s"Resolving $contactPoint")
+            val targetsSoFar = targets.get
+            targets.compareAndSet(targetsSoFar, contactPoint +: targetsSoFar)
+            None
+          }
+        })
+      )
       coordinator ! InitiateBootstrapping(selfUri)
       eventually {
         val targetsToCheck = targets.get

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/internal/BootstrapCoordinatorSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/internal/BootstrapCoordinatorSpec.scala
@@ -105,7 +105,7 @@ class BootstrapCoordinatorSpec
           None
         }
       }))
-      coordinator ! InitiateBootstrapping
+      coordinator ! InitiateBootstrapping(selfUri)
       eventually {
         val targetsToCheck = targets.get
         targetsToCheck.length should be >= (2)

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/internal/BootstrapCoordinatorSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/internal/BootstrapCoordinatorSpec.scala
@@ -6,35 +6,31 @@ package akka.management.cluster.bootstrap.internal
 
 import java.util.concurrent.atomic.AtomicReference
 
-import akka.actor.{ActorRef, ActorSystem, Props}
-import akka.discovery.ServiceDiscovery.{Resolved, ResolvedTarget}
-import akka.discovery.{Lookup, MockDiscovery}
+import akka.actor.{ ActorRef, ActorSystem, Props }
+import akka.discovery.ServiceDiscovery.{ Resolved, ResolvedTarget }
+import akka.discovery.{ Lookup, MockDiscovery }
 import akka.http.scaladsl.model.Uri
 import akka.management.cluster.bootstrap.internal.BootstrapCoordinator.Protocol.InitiateBootstrapping
-import akka.management.cluster.bootstrap.{
-  ClusterBootstrapSettings,
-  LowestAddressJoinDecider
-}
+import akka.management.cluster.bootstrap.{ ClusterBootstrapSettings, LowestAddressJoinDecider }
 import com.typesafe.config.ConfigFactory
 import org.scalatest.concurrent.Eventually
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
-import org.scalatest.time.{Millis, Seconds, Span}
+import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpec }
+import org.scalatest.time.{ Millis, Seconds, Span }
 
-import scala.concurrent.{Await, Future}
+import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration._
 
-class BootstrapCoordinatorSpec
-    extends WordSpec
-    with Matchers
-    with BeforeAndAfterAll
-    with Eventually {
+class BootstrapCoordinatorSpec extends WordSpec with Matchers with BeforeAndAfterAll with Eventually {
   val serviceName = "bootstrap-coordinator-test-service"
   val selfUri = Uri("http://localhost:8558/")
-  val system = ActorSystem("test", ConfigFactory.parseString(s"""
+  val system = ActorSystem(
+    "test",
+    ConfigFactory.parseString(s"""
       |akka.management.cluster.bootstrap {
       | contact-point-discovery.service-name = $serviceName
       |}
-    """.stripMargin).withFallback(ConfigFactory.load()))
+    """.stripMargin).withFallback(ConfigFactory.load())
+  )
   val settings = ClusterBootstrapSettings(system.settings.config, system.log)
   val joinDecider = new LowestAddressJoinDecider(system, settings)
 
@@ -50,21 +46,25 @@ class BootstrapCoordinatorSpec
       MockDiscovery.set(
         Lookup(serviceName, portName = None, protocol = Some("tcp")),
         () =>
-          Future.successful(Resolved(serviceName,
-            List(
-              ResolvedTarget("host1", Some(2552), None),
-              ResolvedTarget("host1", Some(8558), None),
-              ResolvedTarget("host2", Some(2552), None),
-              ResolvedTarget("host2", Some(8558), None)
-            )))
+          Future.successful(
+            Resolved(
+              serviceName,
+              List(
+                ResolvedTarget("host1", Some(2552), None),
+                ResolvedTarget("host1", Some(8558), None),
+                ResolvedTarget("host2", Some(2552), None),
+                ResolvedTarget("host2", Some(8558), None)
+              )
+            )
+          )
       )
 
       val targets = new AtomicReference[List[ResolvedTarget]](Nil)
       val coordinator = system.actorOf(
         Props(new BootstrapCoordinator(discovery, joinDecider, settings) {
           override def ensureProbing(
-            selfContactPoint: Uri,
-            contactPoint: ResolvedTarget
+              selfContactPoint: Uri,
+              contactPoint: ResolvedTarget
           ): Option[ActorRef] = {
             println(s"Resolving $contactPoint")
             val targetsSoFar = targets.get
@@ -88,13 +88,17 @@ class BootstrapCoordinatorSpec
       MockDiscovery.set(
         Lookup(serviceName, portName = None, protocol = Some("tcp")),
         () =>
-          Future.successful(Resolved(serviceName,
-            List(
-              ResolvedTarget("host1", None, None),
-              ResolvedTarget("host1", None, None),
-              ResolvedTarget("host2", None, None),
-              ResolvedTarget("host2", None, None)
-            )))
+          Future.successful(
+            Resolved(
+              serviceName,
+              List(
+                ResolvedTarget("host1", None, None),
+                ResolvedTarget("host1", None, None),
+                ResolvedTarget("host2", None, None),
+                ResolvedTarget("host2", None, None)
+              )
+            )
+          )
       )
 
       val targets = new AtomicReference[List[ResolvedTarget]](Nil)
@@ -128,7 +132,11 @@ class BootstrapCoordinatorSpec
       )
 
       BootstrapCoordinator.selectHosts(
-        Lookup.create("service").withPortName("cats"), 8558, filterOnFallbackPort = true, beforeFiltering) shouldEqual beforeFiltering
+        Lookup.create("service").withPortName("cats"),
+        8558,
+        filterOnFallbackPort = true,
+        beforeFiltering
+      ) shouldEqual beforeFiltering
     }
 
     // For example when using DNS A-record-based discovery in K8s
@@ -140,8 +148,7 @@ class BootstrapCoordinatorSpec
         ResolvedTarget("host2", Some(4), None)
       )
 
-      BootstrapCoordinator.selectHosts(
-        Lookup.create("service"), 8558, filterOnFallbackPort = true, beforeFiltering) shouldEqual List(
+      BootstrapCoordinator.selectHosts(Lookup.create("service"), 8558, filterOnFallbackPort = true, beforeFiltering) shouldEqual List(
         ResolvedTarget("host1", Some(8558), None),
         ResolvedTarget("host2", Some(8558), None)
       )
@@ -156,8 +163,7 @@ class BootstrapCoordinatorSpec
         ResolvedTarget("host2", Some(4), None)
       )
 
-      BootstrapCoordinator.selectHosts(
-        Lookup.create("service"), 8558, filterOnFallbackPort = false, beforeFiltering) shouldEqual beforeFiltering
+      BootstrapCoordinator.selectHosts(Lookup.create("service"), 8558, filterOnFallbackPort = false, beforeFiltering) shouldEqual beforeFiltering
     }
 
     "not filter if there is a single target per host" in {
@@ -168,8 +174,9 @@ class BootstrapCoordinatorSpec
         ResolvedTarget("host4", Some(4), None)
       )
 
-      BootstrapCoordinator.selectHosts(
-        Lookup.create("service"), 8558, filterOnFallbackPort = true, beforeFiltering).toSet shouldEqual beforeFiltering.toSet
+      BootstrapCoordinator
+        .selectHosts(Lookup.create("service"), 8558, filterOnFallbackPort = true, beforeFiltering)
+        .toSet shouldEqual beforeFiltering.toSet
     }
   }
 

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/internal/BootstrapCoordinatorSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/internal/BootstrapCoordinatorSpec.scala
@@ -63,6 +63,7 @@ class BootstrapCoordinatorSpec
       val coordinator = system.actorOf(
         Props(new BootstrapCoordinator(discovery, joinDecider, settings) {
           override def ensureProbing(
+            selfContactPoint: Uri,
             contactPoint: ResolvedTarget
           ): Option[ActorRef] = {
             println(s"Resolving $contactPoint")
@@ -98,7 +99,7 @@ class BootstrapCoordinatorSpec
 
       val targets = new AtomicReference[List[ResolvedTarget]](Nil)
       val coordinator = system.actorOf(Props(new BootstrapCoordinator(discovery, joinDecider, settings) {
-        override def ensureProbing(contactPoint: ResolvedTarget): Option[ActorRef] = {
+        override def ensureProbing(selfContactPoint: Uri, contactPoint: ResolvedTarget): Option[ActorRef] = {
           println(s"Resolving $contactPoint")
           val targetsSoFar = targets.get
           targets.compareAndSet(targetsSoFar, contactPoint +: targetsSoFar)

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/internal/BootstrapCoordinatorSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/internal/BootstrapCoordinatorSpec.scala
@@ -63,7 +63,7 @@ class BootstrapCoordinatorSpec extends WordSpec with Matchers with BeforeAndAfte
       val coordinator = system.actorOf(
         Props(new BootstrapCoordinator(discovery, joinDecider, settings) {
           override def ensureProbing(
-              selfContactPoint: Uri,
+              selfContactPointScheme: String,
               contactPoint: ResolvedTarget
           ): Option[ActorRef] = {
             println(s"Resolving $contactPoint")
@@ -103,7 +103,7 @@ class BootstrapCoordinatorSpec extends WordSpec with Matchers with BeforeAndAfte
 
       val targets = new AtomicReference[List[ResolvedTarget]](Nil)
       val coordinator = system.actorOf(Props(new BootstrapCoordinator(discovery, joinDecider, settings) {
-        override def ensureProbing(selfContactPoint: Uri, contactPoint: ResolvedTarget): Option[ActorRef] = {
+        override def ensureProbing(selfContactPointScheme: String, contactPoint: ResolvedTarget): Option[ActorRef] = {
           println(s"Resolving $contactPoint")
           val targetsSoFar = targets.get
           targets.compareAndSet(targetsSoFar, contactPoint +: targetsSoFar)


### PR DESCRIPTION
Fixes #603 

When bootstrapping, all nodes must necessarily use the same URL scheme for bootstrapping endpoints, either HTTP or HTTPS. Otherwise, the nodes that use HTTP do not see the nodes that use HTTPS, and vice versa.

Currently, the URL scheme is hard-coded to `"http"` which makes nodes that expose their endpoints via HTTPS uncontactable. This pull request makes it so that contact points will be contacted with the same scheme of the node's own base URL. That is, if the own node exposes it's management enpoints via HTTPS, then other nodes will also be contacted via HTTPS. This is based on the premise that the scheme must be uniform.

PS: I don't think this is a "backwards incompatible change" because change only affects cluster-bootstrap deployments that use HTTPS. But in the current version it's not possible to deploy bootstrap with HTTPS, because those nodes cannot be contacted due to the hard-coded `"http"` protocol. So in the broad scope this change only affects deployments that are already non-functional, so it's purely a fix, not a change.