### PR TITLE
Fix fallback port behavior on multiple resolved targets

### DIFF
--- a/cluster-bootstrap/src/main/resources/reference.conf
+++ b/cluster-bootstrap/src/main/resources/reference.conf
@@ -101,8 +101,9 @@ akka.management {
     contact-point {
 
       # If no port is discovered along with the host/ip of a contact point this port will be used as fallback
-      # Also, when no port-name is used and multiple results are returned for a given service, this port is
-      # used to disambiguate. When set to <fallback-port>, defaults to the value of akka.management.http.port
+      # Also, when no port-name is used and multiple results are returned for a given service with at least one
+      # port defined, this port is used to disambiguate. When set to <fallback-port>, defaults to the value of
+      # akka.management.http.port
       fallback-port = "<fallback-port>"
 
       # If some discovered seed node will keep failing to connect for specified period of time,

--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/internal/BootstrapCoordinator.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/internal/BootstrapCoordinator.scala
@@ -182,7 +182,11 @@ private[akka] class BootstrapCoordinator(discovery: ServiceDiscovery,
             case (host, immutable.Seq(singleResult)) =>
               immutable.Seq(singleResult)
             case (host, multipleResults) =>
-              multipleResults.filter(_.port.contains(settings.contactPoint.fallbackPort))
+              if (multipleResults.exists(_.port.isDefined)) {
+                multipleResults.filter(_.port.contains(settings.contactPoint.fallbackPort))
+              } else {
+                multipleResults
+              }
           }
 
       log.info("Located service members based on: [{}]: [{}], filtered to [{}]", lookup, contactPoints.mkString(", "),


### PR DESCRIPTION
Related to:
* https://github.com/akka/akka-management/issues/542
* https://github.com/akka/akka-management/pull/552

The behavior/description of setting the fallback-port for cluster-bootstrap is unexpected in the case of having multiple `ResolvedTarget` with the same host but no port defined.
Currently, the fallback-port will actually filter out all the found hosts.

I changed this, in the case of not a single defined port, to use the fallback-port.
