### PR TITLE
Scaladoc: make use of new flags

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -255,7 +255,7 @@ lazy val docs = project
         "scaladoc.akka.http.base_url" -> s"https://doc.akka.io/api/akka-http/${Dependencies.AkkaHttpVersion}/",
         "extref.akka-grpc.base_url" -> s"https://doc.akka.io/docs/akka-grpc/current/%s",
         "extref.akka-enhancements.base_url" -> s"https://doc.akka.io/docs/akka-enhancements/current/%s",
-        "scaladoc.akka.management.base_url" -> s"/${(Preprocess / siteSubdirName).value}/",
+        "scaladoc.akka.management.base_url" -> s"/${(Preprocess / siteSubdirName).value}/"
       ),
     publishRsyncArtifact := makeSite.value -> "www/",
     publishRsyncHost := "akkarepo@gustav.akka.io"

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -28,7 +28,7 @@ object Common extends AutoPlugin {
       licenses := Seq(("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0"))),
       description := "Akka Management is a suite of tools for operating Akka Clusters.",
       headerLicense := Some(HeaderLicense.Custom("Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>")),
-      crossScalaVersions := Seq("2.11.12", "2.12.8", "2.13.0"),
+      crossScalaVersions := Seq(Dependencies.Scala211, Dependencies.Scala212, Dependencies.Scala213),
       projectInfoVersion := (if (isSnapshot.value) "snapshot" else version.value),
       crossVersion := CrossVersion.binary,
       scalacOptions ++= Seq(
@@ -43,33 +43,45 @@ object Common extends AutoPlugin {
           "-target:jvm-1.8"
         ),
       javacOptions ++= Seq(
-          "-Xlint:unchecked",
+          "-Xlint:unchecked"
         ),
       javacOptions ++= (
-        if (isJdk8) Seq.empty
-        else Seq("--release", "8")
-      ),
+          if (isJdk8) Seq.empty
+          else Seq("--release", "8")
+        ),
       Compile / doc / scalacOptions := scalacOptions.value ++ Seq(
           "-doc-title",
           "Akka Management",
           "-doc-version",
           version.value,
-          "-sourcepath",
-          (baseDirectory in ThisBuild).value.toString,
-          "-doc-source-url", {
-            val branch = if (isSnapshot.value) "master" else s"v${version.value}"
-            s"https://github.com/akka/akka-management/tree/${branch}€{FILE_PATH}.scala#L1"
-          },
           "-skip-packages",
           "akka.pattern" // for some reason Scaladoc creates this
         ),
+      Compile / doc / scalacOptions ++= (scalaVersion.value match {
+          case Dependencies.Scala211 =>
+            Seq(
+              "-doc-source-url", {
+                val branch = if (isSnapshot.value) "master" else s"v${version.value}"
+                s"https://github.com/akka/akka-management/tree/${branch}€{FILE_PATH}.scala#L1"
+              }
+            )
+          case _ =>
+            Seq(
+              "-doc-source-url", {
+                val branch = if (isSnapshot.value) "master" else s"v${version.value}"
+                s"https://github.com/akka/akka-management/tree/${branch}€{FILE_PATH_EXT}#L€{FILE_LINE}"
+              },
+              "-doc-canonical-base-url",
+              "https://doc.akka.io/api/akka-management/current/"
+            )
+        }),
       autoAPIMappings := true,
       // show full stack traces and test case durations
       testOptions in Test += Tests.Argument("-oDF"),
       // -v Log "test run started" / "test started" / "test run finished" events on log level "info" instead of "debug".
       // -a Show stack traces and exception class name for AssertionErrors.
       testOptions += Tests.Argument(TestFrameworks.JUnit, "-v", "-a"),
-      scalaVersion := "2.12.8"
+      scalaVersion := Dependencies.Scala212
     )
 
   private def isJdk8 =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,6 +3,10 @@ import Keys._
 
 object Dependencies {
 
+  val Scala211 = "2.11.12"
+  val Scala212 = "2.12.10"
+  val Scala213 = "2.13.0"
+
   val AkkaVersion = "2.5.23"
   val AkkaHttpVersion = "10.1.10"
 


### PR DESCRIPTION
## Purpose

* Upgrades to Scala 2.12.10
* Uses the new Scaladoc flags introduced in 2.12.9 and 2.13.0 for better links to source and adding canonical URLs

## References

References https://github.com/akka/akka.github.com/issues/623
