### PR TITLE
bootstrap: access discovery lazily in ClusterBootstrap extension

### DIFF
--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/ClusterBootstrap.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/ClusterBootstrap.scala
@@ -40,7 +40,7 @@ final class ClusterBootstrap(implicit system: ExtendedActorSystem) extends Exten
   val settings: ClusterBootstrapSettings = ClusterBootstrapSettings(system.settings.config, log)
 
   // used for initial discovery of contact points
-  val discovery: ServiceDiscovery =
+  lazy val discovery: ServiceDiscovery =
     settings.contactPointDiscovery.discoveryMethod match {
       case "akka.discovery" =>
         val discovery = Discovery(system).discovery

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/InactiveBootstrapSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/InactiveBootstrapSpec.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.management.cluster.bootstrap
+
+import akka.actor.ActorSystem
+import akka.management.scaladsl.AkkaManagement
+
+class InactiveBootstrapSpec extends AbstractBootstrapSpec {
+  val system = ActorSystem("InactiveBootstrapSpec")
+
+  "cluster-bootstrap on the classpath" should {
+    "not fail management routes if bootstrap is not configured or used" in {
+      // this will call ClusterBootstrap(system) which should not fail even if discovery is not configured
+      AkkaManagement(system)
+    }
+  }
+
+  override protected def afterAll(): Unit = system.terminate()
+}


### PR DESCRIPTION
This allows to have the cluster-bootstrap module on the classpath without
actually configuring it. The management routes automatically instantiate
ClusterBootstrap when on the classpath. This fails when discovery is not
configured.

Fixes #519.
