### PR TITLE
Use TaskSets to discover nodes in ECS

### DIFF
--- a/discovery-aws-api-async/src/main/resources/reference.conf
+++ b/discovery-aws-api-async/src/main/resources/reference.conf
@@ -13,4 +13,12 @@ akka.discovery {
     cluster = "default"
 
   }
+
+  aws-api-ecs-task-set-async {
+
+    class = akka.discovery.awsapi.ecs.AsyncEcsTaskSetDiscovery
+
+    cluster = "default"
+
+  }
 }

--- a/discovery-aws-api-async/src/main/scala/akka/discovery/awsapi/ecs/AsyncEcsDiscovery.scala
+++ b/discovery-aws-api-async/src/main/scala/akka/discovery/awsapi/ecs/AsyncEcsDiscovery.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.discovery.awsapi.ecs
+
+import java.net.{ InetAddress, NetworkInterface }
+
+import scala.collection.JavaConverters._
+
+import akka.annotation.ApiMayChange
+
+@ApiMayChange
+object AsyncEcsDiscovery {
+
+  // InetAddress.getLocalHost.getHostAddress throws an exception when running
+  // in awsvpc mode because the container name cannot be resolved.
+  // ECS provides a metadata file
+  // (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/container-metadata.html)
+  // that we ought to be able to use instead to find our IP address, but the
+  // metadata file does not get set when running on Fargate. So this is our
+  // only option for determining what the canonical Akka and akka-management
+  // hostname values should be set to.
+  def getContainerAddress: Either[String, InetAddress] =
+    NetworkInterface.getNetworkInterfaces.asScala
+      .flatMap(_.getInetAddresses.asScala)
+      .filterNot(_.isLoopbackAddress)
+      .filter(_.isSiteLocalAddress)
+      .toList match {
+      case List(value) =>
+        Right(value)
+
+      case other =>
+        Left(s"Exactly one private address must be configured (found: $other).")
+    }
+}

--- a/discovery-aws-api-async/src/main/scala/akka/discovery/awsapi/ecs/AsyncEcsServiceDiscovery.scala
+++ b/discovery-aws-api-async/src/main/scala/akka/discovery/awsapi/ecs/AsyncEcsServiceDiscovery.scala
@@ -4,7 +4,7 @@
 
 package akka.discovery.awsapi.ecs
 
-import java.net.{ InetAddress, NetworkInterface }
+import java.net.InetAddress
 import java.util.concurrent.TimeoutException
 
 import akka.actor.ActorSystem
@@ -65,27 +65,6 @@ class AsyncEcsServiceDiscovery(system: ActorSystem) extends ServiceDiscovery {
 
 @ApiMayChange
 object AsyncEcsServiceDiscovery {
-
-  // InetAddress.getLocalHost.getHostAddress throws an exception when running
-  // in awsvpc mode because the container name cannot be resolved.
-  // ECS provides a metadata file
-  // (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/container-metadata.html)
-  // that we ought to be able to use instead to find our IP address, but the
-  // metadata file does not get set when running on Fargate. So this is our
-  // only option for determining what the canonical Akka and akka-management
-  // hostname values should be set to.
-  def getContainerAddress: Either[String, InetAddress] =
-    NetworkInterface.getNetworkInterfaces.asScala
-      .flatMap(_.getInetAddresses.asScala)
-      .filterNot(_.isLoopbackAddress)
-      .filter(_.isSiteLocalAddress)
-      .toList match {
-      case List(value) =>
-        Right(value)
-
-      case other =>
-        Left(s"Exactly one private address must be configured (found: $other).")
-    }
 
   private def resolveTasks(ecsClient: EcsAsyncClient, cluster: String, serviceName: String)(
       implicit ec: ExecutionContext

--- a/discovery-aws-api-async/src/main/scala/akka/discovery/awsapi/ecs/AsyncEcsTaskSetDiscovery.scala
+++ b/discovery-aws-api-async/src/main/scala/akka/discovery/awsapi/ecs/AsyncEcsTaskSetDiscovery.scala
@@ -4,7 +4,7 @@
 
 package akka.discovery.awsapi.ecs
 
-import java.net.{ InetAddress, NetworkInterface }
+import java.net.InetAddress
 import java.util.concurrent.TimeoutException
 
 import scala.collection.JavaConverters._
@@ -59,7 +59,7 @@ class AsyncEcsTaskSetDiscovery(system: ActorSystem) extends ServiceDiscovery {
     Future.firstCompletedOf(
       Seq(
         after(resolveTimeout, using = system.scheduler)(
-          Future.failed(new TimeoutException("Future timed out!"))
+          Future.failed(new TimeoutException(s"$lookup timed out after $resolveTimeout"))
         ),
         resolveTasks(ecsClient, cluster, httpClient).map(
           tasks =>
@@ -89,27 +89,6 @@ object AsyncEcsTaskSetDiscovery {
   private[this] implicit val orderFormat = jsonFormat1(TaskMetadata)
 
   private val ECS_CONTAINER_METADATA_URI_PATH = "ECS_CONTAINER_METADATA_URI"
-
-  // InetAddress.getLocalHost.getHostAddress throws an exception when running
-  // in awsvpc mode because the container name cannot be resolved.
-  // ECS provides a metadata file
-  // (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/container-metadata.html)
-  // that we ought to be able to use instead to find our IP address, but the
-  // metadata file does not get set when running on Fargate. So this is our
-  // only option for determining what the canonical Akka and akka-management
-  // hostname values should be set to.
-  def getContainerAddress: Either[String, InetAddress] =
-    NetworkInterface.getNetworkInterfaces.asScala
-      .flatMap(_.getInetAddresses.asScala)
-      .filterNot(_.isLoopbackAddress)
-      .filter(_.isSiteLocalAddress)
-      .toList match {
-      case List(value) =>
-        Right(value)
-
-      case other =>
-        Left(s"Exactly one private address must be configured (found: $other).")
-    }
 
   private def resolveTasks(ecsClient: EcsAsyncClient, cluster: String, httpClient: HttpExt)(
       implicit

--- a/discovery-aws-api-async/src/main/scala/akka/discovery/awsapi/ecs/AsyncEcsTaskSetDiscovery.scala
+++ b/discovery-aws-api-async/src/main/scala/akka/discovery/awsapi/ecs/AsyncEcsTaskSetDiscovery.scala
@@ -41,19 +41,19 @@ import spray.json.DefaultJsonProtocol._
 @ApiMayChange
 class AsyncEcsTaskSetDiscovery(system: ActorSystem) extends ServiceDiscovery {
 
-  private[this] val config = system.settings.config.getConfig("akka.discovery.aws-api-ecs-task-set-async")
-  private[this] val cluster = config.getString("cluster")
+  private val config = system.settings.config.getConfig("akka.discovery.aws-api-ecs-task-set-async")
+  private val cluster = config.getString("cluster")
 
-  private[this] lazy val ecsClient = {
+  private lazy val ecsClient = {
     val conf = ClientOverrideConfiguration.builder().retryPolicy(RetryPolicy.none).build()
     EcsAsyncClient.builder().overrideConfiguration(conf).build()
   }
 
-  private[this] implicit val actorSystem: ActorSystem = system
-  private[this] implicit val materializer: ActorMaterializer = ActorMaterializer()
-  private[this] implicit val ec: ExecutionContext = system.dispatcher
+  private implicit val actorSystem: ActorSystem = system
+  private implicit val materializer: ActorMaterializer = ActorMaterializer()
+  private implicit val ec: ExecutionContext = system.dispatcher
 
-  private[this] val httpClient: HttpExt = Http()
+  private val httpClient: HttpExt = Http()
 
   override def lookup(lookup: Lookup, resolveTimeout: FiniteDuration): Future[Resolved] =
     Future.firstCompletedOf(

--- a/docs/src/main/paradox/discovery/aws.md
+++ b/docs/src/main/paradox/discovery/aws.md
@@ -139,10 +139,8 @@ Screenshot of two ECS task instances (the service name is
 
 #### Dependencies and usage (ECS Discovery)
 
-There are two "flavours" of the ECS Discovery module. Functionally they are
-identical; the difference is in which version of the AWS SDK they use. They are
-both provided so that you can choose which set of AWS SDK dependencies you're
-most comfortable with bringing in to your project.
+There are two "flavours" of the ECS Discovery module. One offers service-discovery using
+the AWS SDK with blocking IO and the second one uses the newer AWS SDK with non-blocking IO.
 
 ##### akka-discovery-aws-api
 
@@ -186,7 +184,11 @@ Once the async AWS SDK is out of preview it is likely that the
   version="$project.version$"
 }
 
-And in your `application.conf`:
+We have 2 approaches in ECS: `aws-api-ecs-async` and `aws-api-ecs-task-set-async`.
+
+###### aws-api-ecs-async
+
+In your `application.conf`:
 
 ```
 akka.discovery {
@@ -197,6 +199,31 @@ akka.discovery {
   }
 }
 ```
+
+This will query the AWS API to retrieve all running tasks of the ESC service specified at
+`akka.management.cluster.bootstrap.contact-point-discovery.service-name`.
+
+###### aws-api-ecs-task-set-async
+
+If you use AWS CodeDeploy, you probably want to use this method of discovery.
+
+In your `application.conf`:
+
+```
+akka.discovery {
+  method = aws-api-ecs-task-set-async
+  aws-api-ecs-task-set-async {
+    # Defaults to "default" to match the AWS default cluster name if not overridden
+    cluster = "your-ecs-cluster-name"
+  }
+}
+```
+
+The service-discovery works in 3 steps:
+1. Query the internal ECS metadata API to retrieve the TaskARN of itself 
+(See [AWS docs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v3.html))
+2. Retrieve the TaskSet to which the TaskARN belongs
+3. Retrieve all Tasks belonging to that TaskSet
 
 
 Notes:

--- a/docs/src/main/paradox/discovery/aws.md
+++ b/docs/src/main/paradox/discovery/aws.md
@@ -247,7 +247,7 @@ Notes:
   to set this explicitly. An alternative host address discovery method is
   provided by both modules. The methods are
   `EcsSimpleServiceDiscovery.getContainerAddress` and
-  `AsyncEcsSimpleServiceDiscovery.getContainerAddress` respectively, which you
+  `AsyncEcsDiscovery.getContainerAddress` respectively, which you
   should use to programmatically set both config hostnames.
 
 * Because ECS service discovery is only able to discover IP addresses (not ports

--- a/integration-test/aws-api-ecs/src/main/scala/akka/cluster/bootstrap/EcsApiDemoApp.scala
+++ b/integration-test/aws-api-ecs/src/main/scala/akka/cluster/bootstrap/EcsApiDemoApp.scala
@@ -7,7 +7,7 @@ package akka.cluster.bootstrap
 import java.net.InetAddress
 
 import akka.actor.ActorSystem
-import akka.discovery.awsapi.ecs.AsyncEcsServiceDiscovery
+import akka.discovery.awsapi.ecs.AsyncEcsDiscovery
 import akka.management.cluster.bootstrap.ClusterBootstrap
 import akka.management.scaladsl.AkkaManagement
 import com.typesafe.config.ConfigFactory
@@ -37,7 +37,7 @@ object EcsApiDemoApp {
   }
 
   private[this] def getPrivateAddressOrExit: InetAddress =
-    AsyncEcsServiceDiscovery.getContainerAddress match {
+    AsyncEcsDiscovery.getContainerAddress match {
       case Left(error) =>
         System.err.println(s"$error Halting.")
         sys.exit(1)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -126,6 +126,7 @@ object Dependencies {
     libraryDependencies ++=
       DependencyGroups.AkkaActor ++
       DependencyGroups.AkkaDiscovery ++
+      DependencyGroups.AkkaHttp ++
       DependencyGroups.Aws2Ecs
   )
 


### PR DESCRIPTION
## Purpose

Add a new discovery method for Akka in ECS Fargate using TaskSets.

## Changes

1. Add `aws-api-ecs-task-set-async`
2. Update aws docs
3. Tested on our own instances using AWS CodeDeploy

## Background Context

ECS can be used together with AWS CodeDeploy to support blue/green deployments.
These new nodes are spawned in the same service-group. Therefore, we need a new approach to make sure nodes only form a cluster with only newly spawned nodes.
Otherwise, the new nodes will join the existing AkkaCluster forming 1 large cluster instead of 2 smaller ones.
