### PR TITLE
Include failing/timed out check name in health/readiness check response

### DIFF
--- a/management/src/main/scala/akka/management/scaladsl/HealthChecks.scala
+++ b/management/src/main/scala/akka/management/scaladsl/HealthChecks.scala
@@ -36,11 +36,21 @@ abstract class HealthChecks {
   def ready(): Future[Boolean]
 
   /**
+   * Returns Future(result) containing the system's readiness result
+   */
+  def readyResult(): Future[Either[String, Unit]]
+
+  /**
    * Returns Future(true) to indicate that the process is alive but does not
    * mean that it is ready to receive traffic e.g. is has not joined the cluster
    * or is loading initial state from a database
    */
   def alive(): Future[Boolean]
+
+  /**
+   * Returns Future(result) containing the system's liveness result
+   */
+  def aliveResult(): Future[Either[String, Unit]]
 }
 
 object ReadinessCheckSetup {

--- a/management/src/test/java/akka/management/HealthCheckTest.java
+++ b/management/src/test/java/akka/management/HealthCheckTest.java
@@ -74,6 +74,8 @@ public class HealthCheckTest extends JUnitSuite {
                 "alive",
                 java.time.Duration.ofSeconds(1)
         ));
+        assertEquals(true, checks.aliveResult().toCompletableFuture().get().isSuccess());
+        assertEquals(true, checks.readyResult().toCompletableFuture().get().isSuccess());
         assertEquals(true, checks.alive().toCompletableFuture().get());
         assertEquals(true, checks.ready().toCompletableFuture().get());
     }
@@ -88,6 +90,8 @@ public class HealthCheckTest extends JUnitSuite {
                 "alive",
                 java.time.Duration.ofSeconds(1)
         ));
+        assertEquals(true, checks.aliveResult().toCompletableFuture().get().isSuccess());
+        assertEquals(true, checks.readyResult().toCompletableFuture().get().isSuccess());
         assertEquals(true, checks.alive().toCompletableFuture().get());
         assertEquals(true, checks.ready().toCompletableFuture().get());
     }
@@ -107,7 +111,7 @@ public class HealthCheckTest extends JUnitSuite {
             checks.alive().toCompletableFuture().get();
             Assert.fail("Expected exception");
         } catch (ExecutionException re) {
-            assertEquals(cause, re.getCause());
+            assertEquals(cause, re.getCause().getCause());
         }
     }
 
@@ -129,6 +133,8 @@ public class HealthCheckTest extends JUnitSuite {
               "alive",
               java.time.Duration.ofSeconds(1)
             ));
+            assertEquals(false, checks.aliveResult().toCompletableFuture().get().isSuccess());
+            assertEquals(false, checks.readyResult().toCompletableFuture().get().isSuccess());
             assertEquals(false, checks.alive().toCompletableFuture().get());
             assertEquals(false, checks.ready().toCompletableFuture().get());
       } finally {


### PR DESCRIPTION
Include failing check name in health/readiness check messages/responses

This modifies the readiness/health check internals to ensure that when a check fails, for any reason, that the check's class name is included in the message to aid in debugging. Additionally, timeouts are now tracked on a per-check basis so that it's clear which check timed out.

~I haven't updated the tests yet -- if I could get some validation/assurance that such a chance would be accepted, then I'd be happy to get the tests passing.~

*Ready for a review.*

Example failure:

```
$ curl  192.168.1.20:8558/ready

Health Check Failed: Check [com.myco.GrpcReadinessCheck] failed: UNAVAILABLE: io exception
```
