### PR TITLE
AWS: Introduced a way to define amazon's endpoint and region

### DIFF
--- a/discovery-aws-api/src/main/resources/reference.conf
+++ b/discovery-aws-api/src/main/resources/reference.conf
@@ -23,6 +23,9 @@ akka.discovery {
     # to the list of Akka Management port numbers
     ports = []
 
+    # client may use specified endpoint and region for example ec2.us-west-1.amazonaws.com and us-west-1
+    endpoint = ""
+    region = ""
   }
 
   # Set the following in your application.conf if you want to use this discovery mechanism:
@@ -34,5 +37,8 @@ akka.discovery {
 
     cluster = "default"
 
+    # client may use specified endpoint and region for example ec2.us-west-1.amazonaws.com and us-west-1
+    endpoint = ""
+    region = ""
   }
 }

--- a/discovery-aws-api/src/main/resources/reference.conf
+++ b/discovery-aws-api/src/main/resources/reference.conf
@@ -24,8 +24,8 @@ akka.discovery {
     ports = []
 
     # client may use specified endpoint and region for example ec2.us-west-1.amazonaws.com and us-west-1
-    endpoint = ""
-    region = ""
+    # endpoint = ""
+    # region = ""
   }
 
   # Set the following in your application.conf if you want to use this discovery mechanism:
@@ -38,7 +38,7 @@ akka.discovery {
     cluster = "default"
 
     # client may use specified endpoint and region for example ec2.us-west-1.amazonaws.com and us-west-1
-    endpoint = ""
-    region = ""
+    # endpoint = ""
+    # region = ""
   }
 }

--- a/discovery-aws-api/src/main/scala/akka/discovery/awsapi/ec2/Ec2TagBasedServiceDiscovery.scala
+++ b/discovery-aws-api/src/main/scala/akka/discovery/awsapi/ec2/Ec2TagBasedServiceDiscovery.scala
@@ -108,9 +108,7 @@ class Ec2TagBasedServiceDiscovery(system: ExtendedActorSystem) extends ServiceDi
       case None =>
         defaultClientConfiguration
     }
-    val builder = AmazonEC2ClientBuilder
-      .standard()
-      .withClientConfiguration(clientConfiguration)
+    val builder = AmazonEC2ClientBuilder.standard().withClientConfiguration(clientConfiguration)
 
     if (config.hasPath("endpoint") && config.hasPath("region")) {
       val endpoint = config.getString("endpoint")
@@ -118,8 +116,7 @@ class Ec2TagBasedServiceDiscovery(system: ExtendedActorSystem) extends ServiceDi
       builder.withEndpointConfiguration(new EndpointConfiguration(endpoint, region))
     }
 
-    builder
-      .build()
+    builder.build()
   }
 
   @tailrec

--- a/discovery-aws-api/src/main/scala/akka/discovery/awsapi/ec2/Ec2TagBasedServiceDiscovery.scala
+++ b/discovery-aws-api/src/main/scala/akka/discovery/awsapi/ec2/Ec2TagBasedServiceDiscovery.scala
@@ -108,16 +108,17 @@ class Ec2TagBasedServiceDiscovery(system: ExtendedActorSystem) extends ServiceDi
       case None =>
         defaultClientConfiguration
     }
-    val endpointConfiguration = (config.getString("endpoint"), config.getString("region")) match {
-      case ("", _) | (_, "") =>
-        null
-      case (endpoint, region) =>
-        new EndpointConfiguration(endpoint, region)
-    }
-    AmazonEC2ClientBuilder
+    val builder = AmazonEC2ClientBuilder
       .standard()
       .withClientConfiguration(clientConfiguration)
-      .withEndpointConfiguration(endpointConfiguration)
+
+    if (config.hasPath("endpoint") && config.hasPath("region")) {
+      val endpoint = config.getString("endpoint")
+      val region = config.getString("region")
+      builder.withEndpointConfiguration(new EndpointConfiguration(endpoint, region))
+    }
+
+    builder
       .build()
   }
 

--- a/discovery-aws-api/src/main/scala/akka/discovery/awsapi/ec2/Ec2TagBasedServiceDiscovery.scala
+++ b/discovery-aws-api/src/main/scala/akka/discovery/awsapi/ec2/Ec2TagBasedServiceDiscovery.scala
@@ -15,6 +15,7 @@ import akka.discovery.{ Lookup, ServiceDiscovery }
 import akka.event.Logging
 import akka.pattern.after
 import com.amazonaws.ClientConfiguration
+import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
 import com.amazonaws.retry.PredefinedRetryPolicies
 import com.amazonaws.services.ec2.model.{ DescribeInstancesRequest, Filter, Reservation }
 import com.amazonaws.services.ec2.{ AmazonEC2, AmazonEC2ClientBuilder }
@@ -107,7 +108,17 @@ class Ec2TagBasedServiceDiscovery(system: ExtendedActorSystem) extends ServiceDi
       case None =>
         defaultClientConfiguration
     }
-    AmazonEC2ClientBuilder.standard().withClientConfiguration(clientConfiguration).build()
+    val endpointConfiguration = (config.getString("endpoint"), config.getString("region")) match {
+      case ("", _) | (_, "") =>
+        null
+      case (endpoint, region) =>
+        new EndpointConfiguration(endpoint, region)
+    }
+    AmazonEC2ClientBuilder
+      .standard()
+      .withClientConfiguration(clientConfiguration)
+      .withEndpointConfiguration(endpointConfiguration)
+      .build()
   }
 
   @tailrec

--- a/discovery-aws-api/src/main/scala/akka/discovery/awsapi/ecs/EcsServiceDiscovery.scala
+++ b/discovery-aws-api/src/main/scala/akka/discovery/awsapi/ecs/EcsServiceDiscovery.scala
@@ -36,9 +36,7 @@ class EcsServiceDiscovery(system: ActorSystem) extends ServiceDiscovery {
     // we have our own retry/backoff mechanism, so we don't need EC2Client's in addition
     val clientConfiguration = new ClientConfiguration()
     clientConfiguration.setRetryPolicy(PredefinedRetryPolicies.NO_RETRY_POLICY)
-    val builder = AmazonECSClientBuilder
-      .standard()
-      .withClientConfiguration(clientConfiguration)
+    val builder = AmazonECSClientBuilder.standard().withClientConfiguration(clientConfiguration)
 
     if (config.hasPath("endpoint") && config.hasPath("region")) {
       val endpoint = config.getString("endpoint")
@@ -46,8 +44,7 @@ class EcsServiceDiscovery(system: ActorSystem) extends ServiceDiscovery {
       builder.withEndpointConfiguration(new EndpointConfiguration(endpoint, region))
     }
 
-    builder
-      .build()
+    builder.build()
   }
 
   private[this] implicit val ec: ExecutionContext = system.dispatcher

--- a/discovery-aws-api/src/main/scala/akka/discovery/awsapi/ecs/EcsServiceDiscovery.scala
+++ b/discovery-aws-api/src/main/scala/akka/discovery/awsapi/ecs/EcsServiceDiscovery.scala
@@ -36,16 +36,17 @@ class EcsServiceDiscovery(system: ActorSystem) extends ServiceDiscovery {
     // we have our own retry/backoff mechanism, so we don't need EC2Client's in addition
     val clientConfiguration = new ClientConfiguration()
     clientConfiguration.setRetryPolicy(PredefinedRetryPolicies.NO_RETRY_POLICY)
-    val endpointConfiguration = (config.getString("endpoint"), config.getString("region")) match {
-      case ("", _) | (_, "") =>
-        null
-      case (endpoint, region) =>
-        new EndpointConfiguration(endpoint, region)
-    }
-    AmazonECSClientBuilder
+    val builder = AmazonECSClientBuilder
       .standard()
       .withClientConfiguration(clientConfiguration)
-      .withEndpointConfiguration(endpointConfiguration)
+
+    if (config.hasPath("endpoint") && config.hasPath("region")) {
+      val endpoint = config.getString("endpoint")
+      val region = config.getString("region")
+      builder.withEndpointConfiguration(new EndpointConfiguration(endpoint, region))
+    }
+
+    builder
       .build()
   }
 


### PR DESCRIPTION
By default amazon client uses us-west-1 and at some regions that is far away it may cause very rare issue related to network connectivity.

This may be cause to split brain issue in the cluster when region that is far away from us-west-1 and use auto scaling group.
