### PR TITLE
Kubernetes: Opt in to ip instead of host

### DIFF
--- a/discovery-kubernetes-api/src/main/resources/reference.conf
+++ b/discovery-kubernetes-api/src/main/resources/reference.conf
@@ -31,5 +31,8 @@ akka.discovery {
     # Selector value to query pod API with.
     # `%s` will be replaced with the configured effective name, which defaults to the actor system name
     pod-label-selector = "app=%s"
+
+    # Enables the usage of the raw IP instead of the composed value for the resolved target host
+    raw-ip-enabled = false
   }
 }

--- a/discovery-kubernetes-api/src/main/resources/reference.conf
+++ b/discovery-kubernetes-api/src/main/resources/reference.conf
@@ -33,6 +33,6 @@ akka.discovery {
     pod-label-selector = "app=%s"
 
     # Enables the usage of the raw IP instead of the composed value for the resolved target host
-    raw-ip-enabled = false
+    use-raw-ip = false
   }
 }

--- a/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/KubernetesApiServiceDiscovery.scala
+++ b/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/KubernetesApiServiceDiscovery.scala
@@ -64,7 +64,7 @@ object KubernetesApiServiceDiscovery {
           } yield Some(port.containerPort)
       }
     } yield {
-      val hostOrIp = if(rawIp) ip else s"${ip.replace('.', '-')}.$podNamespace.pod.$podDomain"
+      val hostOrIp = if (rawIp) ip else s"${ip.replace('.', '-')}.$podNamespace.pod.$podDomain"
       ResolvedTarget(
         host = hostOrIp,
         port = maybePort,

--- a/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/KubernetesApiServiceDiscovery.scala
+++ b/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/KubernetesApiServiceDiscovery.scala
@@ -42,7 +42,8 @@ object KubernetesApiServiceDiscovery {
       podList: PodList,
       portName: Option[String],
       podNamespace: String,
-      podDomain: String): Seq[ResolvedTarget] =
+      podDomain: String,
+      rawIp: Boolean): Seq[ResolvedTarget] =
     for {
       item <- podList.items
       if item.metadata.flatMap(_.deletionTimestamp).isEmpty
@@ -63,9 +64,9 @@ object KubernetesApiServiceDiscovery {
           } yield Some(port.containerPort)
       }
     } yield {
-      val host = s"${ip.replace('.', '-')}.$podNamespace.pod.$podDomain"
+      val hostOrIp = if(rawIp) ip else s"${ip.replace('.', '-')}.$podNamespace.pod.$podDomain"
       ResolvedTarget(
-        host = host,
+        host = hostOrIp,
         port = maybePort,
         address = Some(InetAddress.getByName(ip))
       )
@@ -159,7 +160,7 @@ class KubernetesApiServiceDiscovery(system: ActorSystem) extends ServiceDiscover
       }
 
     } yield {
-      val addresses = targets(podList, query.portName, podNamespace, settings.podDomain)
+      val addresses = targets(podList, query.portName, podNamespace, settings.podDomain, settings.rawIp)
       if (addresses.isEmpty && podList.items.nonEmpty) {
         if (log.isInfoEnabled) {
           val containerPortNames = podList.items.flatMap(_.spec).flatMap(_.containers).flatMap(_.ports).flatten.toSet

--- a/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/Settings.scala
+++ b/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/Settings.scala
@@ -57,7 +57,7 @@ final class Settings(system: ExtendedActorSystem) extends Extension {
   def podLabelSelector(name: String): String =
     kubernetesApi.getString("pod-label-selector").format(name)
 
-  lazy val rawIp: Boolean = kubernetesApi.getBoolean("raw-ip-enabled")
+  lazy val rawIp: Boolean = kubernetesApi.getBoolean("use-raw-ip")
 
   override def toString =
     s"Settings($apiCaPath, $apiTokenPath, $apiServiceHostEnvName, $apiServicePortEnvName, " +

--- a/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/Settings.scala
+++ b/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/Settings.scala
@@ -8,7 +8,9 @@ import java.util.Optional
 
 import akka.actor._
 import com.typesafe.config.Config
+
 import scala.compat.java8.OptionConverters._
+import scala.util.Try
 
 final class Settings(system: ExtendedActorSystem) extends Extension {
 
@@ -54,6 +56,8 @@ final class Settings(system: ExtendedActorSystem) extends Extension {
 
   def podLabelSelector(name: String): String =
     kubernetesApi.getString("pod-label-selector").format(name)
+
+  lazy val rawIp: Boolean = kubernetesApi.getBoolean("raw-ip-enabled")
 
   override def toString =
     s"Settings($apiCaPath, $apiTokenPath, $apiServiceHostEnvName, $apiServicePortEnvName, " +

--- a/discovery-kubernetes-api/src/test/scala/akka/discovery/kubernetes/KubernetesApiServiceDiscoverySpec.scala
+++ b/discovery-kubernetes-api/src/test/scala/akka/discovery/kubernetes/KubernetesApiServiceDiscoverySpec.scala
@@ -145,7 +145,7 @@ class KubernetesApiServiceDiscoverySpec extends WordSpec with Matchers {
       KubernetesApiServiceDiscovery.targets(podList, Some("management"), "default", "cluster.local", false) shouldBe List.empty
     }
 
-    "use a ip instead of the host if requested" in  {
+    "use a ip instead of the host if requested" in {
       val podList =
         PodList(
           List(

--- a/discovery-kubernetes-api/src/test/scala/akka/discovery/kubernetes/KubernetesApiServiceDiscoverySpec.scala
+++ b/discovery-kubernetes-api/src/test/scala/akka/discovery/kubernetes/KubernetesApiServiceDiscoverySpec.scala
@@ -42,7 +42,7 @@ class KubernetesApiServiceDiscoverySpec extends WordSpec with Matchers {
             )
           ))
 
-      KubernetesApiServiceDiscovery.targets(podList, Some("management"), "default", "cluster.local") shouldBe List(
+      KubernetesApiServiceDiscovery.targets(podList, Some("management"), "default", "cluster.local", false) shouldBe List(
         ResolvedTarget(
           host = "172-17-0-4.default.pod.cluster.local",
           port = Some(10001),
@@ -65,7 +65,7 @@ class KubernetesApiServiceDiscoverySpec extends WordSpec with Matchers {
             Some(Metadata(deletionTimestamp = Some("2017-12-06T16:30:22Z")))
           )))
 
-      KubernetesApiServiceDiscovery.targets(podList, Some("management"), "default", "cluster.local") shouldBe List.empty
+      KubernetesApiServiceDiscovery.targets(podList, Some("management"), "default", "cluster.local", false) shouldBe List.empty
     }
 
     // This test allows users to not declare the management port in their container spec,
@@ -108,7 +108,7 @@ class KubernetesApiServiceDiscoverySpec extends WordSpec with Matchers {
             )
           ))
 
-      KubernetesApiServiceDiscovery.targets(podList, None, "default", "cluster.local") shouldBe List(
+      KubernetesApiServiceDiscovery.targets(podList, None, "default", "cluster.local", false) shouldBe List(
         ResolvedTarget(
           host = "172-17-0-4.default.pod.cluster.local",
           port = None,
@@ -142,7 +142,32 @@ class KubernetesApiServiceDiscoverySpec extends WordSpec with Matchers {
             Some(Metadata(deletionTimestamp = None))
           )))
 
-      KubernetesApiServiceDiscovery.targets(podList, Some("management"), "default", "cluster.local") shouldBe List.empty
+      KubernetesApiServiceDiscovery.targets(podList, Some("management"), "default", "cluster.local", false) shouldBe List.empty
+    }
+
+    "use a ip instead of the host if requested" in  {
+      val podList =
+        PodList(
+          List(
+            Pod(
+              Some(PodSpec(List(Container(
+                "akka-cluster-tooling-example",
+                Some(List(
+                  ContainerPort(Some("akka-remote"), 10000),
+                  ContainerPort(Some("management"), 10001),
+                  ContainerPort(Some("http"), 10002)))
+              )))),
+              Some(PodStatus(Some("172.17.0.4"), Some("Running"))),
+              Some(Metadata(deletionTimestamp = None))
+            )
+          ))
+
+      KubernetesApiServiceDiscovery.targets(podList, Some("management"), "default", "cluster.local", true) shouldBe List(
+        ResolvedTarget(
+          host = "172.17.0.4",
+          port = Some(10001),
+          address = Some(InetAddress.getByName("172.17.0.4"))
+        ))
     }
   }
 


### PR DESCRIPTION
Enables the usage of the dotted IP address string as the host name, rather than relying on Kube's pod DNS scheme.