### PR TITLE
Update jackson-databind to 2.10.4

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -4,4 +4,9 @@ updates.ignore = [
   { groupId = "com.typesafe.akka" }
 ]
 
+updates.pin = [
+  # To be updated in tandem with upstream Akka
+  { groupId = "com.fasterxml.jackson.core", version="2.10." }
+]
+
 commits.message = "${artifactName} ${nextVersion} (was ${currentVersion})"

--- a/integration-test/aws-api-ec2/build.sbt
+++ b/integration-test/aws-api-ec2/build.sbt
@@ -6,7 +6,7 @@ libraryDependencies += "com.amazonaws" % "aws-java-sdk-cloudformation" % "1.11.8
 
 libraryDependencies += "com.amazonaws" % "aws-java-sdk-autoscaling" % "1.11.819" % IntegrationTest
 
-libraryDependencies += "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.7" // aws SDK depends on insecure jackson
+libraryDependencies += "com.fasterxml.jackson.core" % "jackson-databind" % "2.10.4" // aws SDK depends on insecure jackson
 
 libraryDependencies += "org.scalatest" %% "scalatest" % Dependencies.ScalaTestVersion % IntegrationTest
 


### PR DESCRIPTION
To keep consistent with Akka

Let's see if this conflicts with the AWS SDK

If this works, it superseded #708 and #709

Otherwise we might first want to update to awssdk2...