### PR TITLE
ScalaTest 3.1.1 (was 3.0.8) with rewrites

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -2,6 +2,8 @@ pullRequests.frequency = "@monthly"
 
 updates.ignore = [
   { groupId = "com.typesafe.akka" }
+  // Keep 2.12 until ScalaTest+ Junit upgrades https://github.com/scalatest/scalatestplus-junit/releases
+  { groupId = "junit", artifactId = "junit" }
 ]
 
 commits.message = "${artifactName} ${nextVersion} (was ${currentVersion})"

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/AbstractBootstrapSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/AbstractBootstrapSpec.scala
@@ -4,7 +4,9 @@
 
 package akka.management.cluster.bootstrap
 
-import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpecLike }
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
-abstract class AbstractBootstrapSpec extends WordSpecLike with Matchers with ScalaFutures with BeforeAndAfterAll
+abstract class AbstractBootstrapSpec extends AnyWordSpecLike with Matchers with ScalaFutures with BeforeAndAfterAll

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapBasePathIntegrationSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapBasePathIntegrationSpec.scala
@@ -14,17 +14,18 @@ import akka.discovery.{ Lookup, MockDiscovery }
 import akka.management.cluster.bootstrap.ClusterBootstrap
 import akka.testkit.{ SocketUtil, TestKit, TestProbe }
 import com.typesafe.config.ConfigFactory
-import org.scalatest.{ Matchers, WordSpecLike }
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
 import akka.management.scaladsl.AkkaManagement
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 /**
  * This test ensures that the client and server both respect the base-path setting and thus that the boostrapping
  * process works correctly when this setting is specified.
  */
-class ClusterBootstrapBasePathIntegrationSpec extends WordSpecLike with Matchers {
+class ClusterBootstrapBasePathIntegrationSpec extends AnyWordSpecLike with Matchers {
 
   "Cluster Bootstrap" should {
     val Vector(managementPort, remotingPort) =

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapDiscoveryBackoffIntegrationSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapDiscoveryBackoffIntegrationSpec.scala
@@ -19,12 +19,13 @@ import akka.testkit.{ SocketUtil, TestKit, TestProbe }
 import com.typesafe.config.{ Config, ConfigFactory }
 import org.scalactic.Tolerance
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{ Matchers, WordSpecLike }
 import scala.concurrent.Future
 import scala.concurrent.duration._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 class ClusterBootstrapDiscoveryBackoffIntegrationSpec
-    extends WordSpecLike
+    extends AnyWordSpecLike
     with Matchers
     with Tolerance
     with ScalaFutures {

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapExistingSeedNodesSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapExistingSeedNodesSpec.scala
@@ -14,13 +14,15 @@ import akka.management.cluster.bootstrap.ClusterBootstrap
 import akka.stream.ActorMaterializer
 import akka.testkit.{ SocketUtil, TestKit }
 import com.typesafe.config.ConfigFactory
-import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpecLike }
+import org.scalatest.BeforeAndAfterAll
 
 import scala.concurrent.duration._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 class ClusterBootstrapExistingSeedNodesSpec(system: ActorSystem)
     extends TestKit(system)
-    with WordSpecLike
+    with AnyWordSpecLike
     with Matchers
     with BeforeAndAfterAll {
 

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapIntegrationSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapIntegrationSpec.scala
@@ -17,11 +17,12 @@ import akka.management.cluster.bootstrap.ClusterBootstrap
 import akka.stream.ActorMaterializer
 import akka.testkit.{ SocketUtil, TestKit, TestProbe }
 import com.typesafe.config.{ Config, ConfigFactory }
-import org.scalatest.{ Matchers, WordSpecLike }
 import scala.concurrent.Future
 import scala.concurrent.duration._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
-class ClusterBootstrapIntegrationSpec extends WordSpecLike with Matchers {
+class ClusterBootstrapIntegrationSpec extends AnyWordSpecLike with Matchers {
 
   "Cluster Bootstrap" should {
 

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapRetryUnreachableContactPointIntegrationSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapRetryUnreachableContactPointIntegrationSpec.scala
@@ -17,11 +17,12 @@ import akka.management.cluster.bootstrap.ClusterBootstrap
 import akka.stream.ActorMaterializer
 import akka.testkit.{ SocketUtil, TestKit, TestProbe }
 import com.typesafe.config.{ Config, ConfigFactory }
-import org.scalatest.{ Matchers, WordSpecLike }
 import scala.concurrent.Future
 import scala.concurrent.duration._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
-class ClusterBootstrapRetryUnreachableContactPointIntegrationSpec extends WordSpecLike with Matchers {
+class ClusterBootstrapRetryUnreachableContactPointIntegrationSpec extends AnyWordSpecLike with Matchers {
 
   "Cluster Bootstrap" should {
 

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/HttpContactPointRoutesSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/HttpContactPointRoutesSpec.scala
@@ -11,10 +11,11 @@ import akka.management.cluster.bootstrap.ClusterBootstrapSettings
 import akka.testkit.{ SocketUtil, TestProbe }
 import org.scalatest.concurrent.Eventually
 import org.scalatest.time.{ Millis, Seconds, Span }
-import org.scalatest.{ Matchers, WordSpecLike }
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 class HttpContactPointRoutesSpec
-    extends WordSpecLike
+    extends AnyWordSpecLike
     with Matchers
     with ScalatestRouteTest
     with HttpBootstrapJsonProtocol

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/internal/BootstrapCoordinatorSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/internal/BootstrapCoordinatorSpec.scala
@@ -14,13 +14,15 @@ import akka.management.cluster.bootstrap.internal.BootstrapCoordinator.Protocol.
 import akka.management.cluster.bootstrap.{ ClusterBootstrapSettings, LowestAddressJoinDecider }
 import com.typesafe.config.ConfigFactory
 import org.scalatest.concurrent.Eventually
-import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpec }
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.time.{ Millis, Seconds, Span }
 
 import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class BootstrapCoordinatorSpec extends WordSpec with Matchers with BeforeAndAfterAll with Eventually {
+class BootstrapCoordinatorSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll with Eventually {
   val serviceName = "bootstrap-coordinator-test-service"
   val selfUri = Uri("http://localhost:8558/")
   val system = ActorSystem(

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/internal/HttpContactPointBootstrapSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/internal/HttpContactPointBootstrapSpec.scala
@@ -7,10 +7,10 @@ package akka.management.cluster.bootstrap.internal
 import akka.actor.ActorPath
 import akka.http.scaladsl.model.Uri.Host
 
-import org.scalatest.WordSpec
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class HttpContactPointBootstrapSpec extends WordSpec with Matchers {
+class HttpContactPointBootstrapSpec extends AnyWordSpec with Matchers {
   "HttpContactPointBootstrap" should {
     "use a safe name when connecting over IPv6" in {
       val name = HttpContactPointBootstrap.name(Host("[fe80::1013:2070:258a:c662]"), 443)

--- a/cluster-http/src/test/scala/akka/cluster/http/management/scaladsl/ClusterHttpManagementRoutesSpec.scala
+++ b/cluster-http/src/test/scala/akka/cluster/http/management/scaladsl/ClusterHttpManagementRoutesSpec.scala
@@ -33,13 +33,13 @@ import akka.util.Timeout
 import com.typesafe.config.ConfigFactory
 import org.mockito.Matchers._
 import org.mockito.Mockito._
-import org.scalatest.Matchers
-import org.scalatest.WordSpecLike
 import org.scalatest.concurrent.PatienceConfiguration.{ Timeout => ScalatestTimeout }
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 class ClusterHttpManagementRoutesSpec
-    extends WordSpecLike
+    extends AnyWordSpecLike
     with Matchers
     with ScalatestRouteTest
     with ClusterHttpManagementJsonProtocol

--- a/cluster-http/src/test/scala/akka/management/cluster/ClusterHttpManagementHelperSpec.scala
+++ b/cluster-http/src/test/scala/akka/management/cluster/ClusterHttpManagementHelperSpec.scala
@@ -10,9 +10,10 @@ import akka.actor.Address
 import akka.cluster.MemberStatus._
 import akka.cluster.{ Member, UniqueAddress }
 import akka.management.cluster.ClusterHttpManagementHelper
-import org.scalatest.{ Matchers, WordSpec }
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class ClusterHttpManagementHelperSpec extends WordSpec with Matchers {
+class ClusterHttpManagementHelperSpec extends AnyWordSpec with Matchers {
 
   "Oldest nodes per role" must {
     "work" in {

--- a/cluster-http/src/test/scala/akka/management/cluster/ClusterHttpManagementRouteProviderSpec.scala
+++ b/cluster-http/src/test/scala/akka/management/cluster/ClusterHttpManagementRouteProviderSpec.scala
@@ -9,11 +9,12 @@ import akka.cluster.Cluster
 import akka.http.scaladsl.model.{ StatusCodes, Uri }
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.management.scaladsl.ManagementRouteProviderSettings
-import org.scalatest.{ Matchers, WordSpec }
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 object ClusterHttpManagementRouteProviderSpec {}
 
-class ClusterHttpManagementRouteProviderSpec extends WordSpec with ScalatestRouteTest with Matchers {
+class ClusterHttpManagementRouteProviderSpec extends AnyWordSpec with ScalatestRouteTest with Matchers {
 
   val cluster = Cluster(system)
 

--- a/cluster-http/src/test/scala/akka/management/cluster/MultiDcSpec.scala
+++ b/cluster-http/src/test/scala/akka/management/cluster/MultiDcSpec.scala
@@ -12,12 +12,13 @@ import akka.management.scaladsl.ManagementRouteProviderSettings
 import akka.stream.ActorMaterializer
 import akka.testkit.SocketUtil
 import com.typesafe.config.ConfigFactory
-import org.scalatest.{ Matchers, WordSpec }
 import org.scalatest.concurrent.{ Eventually, ScalaFutures }
 import org.scalatest.time.{ Millis, Seconds, Span }
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 class MultiDcSpec
-    extends WordSpec
+    extends AnyWordSpec
     with Matchers
     with ScalaFutures
     with ClusterHttpManagementJsonProtocol

--- a/cluster-http/src/test/scala/akka/management/cluster/scaladsl/ClusterMembershipCheckSettingsSpec.scala
+++ b/cluster-http/src/test/scala/akka/management/cluster/scaladsl/ClusterMembershipCheckSettingsSpec.scala
@@ -5,9 +5,10 @@
 package akka.management.cluster.scaladsl
 
 import akka.cluster.MemberStatus
-import org.scalatest.{ Matchers, WordSpec }
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class ClusterMembershipCheckSettingsSpec extends WordSpec with Matchers {
+class ClusterMembershipCheckSettingsSpec extends AnyWordSpec with Matchers {
 
   "Member status parsing" must {
     "be case insensitive" in {

--- a/cluster-http/src/test/scala/akka/management/cluster/scaladsl/ClusterMembershipCheckSpec.scala
+++ b/cluster-http/src/test/scala/akka/management/cluster/scaladsl/ClusterMembershipCheckSpec.scala
@@ -8,11 +8,12 @@ import akka.actor.ActorSystem
 import akka.cluster.MemberStatus
 import akka.testkit.TestKit
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{ Matchers, WordSpecLike }
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 class ClusterMembershipCheckSpec
     extends TestKit(ActorSystem("ClusterHealthCheck"))
-    with WordSpecLike
+    with AnyWordSpecLike
     with Matchers
     with ScalaFutures {
 

--- a/discovery-aws-api/src/test/scala/akka/discovery/awsapi/ec2/Ec2TagBasedSimpleServiceDiscoveryTest.scala
+++ b/discovery-aws-api/src/test/scala/akka/discovery/awsapi/ec2/Ec2TagBasedSimpleServiceDiscoveryTest.scala
@@ -6,9 +6,10 @@ package akka.discovery.awsapi.ec2
 
 import akka.discovery.awsapi.ec2.Ec2TagBasedServiceDiscovery.parseFiltersString
 import com.amazonaws.services.ec2.model.Filter
-import org.scalatest.{ FunSuite, Matchers }
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class FiltersParsingTest extends FunSuite with Matchers {
+class FiltersParsingTest extends AnyFunSuite with Matchers {
 
   import scala.collection.JavaConverters._
 

--- a/discovery-consul/src/test/scala/akka/cluster/bootstrap/discovery/ConsulDiscoverySpec.scala
+++ b/discovery-consul/src/test/scala/akka/cluster/bootstrap/discovery/ConsulDiscoverySpec.scala
@@ -17,11 +17,13 @@ import com.orbitz.consul.model.health.ImmutableService
 import com.pszymczyk.consul.{ ConsulProcess, ConsulStarterBuilder }
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{ Millis, Seconds, Span }
-import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpecLike }
+import org.scalatest.BeforeAndAfterAll
 
 import scala.concurrent.duration._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
-class ConsulDiscoverySpec extends WordSpecLike with Matchers with BeforeAndAfterAll with TestKitBase with ScalaFutures {
+class ConsulDiscoverySpec extends AnyWordSpecLike with Matchers with BeforeAndAfterAll with TestKitBase with ScalaFutures {
 
   private val consul: ConsulProcess = ConsulStarterBuilder.consulStarter().withHttpPort(8500).build().start()
 

--- a/discovery-consul/src/test/scala/akka/cluster/bootstrap/discovery/ConsulDiscoverySpec.scala
+++ b/discovery-consul/src/test/scala/akka/cluster/bootstrap/discovery/ConsulDiscoverySpec.scala
@@ -23,7 +23,12 @@ import scala.concurrent.duration._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
-class ConsulDiscoverySpec extends AnyWordSpecLike with Matchers with BeforeAndAfterAll with TestKitBase with ScalaFutures {
+class ConsulDiscoverySpec
+    extends AnyWordSpecLike
+    with Matchers
+    with BeforeAndAfterAll
+    with TestKitBase
+    with ScalaFutures {
 
   private val consul: ConsulProcess = ConsulStarterBuilder.consulStarter().withHttpPort(8500).build().start()
 

--- a/discovery-kubernetes-api/src/test/scala/akka/discovery/kubernetes/JsonFormatSpec.scala
+++ b/discovery-kubernetes-api/src/test/scala/akka/discovery/kubernetes/JsonFormatSpec.scala
@@ -4,13 +4,14 @@
 
 package akka.discovery.kubernetes
 
-import org.scalatest.{ Matchers, WordSpec }
 import spray.json._
 import scala.io.Source
 
 import PodList._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class JsonFormatSpec extends WordSpec with Matchers {
+class JsonFormatSpec extends AnyWordSpec with Matchers {
   "JsonFormat" should {
     val data = resourceAsString("pods.json")
 

--- a/discovery-kubernetes-api/src/test/scala/akka/discovery/kubernetes/KubernetesApiServiceDiscoverySpec.scala
+++ b/discovery-kubernetes-api/src/test/scala/akka/discovery/kubernetes/KubernetesApiServiceDiscoverySpec.scala
@@ -6,13 +6,14 @@ package akka.discovery.kubernetes
 
 import java.net.InetAddress
 
-import org.scalatest.{ Matchers, WordSpec }
 import PodList.{ Pod, _ }
 import akka.actor.ActorSystem
 import akka.discovery.Discovery
 import akka.discovery.ServiceDiscovery.ResolvedTarget
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class KubernetesApiServiceDiscoverySpec extends WordSpec with Matchers {
+class KubernetesApiServiceDiscoverySpec extends AnyWordSpec with Matchers {
   "targets" should {
     "calculate the correct list of resolved targets" in {
       val podList =

--- a/discovery-marathon-api/src/test/scala/akka/discovery/marathon/MarathonApiServiceDiscoverySpec.scala
+++ b/discovery-marathon-api/src/test/scala/akka/discovery/marathon/MarathonApiServiceDiscoverySpec.scala
@@ -7,11 +7,12 @@ package akka.discovery.marathon
 import java.net.InetAddress
 
 import akka.discovery.ServiceDiscovery.ResolvedTarget
-import org.scalatest.{ Matchers, WordSpec }
 import spray.json._
 import scala.io.Source
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class MarathonApiServiceDiscoverySpec extends WordSpec with Matchers {
+class MarathonApiServiceDiscoverySpec extends AnyWordSpec with Matchers {
   "targets" should {
     "calculate the correct list of resolved targets" in {
       val data = resourceAsString("apps.json")

--- a/integration-test/local/src/test/scala/akka/management/LocalBootstrapTest.scala
+++ b/integration-test/local/src/test/scala/akka/management/LocalBootstrapTest.scala
@@ -14,7 +14,8 @@ import akka.testkit.SocketUtil
 import com.typesafe.config.ConfigFactory
 import org.scalatest.concurrent.{ Eventually, ScalaFutures }
 import org.scalatest.time.{ Millis, Seconds, Span }
-import org.scalatest.{ Matchers, WordSpec }
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 object LocalBootstrapTest {
   val managementPorts = SocketUtil.temporaryServerAddresses(3, "127.0.0.1").map(_.getPort)
@@ -55,7 +56,7 @@ object LocalBootstrapTest {
     """).withFallback(ConfigFactory.load())
 }
 
-class LocalBootstrapTest extends WordSpec with ScalaFutures with Matchers with Eventually {
+class LocalBootstrapTest extends AnyWordSpec with ScalaFutures with Matchers with Eventually {
   import LocalBootstrapTest._
 
   implicit override val patienceConfig: PatienceConfig =

--- a/lease-kubernetes-int-test/src/main/scala/akka/coordination/lease/kubernetes/LeaseSpec.scala
+++ b/lease-kubernetes-int-test/src/main/scala/akka/coordination/lease/kubernetes/LeaseSpec.scala
@@ -10,12 +10,14 @@ import akka.coordination.lease.kubernetes.internal.KubernetesApiImpl
 import akka.coordination.lease.scaladsl.LeaseProvider
 import org.scalatest.concurrent.{ Eventually, ScalaFutures }
 import org.scalatest.time.{ Milliseconds, Seconds, Span }
-import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpec }
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 /**
  * This spec is for running inside a k8s cluster.
  */
-abstract class LeaseSpec() extends WordSpec with ScalaFutures with BeforeAndAfterAll with Matchers with Eventually {
+abstract class LeaseSpec() extends AnyWordSpec with ScalaFutures with BeforeAndAfterAll with Matchers with Eventually {
 
   def system: ActorSystem
 

--- a/lease-kubernetes/src/test/scala/akka/coordination/lease/kubernetes/KubernetesApiSpec.scala
+++ b/lease-kubernetes/src/test/scala/akka/coordination/lease/kubernetes/KubernetesApiSpec.scala
@@ -14,14 +14,16 @@ import com.github.tomakehurst.wiremock.client.WireMock
 import org.scalatest.concurrent.ScalaFutures
 import com.github.tomakehurst.wiremock.client.WireMock._
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
-import org.scalatest.{ BeforeAndAfterAll, BeforeAndAfterEach, Matchers, WordSpecLike }
+import org.scalatest.{ BeforeAndAfterAll, BeforeAndAfterEach }
 
 import scala.concurrent.duration._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 class KubernetesApiSpec
     extends TestKit(ActorSystem("KubernetesApiSpec"))
     with ScalaFutures
-    with WordSpecLike
+    with AnyWordSpecLike
     with BeforeAndAfterAll
     with Matchers
     with BeforeAndAfterEach {

--- a/lease-kubernetes/src/test/scala/akka/coordination/lease/kubernetes/KubernetesSettingsSpec.scala
+++ b/lease-kubernetes/src/test/scala/akka/coordination/lease/kubernetes/KubernetesSettingsSpec.scala
@@ -6,10 +6,11 @@ package akka.coordination.lease.kubernetes
 
 import akka.coordination.lease.TimeoutSettings
 import com.typesafe.config.ConfigFactory
-import org.scalatest.{ Matchers, WordSpec }
 import scala.concurrent.duration._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class KubernetesSettingsSpec extends WordSpec with Matchers {
+class KubernetesSettingsSpec extends AnyWordSpec with Matchers {
 
   private def conf(overrides: String): KubernetesSettings = {
     val c = ConfigFactory

--- a/lease-kubernetes/src/test/scala/akka/coordination/lease/kubernetes/LeaseActorSpec.scala
+++ b/lease-kubernetes/src/test/scala/akka/coordination/lease/kubernetes/LeaseActorSpec.scala
@@ -14,10 +14,12 @@ import akka.pattern.ask
 import akka.testkit.{ TestKit, TestProbe }
 import akka.util.{ ConstantFun, Timeout }
 import com.typesafe.config.ConfigFactory
-import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpecLike }
+import org.scalatest.BeforeAndAfterAll
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 class MockKubernetesApi(system: ActorSystem, currentLease: ActorRef, updateLease: ActorRef) extends KubernetesApi {
 
@@ -47,7 +49,7 @@ class LeaseActorSpec
     akka.actor.debug.fsm = true
   """)
       ))
-    with WordSpecLike
+    with AnyWordSpecLike
     with Matchers
     with BeforeAndAfterAll {
 

--- a/loglevels-logback/src/test/scala/akka/management/loglevels/logback/LogLevelRoutesSpec.scala
+++ b/loglevels-logback/src/test/scala/akka/management/loglevels/logback/LogLevelRoutesSpec.scala
@@ -10,12 +10,12 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.Uri
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.management.scaladsl.ManagementRouteProviderSettings
-import org.scalatest.Matchers
-import org.scalatest.WordSpec
 import org.slf4j.LoggerFactory
 import akka.event.{ Logging => ClassicLogging }
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class LogLevelRoutesSpec extends WordSpec with Matchers with ScalatestRouteTest {
+class LogLevelRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest {
 
   override def testConfigSource: String =
     """

--- a/management/src/test/java/akka/management/HealthCheckTest.java
+++ b/management/src/test/java/akka/management/HealthCheckTest.java
@@ -16,7 +16,7 @@ import com.typesafe.config.ConfigFactory;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/management/src/test/scala/akka/management/AkkaManagementHttpEndpointSpec.scala
+++ b/management/src/test/scala/akka/management/AkkaManagementHttpEndpointSpec.scala
@@ -33,8 +33,8 @@ import com.typesafe.config.ConfigFactory
 import javax.net.ssl.KeyManagerFactory
 import javax.net.ssl.SSLContext
 import javax.net.ssl.TrustManagerFactory
-import org.scalatest.Matchers
-import org.scalatest.WordSpecLike
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 class HttpManagementEndpointSpecRoutesScaladsl extends ManagementRouteProvider with Directives {
   override def routes(settings: ManagementRouteProviderSettings): Route =
@@ -56,7 +56,7 @@ class HttpManagementEndpointSpecRoutesJavadsl extends javadsl.ManagementRoutePro
     }
 }
 
-class AkkaManagementHttpEndpointSpec extends WordSpecLike with Matchers {
+class AkkaManagementHttpEndpointSpec extends AnyWordSpecLike with Matchers {
 
   val config = ConfigFactory.parseString(
     """

--- a/management/src/test/scala/akka/management/HealthCheckRoutesSpec.scala
+++ b/management/src/test/scala/akka/management/HealthCheckRoutesSpec.scala
@@ -9,11 +9,12 @@ import akka.http.scaladsl.model.{ StatusCodes, Uri }
 import akka.http.scaladsl.server._
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.management.scaladsl.{ HealthChecks, ManagementRouteProviderSettings }
-import org.scalatest.{ Matchers, WordSpec }
 
 import scala.concurrent.Future
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class HealthCheckRoutesSpec extends WordSpec with Matchers with ScalatestRouteTest {
+class HealthCheckRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest {
 
   private val eas = system.asInstanceOf[ExtendedActorSystem]
 

--- a/management/src/test/scala/akka/management/HealthCheckSettingsSpec.scala
+++ b/management/src/test/scala/akka/management/HealthCheckSettingsSpec.scala
@@ -4,9 +4,10 @@
 
 package akka.management
 import com.typesafe.config.ConfigFactory
-import org.scalatest.{ Matchers, WordSpec }
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class HealthCheckSettingsSpec extends WordSpec with Matchers {
+class HealthCheckSettingsSpec extends AnyWordSpec with Matchers {
 
   "Health Check Settings" should {
     "filter out blank fqcn" in {

--- a/management/src/test/scala/akka/management/HealthChecksSpec.scala
+++ b/management/src/test/scala/akka/management/HealthChecksSpec.scala
@@ -7,7 +7,7 @@ package akka.management
 import akka.actor.{ ActorSystem, ExtendedActorSystem }
 import akka.testkit.TestKit
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpecLike }
+import org.scalatest.BeforeAndAfterAll
 import HealthChecksSpec._
 import akka.management.internal.CheckTimeoutException
 import akka.management.scaladsl.HealthChecks
@@ -21,6 +21,8 @@ import akka.actor.setup.ActorSystemSetup
 import akka.management.scaladsl.LivenessCheckSetup
 import akka.management.scaladsl.ReadinessCheckSetup
 import com.typesafe.config.ConfigFactory
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 object HealthChecksSpec {
   val failedCause = new TE()
@@ -83,7 +85,7 @@ class CtrException(system: ActorSystem) extends (() => Future[Boolean]) {
 
 class HealthChecksSpec
     extends TestKit(ActorSystem("HealthChecksSpec"))
-    with WordSpecLike
+    with AnyWordSpecLike
     with BeforeAndAfterAll
     with ScalaFutures
     with Matchers {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,8 +13,11 @@ object Dependencies {
   val AkkaHttpVersion = "10.1.11"
   val AkkaHttpBinaryVersion = "10.1"
 
-  val JUnitVersion = "4.13"
-  val ScalaTestVersion = "3.0.8"
+  // JUnit, ScalaTest and ScalaTestPlus JUnit must stick together
+  val JUnitVersion = "4.12"
+  val ScalaTestVersion = "3.1.1"
+  val ScalaTestPlusJUnitVersion = "3.1.1.0"
+
   val SprayJsonVersion = "1.3.5"
 
   val AwsSdkVersion = "1.11.761"
@@ -22,14 +25,15 @@ object Dependencies {
 
 
   object TestDeps {
-    val scalaTest = "org.scalatest"     %% "scalatest"     % ScalaTestVersion
+    val scalaTest = Seq(
+      "org.scalatest"     %% "scalatest"     % ScalaTestVersion,
+      "org.scalatestplus" %% "junit-4-12" % ScalaTestPlusJUnitVersion
+    )
     val akkaTestKit = "com.typesafe.akka" %% "akka-testkit" % AkkaVersion
   }
 
   val Common = Seq(
-    libraryDependencies ++= Seq(
-      TestDeps.scalaTest % Test // ApacheV2
-    )
+    libraryDependencies ++= TestDeps.scalaTest.map(_ % Test)
   )
   private object DependencyGroups {
     val AkkaActor = Seq(
@@ -191,15 +195,15 @@ object Dependencies {
       DependencyGroups.AkkaHttp ++
       DependencyGroups.AkkaCoordination ++
       DependencyGroups.WireMock ++
+      TestDeps.scalaTest.map(_ % "it,test") ++
       Seq(
-        TestDeps.scalaTest % "it,test",
         TestDeps.akkaTestKit % "it,test"
       )
   )
 
   val LeaseKubernetesTest = Seq(
     libraryDependencies ++=
-      Seq(TestDeps.scalaTest)
+      TestDeps.scalaTest
   )
 
   val BootstrapDemos = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,8 +13,6 @@ object Dependencies {
   val AkkaHttpVersion = "10.1.11"
   val AkkaHttpBinaryVersion = "10.1"
 
-  // JUnit, ScalaTest and ScalaTestPlus JUnit must stick together
-  val JUnitVersion = "4.12"
   val ScalaTestVersion = "3.1.1"
   val ScalaTestPlusJUnitVersion = "3.1.1.0"
 
@@ -72,7 +70,6 @@ object Dependencies {
 
     val AkkaTesting = Seq(
       TestDeps.akkaTestKit % "test",
-      "junit" % "junit" % JUnitVersion % "test",
       "org.mockito" % "mockito-all" % "1.10.19" % "test" // Common Public License 1.0
     )
 


### PR DESCRIPTION
This is required to enable the upgrade to 3.2 in #720