### PR TITLE
build: Scala 2.12 and 2.13 in scheduled build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-import com.typesafe.sbt.packager.docker.{Cmd, ExecCmd}
+import com.typesafe.sbt.packager.docker.{ Cmd, ExecCmd }
 
 ThisBuild / resolvers += Resolver.jcenterRepo
 
@@ -95,7 +95,8 @@ lazy val `loglevels-logback` = project
   .settings(
     name := "akka-management-loglevels-logback",
     Dependencies.LoglevelsLogback
-  ).dependsOn(`akka-management`)
+  )
+  .dependsOn(`akka-management`)
 
 lazy val `cluster-http` = project
   .in(file("cluster-http"))
@@ -142,15 +143,15 @@ lazy val `lease-kubernetes-int-test` = project
     dockerBaseImage := "openjdk:8-jre-alpine",
     dockerUpdateLatest := true,
     dockerCommands := dockerCommands.value.flatMap {
-      case ExecCmd("ENTRYPOINT", args @ _*) => Seq(Cmd("ENTRYPOINT", args.mkString(" ")))
-      case v => Seq(v)
-    },
+        case ExecCmd("ENTRYPOINT", args @ _*) => Seq(Cmd("ENTRYPOINT", args.mkString(" ")))
+        case v                                => Seq(v)
+      },
     dockerCommands ++= Seq(
-      Cmd("USER", "root"),
-      Cmd("RUN", "chgrp -R 0 . && chmod -R g=u ."),
-      Cmd("RUN", "/sbin/apk", "add", "--no-cache", "bash", "bind-tools", "busybox-extras", "curl", "strace"),
-      Cmd("RUN", "chmod +x /opt/docker/bin/akka-lease-kubernetes-int-test")
-    ),
+        Cmd("USER", "root"),
+        Cmd("RUN", "chgrp -R 0 . && chmod -R g=u ."),
+        Cmd("RUN", "/sbin/apk", "add", "--no-cache", "bash", "bind-tools", "busybox-extras", "curl", "strace"),
+        Cmd("RUN", "chmod +x /opt/docker/bin/akka-lease-kubernetes-int-test")
+      )
   )
 lazy val `integration-test-kubernetes-api` = project
   .in(file("integration-test/kubernetes-api"))

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -28,7 +28,7 @@ object Common extends AutoPlugin {
       licenses := Seq(("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0"))),
       description := "Akka Management is a suite of tools for operating Akka Clusters.",
       headerLicense := Some(HeaderLicense.Custom("Copyright (C) 2017-2020 Lightbend Inc. <https://www.lightbend.com>")),
-      crossScalaVersions := Seq(Dependencies.Scala211, Dependencies.Scala212, Dependencies.Scala213),
+      crossScalaVersions := Dependencies.CrossScalaVersions,
       projectInfoVersion := (if (isSnapshot.value) "snapshot" else version.value),
       crossVersion := CrossVersion.binary,
       scalacOptions ++= Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,6 +8,9 @@ object Dependencies {
   val Scala211 = "2.11.12"
   val Scala212 = "2.12.10"
   val Scala213 = "2.13.0"
+  val CrossScalaVersions =
+    if (CronBuild) Seq(Dependencies.Scala212, Dependencies.Scala213)
+    else Seq(Dependencies.Scala211, Dependencies.Scala212, Dependencies.Scala213)
 
   val Akka25Version = "2.5.31"
   val Akka26Version = "2.6.5"
@@ -26,10 +29,9 @@ object Dependencies {
   val AwsSdkVersion = "1.11.761"
   val JacksonDatabindVersion = "2.10.4"
 
-
   object TestDeps {
     val scalaTest = Seq(
-      "org.scalatest"     %% "scalatest"     % ScalaTestVersion,
+      "org.scalatest" %% "scalatest" % ScalaTestVersion,
       "org.scalatestplus" %% "junit-4-12" % ScalaTestPlusJUnitVersion
     )
     val akkaTestKit = "com.typesafe.akka" %% "akka-testkit" % AkkaVersion


### PR DESCRIPTION
The scheduled build uses Akka 2.6 and Akka HTTP 10.2 which are not available for Scala 2.11.