### PR TITLE
build: disable Akka 2.6 in cron jobs for now

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,8 +14,8 @@ object Dependencies {
 
   val Akka25Version = "2.5.31"
   val Akka26Version = "2.6.5"
-  val AkkaVersion = if (CronBuild) Akka26Version else Akka25Version
-  val AkkaBinaryVersion = if (CronBuild) "2.6" else "2.5"
+  val AkkaVersion = /*if (CronBuild) Akka26Version else */Akka25Version // FIXME: need to fix tests wrt artery
+  val AkkaBinaryVersion = /*if (CronBuild) "2.6" else */"2.5"
   val AkkaHttp101 = "10.1.11"
   val AkkaHttp102 = "10.2.0-RC2"
   val AkkaHttpVersion = if (CronBuild) AkkaHttp102 else AkkaHttp101


### PR DESCRIPTION
That gives us at least Akka Http 10.2.0 coverage until we figure how to fix tests for Akka 2.6.x.