### PR TITLE
fix compilation error for Akka 2.6.9, #762

### DIFF
--- a/management/src/main/scala/akka/management/scaladsl/AkkaManagement.scala
+++ b/management/src/main/scala/akka/management/scaladsl/AkkaManagement.scala
@@ -273,7 +273,7 @@ final class AkkaManagement(implicit private[akka] val system: ExtendedActorSyste
                 .createInstanceFor[javadsl.ManagementRouteProvider](fqcn, (classOf[ExtendedActorSystem], system) :: Nil)
           } match {
           case Success(p: ExtensionIdProvider) =>
-            system.registerExtension(p.lookup()) match {
+            system.registerExtension(p.lookup) match {
               case provider: ManagementRouteProvider         => provider
               case provider: javadsl.ManagementRouteProvider => new ManagementRouteProviderAdapter(provider)
               case other =>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,7 +14,7 @@ object Dependencies {
 
   // Align the versions in integration-test/kubernetes-api-java/pom.xml
   val Akka25Version = "2.5.31"
-  val Akka26Version = "2.6.8"
+  val Akka26Version = "2.6.9"
   val AkkaVersion = if (CronBuild) Akka26Version else Akka25Version
   val AkkaBinaryVersion = if (CronBuild) "2.6" else "2.5"
   // Align the versions in integration-test/kubernetes-api-java/pom.xml


### PR DESCRIPTION
* `def lookup()` was changed to `def lookup` in `ExtensionIdProvider`
  as part of the Scala 2.13.3 update in Akka 2.6.9

References #762
