### PR TITLE
Update to Akka 2.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -319,7 +319,6 @@ lazy val docs = project
         "canonical.base_url" -> "https://doc.akka.io/docs/akka-management/current",
         "scala.binary.version" -> scalaBinaryVersion.value,
         "akka.version" -> Dependencies.AkkaVersion,
-        "akka.version26" -> Dependencies.Akka26Version,
         "extref.akka.base_url" -> s"https://doc.akka.io/docs/akka/current/%s",
         "scaladoc.akka.base_url" -> s"https://doc.akka.io/api/akka/current/",
         "extref.akka-http.base_url" -> s"https://doc.akka.io/docs/akka-http/${Dependencies.AkkaHttpBinaryVersion}/%s",

--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/internal/BootstrapCoordinator.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/internal/BootstrapCoordinator.scala
@@ -156,7 +156,7 @@ private[akka] class BootstrapCoordinator(
 
   private var decisionInProgress = false
   def startPeriodicDecisionTimer(): Unit =
-    timers.startPeriodicTimer(DecideTimerKey, DecideTick, settings.contactPoint.probeInterval)
+    timers.startTimerWithFixedDelay(DecideTimerKey, DecideTick, settings.contactPoint.probeInterval)
 
   private var discoveryFailedBackoffCounter = 0
   def resetDiscoveryInterval(): Unit =

--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/internal/HttpContactPointBootstrap.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/internal/HttpContactPointBootstrap.scala
@@ -32,7 +32,6 @@ import akka.management.cluster.bootstrap.contactpoint.HttpBootstrapJsonProtocol
 import akka.management.cluster.bootstrap.contactpoint.HttpBootstrapJsonProtocol.SeedNodes
 import akka.pattern.after
 import akka.pattern.pipe
-import akka.stream.ActorMaterializer
 
 @InternalApi
 private[bootstrap] object HttpContactPointBootstrap {
@@ -81,8 +80,8 @@ private[bootstrap] class HttpContactPointBootstrap(
     )
   }
 
-  private implicit val mat = ActorMaterializer()(context.system)
-  private val http = Http()(context.system)
+  private implicit val sys = context.system
+  private val http = Http()
   private val connectionPoolWithoutRetries = ConnectionPoolSettings(context.system).withMaxRetries(0)
   import context.dispatcher
 

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapDiscoveryBackoffIntegrationSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapDiscoveryBackoffIntegrationSpec.scala
@@ -16,7 +16,6 @@ import akka.discovery.{ Lookup, MockDiscovery }
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.server.RouteResult
 import akka.management.cluster.bootstrap.ClusterBootstrap
-import akka.stream.ActorMaterializer
 import akka.testkit.{ SocketUtil, TestKit, TestProbe }
 import com.typesafe.config.{ Config, ConfigFactory }
 import org.scalactic.Tolerance
@@ -157,7 +156,6 @@ class ClusterBootstrapDiscoveryBackoffIntegrationSpec
       def start(system: ActorSystem, contactPointPort: Int) = {
         import system.dispatcher
         implicit val sys = system
-        implicit val mat = ActorMaterializer()(system)
 
         val bootstrap: ClusterBootstrap = ClusterBootstrap(system)
         val routes = new HttpClusterBootstrapRoutes(bootstrap.settings).routes

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapExistingSeedNodesSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapExistingSeedNodesSpec.scala
@@ -12,7 +12,6 @@ import akka.http.scaladsl.Http
 import akka.http.scaladsl.server.RouteResult
 import akka.management.cluster.bootstrap.ClusterBootstrap
 import akka.remote.RARP
-import akka.stream.ActorMaterializer
 import akka.testkit.{ SocketUtil, TestKit }
 import com.typesafe.config.ConfigFactory
 import org.scalatest.BeforeAndAfterAll
@@ -109,8 +108,7 @@ class ClusterBootstrapExistingSeedNodesSpec(system: ActorSystem)
     "start listening with the http contact-points on all systems" in {
       def start(system: ActorSystem, contactPointPort: Int) = {
         import system.dispatcher
-        implicit val sys = system
-        implicit val mat = ActorMaterializer()(system)
+        implicit val sys: ActorSystem = system
 
         val bootstrap = ClusterBootstrap(system)
         val routes = new HttpClusterBootstrapRoutes(bootstrap.settings).routes

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapIntegrationSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapIntegrationSpec.scala
@@ -14,7 +14,6 @@ import akka.discovery.{ Lookup, MockDiscovery }
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.server.RouteResult
 import akka.management.cluster.bootstrap.ClusterBootstrap
-import akka.stream.ActorMaterializer
 import akka.testkit.{ SocketUtil, TestKit, TestProbe }
 import com.typesafe.config.{ Config, ConfigFactory }
 import scala.concurrent.Future
@@ -128,7 +127,6 @@ class ClusterBootstrapIntegrationSpec extends AnyWordSpecLike with Matchers {
       def start(system: ActorSystem, contactPointPort: Int) = {
         import system.dispatcher
         implicit val sys = system
-        implicit val mat = ActorMaterializer()(system)
 
         val bootstrap = ClusterBootstrap(system)
         val routes = new HttpClusterBootstrapRoutes(bootstrap.settings).routes

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapRetryUnreachableContactPointIntegrationSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/ClusterBootstrapRetryUnreachableContactPointIntegrationSpec.scala
@@ -14,7 +14,6 @@ import akka.discovery.{ Lookup, MockDiscovery }
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.server.RouteResult
 import akka.management.cluster.bootstrap.ClusterBootstrap
-import akka.stream.ActorMaterializer
 import akka.testkit.{ SocketUtil, TestKit, TestProbe }
 import com.typesafe.config.{ Config, ConfigFactory }
 import scala.concurrent.Future
@@ -136,7 +135,6 @@ class ClusterBootstrapRetryUnreachableContactPointIntegrationSpec extends AnyWor
       def start(system: ActorSystem, contactPointPort: Int) = {
         import system.dispatcher
         implicit val sys = system
-        implicit val mat = ActorMaterializer()(system)
 
         val bootstrap = ClusterBootstrap(system)
         val routes = new HttpClusterBootstrapRoutes(bootstrap.settings).routes

--- a/cluster-http/src/main/scala/akka/management/cluster/javadsl/ClusterMembershipCheck.scala
+++ b/cluster-http/src/main/scala/akka/management/cluster/javadsl/ClusterMembershipCheck.scala
@@ -18,6 +18,6 @@ class ClusterMembershipCheck(system: ActorSystem)
   private val delegate = new ScalaClusterReadinessCheck(system)
 
   override def get(): CompletionStage[java.lang.Boolean] = {
-    delegate.apply().map(Boolean.box)(ExecutionContexts.sameThreadExecutionContext).toJava
+    delegate.apply().map(Boolean.box)(ExecutionContexts.parasitic).toJava
   }
 }

--- a/cluster-http/src/test/scala/akka/cluster/http/management/scaladsl/ClusterHttpManagementRoutesSpec.scala
+++ b/cluster-http/src/test/scala/akka/cluster/http/management/scaladsl/ClusterHttpManagementRoutesSpec.scala
@@ -33,11 +33,12 @@ import akka.management.scaladsl.ManagementRouteProviderSettings
 import akka.stream.scaladsl.Sink
 import akka.util.ByteString
 import akka.util.Timeout
+import akka.util.Version
 import com.typesafe.config.ConfigFactory
 import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.Eventually
-import org.scalatest.concurrent.PatienceConfiguration.{ Timeout => ScalatestTimeout }
+import org.scalatest.concurrent.PatienceConfiguration.{Timeout => ScalatestTimeout}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.Millis
@@ -55,6 +56,8 @@ class ClusterHttpManagementRoutesSpec
 
   override implicit def patienceConfig: PatienceConfig =
     PatienceConfig(timeout = Span(3, Seconds), interval = Span(50, Millis))
+
+  val version = new Version("1.42")
 
   "Http Cluster Management Routes" should {
     "prepare cluster for shutdown" when {
@@ -78,8 +81,8 @@ class ClusterHttpManagementRoutesSpec
         val uniqueAddress1 = UniqueAddress(address1, 1L)
         val uniqueAddress2 = UniqueAddress(address2, 2L)
 
-        val clusterMember1 = new Member(uniqueAddress1, 1, Up, Set(s"dc-$dcName"))
-        val clusterMember2 = new Member(uniqueAddress2, 2, Joining, Set(s"dc-$dcName"))
+        val clusterMember1 = new Member(uniqueAddress1, 1, Up, Set(s"dc-$dcName"), version)
+        val clusterMember2 = new Member(uniqueAddress2, 2, Joining, Set(s"dc-$dcName"), version)
         val currentClusterState =
           CurrentClusterState(SortedSet(clusterMember1, clusterMember2), leader = Some(address1))
 
@@ -153,7 +156,7 @@ class ClusterHttpManagementRoutesSpec
         s"calling GET $uri for member $address1" in {
           val uniqueAddress1 = UniqueAddress(address1, 1L)
 
-          val clusterMember1 = Member(uniqueAddress1, Set())
+          val clusterMember1 = Member(uniqueAddress1, Set(), version)
 
           val members = SortedSet(clusterMember1)
 
@@ -185,8 +188,8 @@ class ClusterHttpManagementRoutesSpec
         val uniqueAddress1 = UniqueAddress(address1, 1L)
         val uniqueAddress2 = UniqueAddress(address2, 2L)
 
-        val clusterMember1 = Member(uniqueAddress1, Set())
-        val clusterMember2 = Member(uniqueAddress2, Set())
+        val clusterMember1 = Member(uniqueAddress1, Set(), version)
+        val clusterMember2 = Member(uniqueAddress2, Set(), version)
 
         val members = SortedSet(clusterMember1, clusterMember2)
 
@@ -214,8 +217,8 @@ class ClusterHttpManagementRoutesSpec
         val uniqueAddress1 = UniqueAddress(address1, 1L)
         val uniqueAddress2 = UniqueAddress(address2, 2L)
 
-        val clusterMember1 = Member(uniqueAddress1, Set())
-        val clusterMember2 = Member(uniqueAddress2, Set())
+        val clusterMember1 = Member(uniqueAddress1, Set(), version)
+        val clusterMember2 = Member(uniqueAddress2, Set(), version)
 
         val members = SortedSet(clusterMember1, clusterMember2)
 
@@ -241,7 +244,7 @@ class ClusterHttpManagementRoutesSpec
 
         val uniqueAddress1 = UniqueAddress(address1, 1L)
 
-        val clusterMember1 = Member(uniqueAddress1, Set())
+        val clusterMember1 = Member(uniqueAddress1, Set(), version)
 
         val members = SortedSet(clusterMember1)
 
@@ -270,8 +273,8 @@ class ClusterHttpManagementRoutesSpec
         val uniqueAddress1 = UniqueAddress(address1, 1L)
         val uniqueAddress2 = UniqueAddress(address2, 2L)
 
-        val clusterMember1 = Member(uniqueAddress1, Set())
-        val clusterMember2 = Member(uniqueAddress2, Set())
+        val clusterMember1 = Member(uniqueAddress1, Set(), version)
+        val clusterMember2 = Member(uniqueAddress2, Set(), version)
 
         val members = SortedSet(clusterMember1, clusterMember2)
 
@@ -297,7 +300,7 @@ class ClusterHttpManagementRoutesSpec
 
         val uniqueAddress1 = UniqueAddress(address1, 1L)
 
-        val clusterMember1 = Member(uniqueAddress1, Set())
+        val clusterMember1 = Member(uniqueAddress1, Set(), version)
 
         val members = SortedSet(clusterMember1)
 
@@ -326,7 +329,7 @@ class ClusterHttpManagementRoutesSpec
 
         val uniqueAddress1 = UniqueAddress(address1, 1L)
 
-        val clusterMember1 = Member(uniqueAddress1, Set())
+        val clusterMember1 = Member(uniqueAddress1, Set(), version)
 
         val members = SortedSet(clusterMember1)
 

--- a/cluster-http/src/test/scala/akka/cluster/http/management/scaladsl/ClusterHttpManagementRoutesSpec.scala
+++ b/cluster-http/src/test/scala/akka/cluster/http/management/scaladsl/ClusterHttpManagementRoutesSpec.scala
@@ -38,7 +38,7 @@ import com.typesafe.config.ConfigFactory
 import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.Eventually
-import org.scalatest.concurrent.PatienceConfiguration.{Timeout => ScalatestTimeout}
+import org.scalatest.concurrent.PatienceConfiguration.{ Timeout => ScalatestTimeout }
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.Millis

--- a/cluster-http/src/test/scala/akka/management/cluster/ClusterDomainEventServerSentEventEncoderSpec.scala
+++ b/cluster-http/src/test/scala/akka/management/cluster/ClusterDomainEventServerSentEventEncoderSpec.scala
@@ -12,10 +12,14 @@ import akka.util.Version
 
 package akka.cluster.management {
 
-
   // `Member`'s constructor is private[cluster], hence this
   object TestHelpers {
-    def newMember(uniqueAddress: UniqueAddress, upNumber: Int, status: MemberStatus, roles: Set[String], appVersion: Version): Member =
+    def newMember(
+        uniqueAddress: UniqueAddress,
+        upNumber: Int,
+        status: MemberStatus,
+        roles: Set[String],
+        appVersion: Version): Member =
       new Member(uniqueAddress, upNumber, status, roles, appVersion)
   }
 }
@@ -33,7 +37,8 @@ package akka.management.cluster {
         val appVersion = Version("2.3.4")
 
         ClusterDomainEventServerSentEventEncoder.encode(
-          ClusterEvent.MemberJoined(newMember(uniqueAddress1, 1, MemberStatus.Joining, Set("one", "two", dc), appVersion))
+          ClusterEvent.MemberJoined(
+            newMember(uniqueAddress1, 1, MemberStatus.Joining, Set("one", "two", dc), appVersion))
         ) shouldEqual Some(
           ServerSentEvent(
             """{"member":{"dataCenter":"one","roles":["one","two","dc-one"],"status":"Joining","uniqueAddress":{"address":"akka://Main@hostname.com:3311","longUid":1}},"type":"MemberJoined"}""",
@@ -42,7 +47,8 @@ package akka.management.cluster {
         )
 
         ClusterDomainEventServerSentEventEncoder.encode(
-          ClusterEvent.MemberWeaklyUp(newMember(uniqueAddress1, 1, MemberStatus.WeaklyUp, Set("one", "two", dc), appVersion))
+          ClusterEvent.MemberWeaklyUp(
+            newMember(uniqueAddress1, 1, MemberStatus.WeaklyUp, Set("one", "two", dc), appVersion))
         ) shouldEqual Some(
           ServerSentEvent(
             """{"member":{"dataCenter":"one","roles":["one","two","dc-one"],"status":"WeaklyUp","uniqueAddress":{"address":"akka://Main@hostname.com:3311","longUid":1}},"type":"MemberWeaklyUp"}""",
@@ -69,7 +75,8 @@ package akka.management.cluster {
         )
 
         ClusterDomainEventServerSentEventEncoder.encode(
-          ClusterEvent.MemberExited(newMember(uniqueAddress1, 1, MemberStatus.Exiting, Set("one", "two", dc), appVersion))
+          ClusterEvent.MemberExited(
+            newMember(uniqueAddress1, 1, MemberStatus.Exiting, Set("one", "two", dc), appVersion))
         ) shouldEqual Some(
           ServerSentEvent(
             """{"member":{"dataCenter":"one","roles":["one","two","dc-one"],"status":"Exiting","uniqueAddress":{"address":"akka://Main@hostname.com:3311","longUid":1}},"type":"MemberExited"}""",
@@ -87,8 +94,9 @@ package akka.management.cluster {
         )
 
         ClusterDomainEventServerSentEventEncoder.encode(
-          ClusterEvent
-            .MemberRemoved(newMember(uniqueAddress1, 1, MemberStatus.Removed, Set("one", "two", dc), appVersion), MemberStatus.Down)
+          ClusterEvent.MemberRemoved(
+            newMember(uniqueAddress1, 1, MemberStatus.Removed, Set("one", "two", dc), appVersion),
+            MemberStatus.Down)
         ) shouldEqual Some(
           ServerSentEvent(
             """{"member":{"dataCenter":"one","roles":["one","two","dc-one"],"status":"Removed","uniqueAddress":{"address":"akka://Main@hostname.com:3311","longUid":1}},"previousStatus":"Down","type":"MemberRemoved"}""",
@@ -124,7 +132,8 @@ package akka.management.cluster {
         )
 
         ClusterDomainEventServerSentEventEncoder.encode(
-          ClusterEvent.UnreachableMember(newMember(uniqueAddress1, 1, MemberStatus.Up, Set("one", "two", dc), appVersion))
+          ClusterEvent.UnreachableMember(
+            newMember(uniqueAddress1, 1, MemberStatus.Up, Set("one", "two", dc), appVersion))
         ) shouldEqual Some(
           ServerSentEvent(
             """{"member":{"dataCenter":"one","roles":["one","two","dc-one"],"status":"Up","uniqueAddress":{"address":"akka://Main@hostname.com:3311","longUid":1}},"type":"UnreachableMember"}""",

--- a/cluster-http/src/test/scala/akka/management/cluster/ClusterDomainEventServerSentEventEncoderSpec.scala
+++ b/cluster-http/src/test/scala/akka/management/cluster/ClusterDomainEventServerSentEventEncoderSpec.scala
@@ -8,12 +8,15 @@ import akka.cluster.{ ClusterEvent, Member, UniqueAddress }
 import akka.http.scaladsl.model.sse.ServerSentEvent
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import akka.util.Version
 
 package akka.cluster.management {
+
+
   // `Member`'s constructor is private[cluster], hence this
   object TestHelpers {
-    def newMember(uniqueAddress: UniqueAddress, upNumber: Int, status: MemberStatus, roles: Set[String]): Member =
-      new Member(uniqueAddress, upNumber, status, roles)
+    def newMember(uniqueAddress: UniqueAddress, upNumber: Int, status: MemberStatus, roles: Set[String], appVersion: Version): Member =
+      new Member(uniqueAddress, upNumber, status, roles, appVersion)
   }
 }
 
@@ -27,9 +30,10 @@ package akka.management.cluster {
         val dc = "dc-one"
         val address1 = Address("akka", "Main", "hostname.com", 3311)
         val uniqueAddress1 = UniqueAddress(address1, 1L)
+        val appVersion = Version("2.3.4")
 
         ClusterDomainEventServerSentEventEncoder.encode(
-          ClusterEvent.MemberJoined(newMember(uniqueAddress1, 1, MemberStatus.Joining, Set("one", "two", dc)))
+          ClusterEvent.MemberJoined(newMember(uniqueAddress1, 1, MemberStatus.Joining, Set("one", "two", dc), appVersion))
         ) shouldEqual Some(
           ServerSentEvent(
             """{"member":{"dataCenter":"one","roles":["one","two","dc-one"],"status":"Joining","uniqueAddress":{"address":"akka://Main@hostname.com:3311","longUid":1}},"type":"MemberJoined"}""",
@@ -38,7 +42,7 @@ package akka.management.cluster {
         )
 
         ClusterDomainEventServerSentEventEncoder.encode(
-          ClusterEvent.MemberWeaklyUp(newMember(uniqueAddress1, 1, MemberStatus.WeaklyUp, Set("one", "two", dc)))
+          ClusterEvent.MemberWeaklyUp(newMember(uniqueAddress1, 1, MemberStatus.WeaklyUp, Set("one", "two", dc), appVersion))
         ) shouldEqual Some(
           ServerSentEvent(
             """{"member":{"dataCenter":"one","roles":["one","two","dc-one"],"status":"WeaklyUp","uniqueAddress":{"address":"akka://Main@hostname.com:3311","longUid":1}},"type":"MemberWeaklyUp"}""",
@@ -47,7 +51,7 @@ package akka.management.cluster {
         )
 
         ClusterDomainEventServerSentEventEncoder.encode(
-          ClusterEvent.MemberUp(newMember(uniqueAddress1, 1, MemberStatus.Up, Set("one", "two", dc)))
+          ClusterEvent.MemberUp(newMember(uniqueAddress1, 1, MemberStatus.Up, Set("one", "two", dc), appVersion))
         ) shouldEqual Some(
           ServerSentEvent(
             """{"member":{"dataCenter":"one","roles":["one","two","dc-one"],"status":"Up","uniqueAddress":{"address":"akka://Main@hostname.com:3311","longUid":1}},"type":"MemberUp"}""",
@@ -56,7 +60,7 @@ package akka.management.cluster {
         )
 
         ClusterDomainEventServerSentEventEncoder.encode(
-          ClusterEvent.MemberLeft(newMember(uniqueAddress1, 1, MemberStatus.Leaving, Set("one", "two", dc)))
+          ClusterEvent.MemberLeft(newMember(uniqueAddress1, 1, MemberStatus.Leaving, Set("one", "two", dc), appVersion))
         ) shouldEqual Some(
           ServerSentEvent(
             """{"member":{"dataCenter":"one","roles":["one","two","dc-one"],"status":"Leaving","uniqueAddress":{"address":"akka://Main@hostname.com:3311","longUid":1}},"type":"MemberLeft"}""",
@@ -65,7 +69,7 @@ package akka.management.cluster {
         )
 
         ClusterDomainEventServerSentEventEncoder.encode(
-          ClusterEvent.MemberExited(newMember(uniqueAddress1, 1, MemberStatus.Exiting, Set("one", "two", dc)))
+          ClusterEvent.MemberExited(newMember(uniqueAddress1, 1, MemberStatus.Exiting, Set("one", "two", dc), appVersion))
         ) shouldEqual Some(
           ServerSentEvent(
             """{"member":{"dataCenter":"one","roles":["one","two","dc-one"],"status":"Exiting","uniqueAddress":{"address":"akka://Main@hostname.com:3311","longUid":1}},"type":"MemberExited"}""",
@@ -74,7 +78,7 @@ package akka.management.cluster {
         )
 
         ClusterDomainEventServerSentEventEncoder.encode(
-          ClusterEvent.MemberDowned(newMember(uniqueAddress1, 1, MemberStatus.Down, Set("one", "two", dc)))
+          ClusterEvent.MemberDowned(newMember(uniqueAddress1, 1, MemberStatus.Down, Set("one", "two", dc), appVersion))
         ) shouldEqual Some(
           ServerSentEvent(
             """{"member":{"dataCenter":"one","roles":["one","two","dc-one"],"status":"Down","uniqueAddress":{"address":"akka://Main@hostname.com:3311","longUid":1}},"type":"MemberDowned"}""",
@@ -84,7 +88,7 @@ package akka.management.cluster {
 
         ClusterDomainEventServerSentEventEncoder.encode(
           ClusterEvent
-            .MemberRemoved(newMember(uniqueAddress1, 1, MemberStatus.Removed, Set("one", "two", dc)), MemberStatus.Down)
+            .MemberRemoved(newMember(uniqueAddress1, 1, MemberStatus.Removed, Set("one", "two", dc), appVersion), MemberStatus.Down)
         ) shouldEqual Some(
           ServerSentEvent(
             """{"member":{"dataCenter":"one","roles":["one","two","dc-one"],"status":"Removed","uniqueAddress":{"address":"akka://Main@hostname.com:3311","longUid":1}},"previousStatus":"Down","type":"MemberRemoved"}""",
@@ -120,7 +124,7 @@ package akka.management.cluster {
         )
 
         ClusterDomainEventServerSentEventEncoder.encode(
-          ClusterEvent.UnreachableMember(newMember(uniqueAddress1, 1, MemberStatus.Up, Set("one", "two", dc)))
+          ClusterEvent.UnreachableMember(newMember(uniqueAddress1, 1, MemberStatus.Up, Set("one", "two", dc), appVersion))
         ) shouldEqual Some(
           ServerSentEvent(
             """{"member":{"dataCenter":"one","roles":["one","two","dc-one"],"status":"Up","uniqueAddress":{"address":"akka://Main@hostname.com:3311","longUid":1}},"type":"UnreachableMember"}""",
@@ -129,7 +133,7 @@ package akka.management.cluster {
         )
 
         ClusterDomainEventServerSentEventEncoder.encode(
-          ClusterEvent.ReachableMember(newMember(uniqueAddress1, 1, MemberStatus.Up, Set("one", "two", dc)))
+          ClusterEvent.ReachableMember(newMember(uniqueAddress1, 1, MemberStatus.Up, Set("one", "two", dc), appVersion))
         ) shouldEqual Some(
           ServerSentEvent(
             """{"member":{"dataCenter":"one","roles":["one","two","dc-one"],"status":"Up","uniqueAddress":{"address":"akka://Main@hostname.com:3311","longUid":1}},"type":"ReachableMember"}""",

--- a/cluster-http/src/test/scala/akka/management/cluster/ClusterHttpManagementHelperSpec.scala
+++ b/cluster-http/src/test/scala/akka/management/cluster/ClusterHttpManagementHelperSpec.scala
@@ -8,7 +8,7 @@ package akka.cluster.management
 
 import akka.actor.Address
 import akka.cluster.MemberStatus._
-import akka.cluster.{Member, UniqueAddress}
+import akka.cluster.{ Member, UniqueAddress }
 import akka.management.cluster.ClusterHttpManagementHelper
 import akka.util.Version
 import org.scalatest.matchers.should.Matchers

--- a/cluster-http/src/test/scala/akka/management/cluster/ClusterHttpManagementHelperSpec.scala
+++ b/cluster-http/src/test/scala/akka/management/cluster/ClusterHttpManagementHelperSpec.scala
@@ -8,8 +8,9 @@ package akka.cluster.management
 
 import akka.actor.Address
 import akka.cluster.MemberStatus._
-import akka.cluster.{ Member, UniqueAddress }
+import akka.cluster.{Member, UniqueAddress}
 import akka.management.cluster.ClusterHttpManagementHelper
+import akka.util.Version
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -28,10 +29,11 @@ class ClusterHttpManagementHelperSpec extends AnyWordSpec with Matchers {
       val uniqueAddress3 = UniqueAddress(address3, 3L)
       val uniqueAddress4 = UniqueAddress(address4, 4L)
 
-      val clusterMember1 = new Member(uniqueAddress1, 1, Up, Set("one", "two", dc))
-      val clusterMember2 = new Member(uniqueAddress2, 2, Joining, Set("one", "two", dc))
-      val clusterMember3 = new Member(uniqueAddress3, 3, Joining, Set("three", dc))
-      val clusterMember4 = new Member(uniqueAddress4, 4, Joining, Set(dc))
+      val version = new Version("1.42")
+      val clusterMember1 = new Member(uniqueAddress1, 1, Up, Set("one", "two", dc), version)
+      val clusterMember2 = new Member(uniqueAddress2, 2, Joining, Set("one", "two", dc), version)
+      val clusterMember3 = new Member(uniqueAddress3, 3, Joining, Set("three", dc), version)
+      val clusterMember4 = new Member(uniqueAddress4, 4, Joining, Set(dc), version)
 
       val members = Seq(clusterMember1, clusterMember2, clusterMember3, clusterMember4)
 

--- a/cluster-http/src/test/scala/akka/management/cluster/MultiDcSpec.scala
+++ b/cluster-http/src/test/scala/akka/management/cluster/MultiDcSpec.scala
@@ -9,7 +9,6 @@ import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.{ HttpRequest, StatusCodes }
 import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.management.scaladsl.ManagementRouteProviderSettings
-import akka.stream.ActorMaterializer
 import akka.testkit.SocketUtil
 import com.typesafe.config.ConfigFactory
 import org.scalatest.concurrent.{ Eventually, ScalaFutures }
@@ -59,7 +58,6 @@ class MultiDcSpec
 
       implicit val dcASystem = ActorSystem("MultiDcSystem", config.withFallback(dcA))
       val dcBSystem = ActorSystem("MultiDcSystem", config.withFallback(dcB))
-      implicit val materializer = ActorMaterializer()
 
       val routeSettings =
         ManagementRouteProviderSettings(selfBaseUri = s"http://127.0.0.1:$httpPortA", readOnly = false)

--- a/discovery-aws-api-async/src/main/scala/akka/discovery/awsapi/ecs/AsyncEcsTaskSetDiscovery.scala
+++ b/discovery-aws-api-async/src/main/scala/akka/discovery/awsapi/ecs/AsyncEcsTaskSetDiscovery.scala
@@ -24,7 +24,7 @@ import akka.http.scaladsl.model._
 import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.http.scaladsl.{ Http, HttpExt }
 import akka.pattern.after
-import akka.stream.ActorMaterializer
+import akka.stream.Materializer
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration
 import software.amazon.awssdk.core.retry.RetryPolicy
 import software.amazon.awssdk.services.ecs._
@@ -50,7 +50,6 @@ class AsyncEcsTaskSetDiscovery(system: ActorSystem) extends ServiceDiscovery {
   }
 
   private implicit val actorSystem: ActorSystem = system
-  private implicit val materializer: ActorMaterializer = ActorMaterializer()
   private implicit val ec: ExecutionContext = system.dispatcher
 
   private val httpClient: HttpExt = Http()
@@ -91,7 +90,7 @@ object AsyncEcsTaskSetDiscovery {
   private def resolveTasks(ecsClient: EcsAsyncClient, cluster: String, httpClient: HttpExt)(
       implicit
       ec: ExecutionContext,
-      mat: ActorMaterializer
+      mat: Materializer
   ): Future[Seq[Task]] =
     for {
       taskArn <- resolveTaskMetadata(httpClient).map(_.map(_.TaskARN))
@@ -110,7 +109,7 @@ object AsyncEcsTaskSetDiscovery {
   private[this] def resolveTaskMetadata(httpClient: HttpExt)(
       implicit
       ec: ExecutionContext,
-      mat: ActorMaterializer
+      mat: Materializer
   ): Future[Option[TaskMetadata]] = {
     val ecsContainerMetadataUri = sys.env.get(ECS_CONTAINER_METADATA_URI_PATH) match {
       case Some(uri) => uri

--- a/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/KubernetesApiServiceDiscovery.scala
+++ b/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/KubernetesApiServiceDiscovery.scala
@@ -14,7 +14,6 @@ import akka.http.scaladsl._
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.{ Authorization, OAuth2BearerToken }
 import akka.http.scaladsl.unmarshalling.Unmarshal
-import akka.stream.ActorMaterializer
 import com.typesafe.sslconfig.akka.AkkaSSLConfig
 import com.typesafe.sslconfig.ssl.TrustStoreConfig
 
@@ -79,16 +78,14 @@ object KubernetesApiServiceDiscovery {
  * An alternative implementation that uses the Kubernetes API. The main advantage of this method is that it allows
  * you to define readiness/health checks that don't affect the bootstrap mechanism.
  */
-class KubernetesApiServiceDiscovery(system: ActorSystem) extends ServiceDiscovery {
+class KubernetesApiServiceDiscovery(implicit system: ActorSystem) extends ServiceDiscovery {
 
   import akka.discovery.kubernetes.KubernetesApiServiceDiscovery._
   import system.dispatcher
 
-  private val http = Http()(system)
+  private val http = Http()
 
   private val settings = Settings(system)
-
-  private implicit val mat: ActorMaterializer = ActorMaterializer()(system)
 
   private val log = Logging(system, getClass)
 

--- a/discovery-marathon-api/src/main/scala/akka/discovery/marathon/MarathonApiServiceDiscovery.scala
+++ b/discovery-marathon-api/src/main/scala/akka/discovery/marathon/MarathonApiServiceDiscovery.scala
@@ -11,7 +11,6 @@ import akka.discovery._
 import akka.http.scaladsl._
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.unmarshalling.Unmarshal
-import akka.stream.ActorMaterializer
 import scala.collection.immutable.Seq
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
@@ -75,17 +74,15 @@ object MarathonApiServiceDiscovery {
  * Service discovery that uses the Marathon API.
  */
 @ApiMayChange
-class MarathonApiServiceDiscovery(system: ActorSystem) extends ServiceDiscovery {
+class MarathonApiServiceDiscovery(implicit system: ActorSystem) extends ServiceDiscovery {
   import MarathonApiServiceDiscovery._
   import system.dispatcher
 
   private val log = Logging(system, getClass)
 
-  private val http = Http()(system)
+  private val http = Http()
 
   private val settings = Settings(system)
-
-  private implicit val mat: ActorMaterializer = ActorMaterializer()(system)
 
   override def lookup(lookup: Lookup, resolveTimeout: FiniteDuration): Future[Resolved] = {
     val uri =

--- a/docs/src/main/paradox/akka-management.md
+++ b/docs/src/main/paradox/akka-management.md
@@ -26,14 +26,14 @@ And in addition to that, include all of the dependencies for the features you'd 
 like `akka-management-bootstrap` etc. Refer to each extensions documentation page to learn about how
 to configure and use it.
 
-Akka Management can be used with Akka $akka.version$ or $akka.version26$ or later.
+Akka Management can be used with Akka $akka.version$ or later.
 You have to override the following Akka dependencies by defining them explicitly in your build and
 define the Akka version to the one that you are using. Latest patch version of Akka is recommended and
-a later version than $akka.version26$ can be used.
+a later version than $akka.version$ can be used.
 
 @@dependency[sbt,Gradle,Maven] {
   symbol1=AkkaVersion
-  value1="$akka.version26$"
+  value1="$akka.version$"
   group=com.typesafe.akka
   artifact=akka-stream_$scala.binary.version$
   version=AkkaVersion

--- a/docs/src/main/paradox/bootstrap/index.md
+++ b/docs/src/main/paradox/bootstrap/index.md
@@ -48,14 +48,14 @@ and bootstrap extensions:
   version2=AkkaVersion
 }
 
-Akka Cluster Bootstrap can be used with Akka $akka.version$ or $akka.version26$ or later.
+Akka Cluster Bootstrap can be used with Akka $akka.version$ or later.
 You have to override the following Akka dependencies by defining them explicitly in your build and
 define the Akka version to the one that you are using. Latest patch version of Akka is recommended and
-a later version than $akka.version26$ can be used.
+a later version than $akka.version$ can be used.
 
 @@dependency[sbt,Gradle,Maven] {
   symbol=AkkaVersion
-  value=$akka.version26$
+  value=$akka.version$
   group=com.typesafe.akka
   artifact=akka-cluster_$scala.binary.version$
   version=AkkaVersion

--- a/docs/src/main/paradox/bootstrap/recipes.md
+++ b/docs/src/main/paradox/bootstrap/recipes.md
@@ -69,14 +69,14 @@ add the following dependency:
   version=AkkaManagementVersion
 }
 
-Akka Cluster HTTP Management can be used with Akka $akka.version$ or $akka.version26$ or later.
+Akka Cluster HTTP Management can be used with Akka $akka.version$ or later.
 You have to override the following Akka dependencies by defining them explicitly in your build and
 define the Akka version to the one that you are using. Latest patch version of Akka is recommended and
-a later version than $akka.version26$ can be used.
+a later version than $akka.version$ can be used.
 
 @@dependency[sbt,Gradle,Maven] {
   symbol=AkkaVersion
-  value=$akka.version26$
+  value=$akka.version$
   group=com.typesafe.akka
   artifact=akka-cluster-sharding_$scala.binary.version$
   version=AkkaVersion

--- a/docs/src/main/paradox/cluster-http-management.md
+++ b/docs/src/main/paradox/cluster-http-management.md
@@ -27,14 +27,14 @@ Make sure to include it along with the core akka-management library in your proj
   version2=AkkaManagementVersion
 }
 
-Akka Cluster HTTP Management can be used with Akka $akka.version$ or $akka.version26$ or later.
+Akka Cluster HTTP Management can be used with Akka $akka.version26$ or later.
 You have to override the following Akka dependencies by defining them explicitly in your build and
 define the Akka version to the one that you are using. Latest patch version of Akka is recommended and
-a later version than $akka.version26$ can be used.
+a later version than $akka.version$ can be used.
 
 @@dependency[sbt,Gradle,Maven] {
   symbol=AkkaVersion
-  value=$akka.version26$
+  value=$akka.version$
   group=com.typesafe.akka
   artifact=akka-cluster-sharding_$scala.binary.version$
   version=AkkaVersion

--- a/docs/src/main/paradox/discovery/aws.md
+++ b/docs/src/main/paradox/discovery/aws.md
@@ -59,14 +59,14 @@ This is a separate JAR file:
   version=AkkaManagementVersion
 }
 
-`akka-discovery-aws-api` can be used with Akka $akka.version$ or $akka.version26$ or later.
+`akka-discovery-aws-api` can be used with Akka $akka.version26$ or later.
 You have to override the following Akka dependencies by defining them explicitly in your build and
 define the Akka version to the one that you are using. Latest patch version of Akka is recommended and
-a later version than $akka.version26$ can be used.
+a later version than $akka.version$ can be used.
 
 @@dependency[sbt,Gradle,Maven] {
   symbol=AkkaVersion
-  value=$akka.version26$
+  value=$akka.version$
   group=com.typesafe.akka
   artifact=akka-cluster_$scala.binary.version$
   version=AkkaVersion

--- a/docs/src/main/paradox/discovery/consul.md
+++ b/docs/src/main/paradox/discovery/consul.md
@@ -24,14 +24,14 @@ If you are using Consul to do the service discovery this would allow you to base
   version=AkkaManagementVersion
 }
 
-`akka-discovery-consul` can be used with Akka $akka.version$ or $akka.version26$ or later.
+`akka-discovery-consul` can be used with Akka $akka.version$ or later.
 You have to override the following Akka dependencies by defining them explicitly in your build and
 define the Akka version to the one that you are using. Latest patch version of Akka is recommended and
-a later version than $akka.version26$ can be used.
+a later version than $akka.version$ can be used.
 
 @@dependency[sbt,Gradle,Maven] {
   symbol=AkkaVersion
-  value=$akka.version26$
+  value=$akka.version$
   group=com.typesafe.akka
   artifact=akka-cluster_$scala.binary.version$
   version=AkkaVersion

--- a/docs/src/main/paradox/discovery/kubernetes.md
+++ b/docs/src/main/paradox/discovery/kubernetes.md
@@ -20,14 +20,14 @@ First, add the dependency on the component:
   version=AkkaManagementVersion
 }
 
-`akka-discovery-kubernetes-api` can be used with Akka $akka.version$ or $akka.version26$ or later.
+`akka-discovery-kubernetes-api` can be used with Akka $akka.version$ or later.
 You have to override the following Akka dependencies by defining them explicitly in your build and
 define the Akka version to the one that you are using. Latest patch version of Akka is recommended and
-a later version than $akka.version26$ can be used.
+a later version than $akka.version$ can be used.
 
 @@dependency[sbt,Gradle,Maven] {
   symbol=AkkaVersion
-  value=$akka.version26$
+  value=$akka.version$
   group=com.typesafe.akka
   artifact=akka-cluster_$scala.binary.version$
   version=AkkaVersion

--- a/docs/src/main/paradox/discovery/marathon.md
+++ b/docs/src/main/paradox/discovery/marathon.md
@@ -33,14 +33,14 @@ This is a separate JAR file:
   version=AkkaManagementVersion
 }
 
-`akka-discovery-marathon-api` can be used with Akka $akka.version$ or $akka.version26$ or later.
+`akka-discovery-marathon-api` can be used with Akka $akka.version$ or later.
 You have to override the following Akka dependencies by defining them explicitly in your build and
 define the Akka version to the one that you are using. Latest patch version of Akka is recommended and
-a later version than $akka.version26$ can be used.
+a later version than $akka.version$ can be used.
 
 @@dependency[sbt,Gradle,Maven] {
   symbol=AkkaVersion
-  value=$akka.version26$
+  value=$akka.version$
   group=com.typesafe.akka
   artifact=akka-cluster_$scala.binary.version$
   version=AkkaVersion

--- a/docs/src/main/paradox/loglevels.md
+++ b/docs/src/main/paradox/loglevels.md
@@ -19,14 +19,14 @@ Requires @ref:[Akka Management](akka-management.md) and that the application use
   version2=AkkaManagementVersion
 }
 
-Akka Management and `akka-management-loglevels-logback` can be used with Akka $akka.version$ or $akka.version26$ or later.
+Akka Management and `akka-management-loglevels-logback` can be used with Akka $akka.version$ or later.
 You have to override the following Akka dependencies by defining them explicitly in your build and
 define the Akka version to the one that you are using. Latest patch version of Akka is recommended and
-a later version than $akka.version26$ can be used.
+a later version than $akka.version$ can be used.
 
 @@dependency[sbt,Gradle,Maven] {
   symbol=AkkaVersion
-  value=$akka.version26$
+  value=$akka.version$
   group=com.typesafe.akka
   artifact=akka-stream_$scala.binary.version$
   version=AkkaVersion

--- a/integration-test/aws-api-ec2/src/it/scala/akka/cluster/bootstrap/IntegrationTest.scala
+++ b/integration-test/aws-api-ec2/src/it/scala/akka/cluster/bootstrap/IntegrationTest.scala
@@ -8,7 +8,6 @@ import akka.event.Logging
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.HttpRequest
 import akka.management.cluster.{ClusterHttpManagementJsonProtocol, ClusterMembers}
-import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
 import akka.util.ByteString
 import com.amazonaws.services.cloudformation.AmazonCloudFormationClientBuilder
 import com.amazonaws.services.cloudformation.model._
@@ -17,7 +16,9 @@ import com.amazonaws.services.ec2.model.{DescribeInstancesRequest, Filter, Reser
 import org.scalatest.concurrent.PatienceConfiguration.{Interval, Timeout}
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.time.{Seconds, Span, SpanSugar}
-import org.scalatest.{BeforeAndAfterAll, FunSuite, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 import spray.json._
 
 import scala.concurrent.{Await, Future}
@@ -27,13 +28,11 @@ trait HttpClient {
 
   implicit val system: ActorSystem = ActorSystem("simple")
 
-  implicit val materializer: ActorMaterializer = ActorMaterializer(ActorMaterializerSettings(system))
-
   import system.dispatcher
 
   import scala.concurrent.duration._
 
-  val http = Http(system)
+  val http = Http()
 
   def httpGetRequest(url: String): Future[(Int, String)] = {
     http.singleRequest(HttpRequest(uri = url))
@@ -45,7 +44,7 @@ trait HttpClient {
 }
 
 class IntegrationTest
-  extends FunSuite
+  extends AnyFunSuite
     with Eventually
     with BeforeAndAfterAll
     with ScalaFutures

--- a/integration-test/dns-api-mesos/src/main/scala/akka/cluster/bootstrap/DemoApp.scala
+++ b/integration-test/dns-api-mesos/src/main/scala/akka/cluster/bootstrap/DemoApp.scala
@@ -9,7 +9,6 @@ import akka.cluster.{ Cluster, ClusterEvent }
 import akka.http.scaladsl.Http
 import akka.management.scaladsl.AkkaManagement
 import akka.management.cluster.bootstrap.ClusterBootstrap
-import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.Source
 import com.typesafe.config.ConfigFactory
@@ -20,7 +19,6 @@ object DemoApp extends App {
 
   import system.log
   import system.dispatcher
-  implicit val mat = ActorMaterializer()
   val cluster = Cluster(system)
 
   log.info("Started [{}], cluster.selfAddress = {}", system, cluster.selfAddress)

--- a/integration-test/kubernetes-api-java/pom.xml
+++ b/integration-test/kubernetes-api-java/pom.xml
@@ -18,7 +18,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <encoding>UTF-8</encoding>
-    <akka.version>2.5.31</akka.version>
+    <akka.version>2.6.10</akka.version>
     <akka.http.version>10.1.11</akka.http.version>
     <akka-management.version>1.0.5</akka-management.version>
     <scala.binary.version>2.12</scala.binary.version>

--- a/integration-test/kubernetes-api-java/src/main/java/akka/cluster/bootstrap/demo/DemoApp.java
+++ b/integration-test/kubernetes-api-java/src/main/java/akka/cluster/bootstrap/demo/DemoApp.java
@@ -16,7 +16,6 @@ import akka.management.javadsl.AkkaManagement;
 
 //#start-akka-management
 import akka.management.cluster.bootstrap.ClusterBootstrap;
-import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
 
 public class DemoApp extends AllDirectives {
@@ -24,7 +23,7 @@ public class DemoApp extends AllDirectives {
   DemoApp() {
     ActorSystem system = ActorSystem.create("Appka");
 
-    Materializer mat = ActorMaterializer.create(system);
+    Materializer mat = Materializer.createMaterializer(system);
     Cluster cluster = Cluster.get(system);
 
     system.log().info("Started [" + system + "], cluster.selfAddress = " + cluster.selfAddress() + ")");

--- a/integration-test/kubernetes-api/src/main/scala/akka/cluster/bootstrap/DemoApp.scala
+++ b/integration-test/kubernetes-api/src/main/scala/akka/cluster/bootstrap/DemoApp.scala
@@ -15,14 +15,12 @@ import akka.management.cluster.bootstrap.ClusterBootstrap
 import akka.management.scaladsl.AkkaManagement
 
 //#start-akka-management
-import akka.stream.ActorMaterializer
 
 object DemoApp extends App {
 
   implicit val system = ActorSystem("Appka")
 
   import system.log
-  implicit val mat = ActorMaterializer()
   val cluster = Cluster(system)
 
   log.info(s"Started [$system], cluster.selfAddress = ${cluster.selfAddress}")

--- a/integration-test/kubernetes-dns/src/main/scala/akka/cluster/bootstrap/ClusterApp.scala
+++ b/integration-test/kubernetes-dns/src/main/scala/akka/cluster/bootstrap/ClusterApp.scala
@@ -13,14 +13,12 @@ import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.Directives._
 import akka.management.cluster.bootstrap.ClusterBootstrap
 import akka.management.scaladsl.AkkaManagement
-import akka.stream.ActorMaterializer
 
 object ClusterApp {
 
   def main(args: Array[String]): Unit = {
 
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
     implicit val executionContext = system.dispatcher
     val cluster = Cluster(system)
 

--- a/integration-test/marathon-api-docker/src/main/scala/akka/cluster/bootstrap/MarathonApiDockerDemoApp.scala
+++ b/integration-test/marathon-api-docker/src/main/scala/akka/cluster/bootstrap/MarathonApiDockerDemoApp.scala
@@ -11,11 +11,9 @@ import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.Directives._
 import akka.management.cluster.bootstrap.ClusterBootstrap
 import akka.management.scaladsl.AkkaManagement
-import akka.stream.ActorMaterializer
 
 object MarathonApiDockerDemoApp extends App {
   implicit val system = ActorSystem("my-system")
-  implicit val materializer = ActorMaterializer()
 
   val cluster = Cluster(system)
 

--- a/integration-test/marathon-api/src/main/scala/akka/cluster/bootstrap/DemoApp.scala
+++ b/integration-test/marathon-api/src/main/scala/akka/cluster/bootstrap/DemoApp.scala
@@ -11,11 +11,9 @@ import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.Directives._
 import akka.management.scaladsl.AkkaManagement
 import akka.management.cluster.bootstrap.ClusterBootstrap
-import akka.stream.ActorMaterializer
 
 object DemoApp extends App {
   implicit val system = ActorSystem("my-system")
-  implicit val materializer = ActorMaterializer()
 
   val cluster = Cluster(system)
 

--- a/lease-kubernetes/src/main/scala/akka/coordination/lease/kubernetes/LeaseActor.scala
+++ b/lease-kubernetes/src/main/scala/akka/coordination/lease/kubernetes/LeaseActor.scala
@@ -186,7 +186,7 @@ private[akka] class LeaseActor(
         resource.owner.contains(ownerName),
         "response from API server has different owner for success: " + resource)
       log.debug("Heartbeat: lease time updated: Version {}", resource.version)
-      setTimer("heartbeat", Heartbeat, settings.timeoutSettings.heartbeatInterval, repeat = false)
+      startSingleTimer("heartbeat", Heartbeat, settings.timeoutSettings.heartbeatInterval)
       stay.using(gv.copy(version = resource.version))
     case Event(WriteResponse(Left(lr @ _)), GrantedVersion(_, leaseLost)) =>
       log.warning("Conflict during heartbeat to lease {}. Lease assumed to be released.", lr)
@@ -266,7 +266,7 @@ private[akka] class LeaseActor(
 
   onTransition {
     case _ -> Granted =>
-      setTimer("heartbeat", Heartbeat, settings.timeoutSettings.heartbeatInterval, repeat = false)
+      startSingleTimer("heartbeat", Heartbeat, settings.timeoutSettings.heartbeatInterval)
     case Granted -> _ =>
       cancelTimer("heartbeat")
       granted.set(false)

--- a/lease-kubernetes/src/main/scala/akka/coordination/lease/kubernetes/internal/KubernetesApiImpl.scala
+++ b/lease-kubernetes/src/main/scala/akka/coordination/lease/kubernetes/internal/KubernetesApiImpl.scala
@@ -18,7 +18,6 @@ import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.pattern.after
 import akka.coordination.lease.kubernetes.{ KubernetesApi, KubernetesSettings, LeaseResource }
 import akka.coordination.lease.{ LeaseException, LeaseTimeoutException }
-import akka.stream.ActorMaterializer
 import com.typesafe.sslconfig.akka.AkkaSSLConfig
 import com.typesafe.sslconfig.ssl.TrustStoreConfig
 import scala.collection.immutable
@@ -35,7 +34,7 @@ import scala.util.control.NonFatal
 
   import system.dispatcher
 
-  private implicit val materializer: ActorMaterializer = ActorMaterializer()(system)
+  private implicit val sys = system
   private val log = Logging(system, getClass)
   private val http = Http()(system)
   private val httpsTrustStoreConfig =

--- a/management/src/main/scala/akka/management/scaladsl/AkkaManagement.scala
+++ b/management/src/main/scala/akka/management/scaladsl/AkkaManagement.scala
@@ -41,7 +41,7 @@ import akka.management.AkkaManagementSettings
 import akka.management.ManagementLogMarker
 import akka.management.NamedRouteProvider
 import akka.management.javadsl
-import akka.stream.ActorMaterializer
+import akka.stream.Materializer
 import akka.util.ManifestInfo
 
 object AkkaManagement extends ExtensionId[AkkaManagement] with ExtensionIdProvider {
@@ -75,7 +75,7 @@ final class AkkaManagement(implicit private[akka] val system: ExtendedActorSyste
   private val log = Logging.withMarker(system, getClass)
   val settings: AkkaManagementSettings = new AkkaManagementSettings(system.settings.config)
 
-  @volatile private var materializer: Option[ActorMaterializer] = None
+  @volatile private var materializer: Option[Materializer] = None
   import system.dispatcher
 
   private val routeProviders: immutable.Seq[ManagementRouteProvider] = loadRouteProviders()
@@ -132,8 +132,7 @@ final class AkkaManagement(implicit private[akka] val system: ExtendedActorSyste
         val effectiveBindPort = settings.Http.EffectiveBindPort
         val effectiveProviderSettings = transformSettings(providerSettings)
 
-        implicit val mat: ActorMaterializer = ActorMaterializer()
-        materializer = Some(mat)
+        materializer = Some(implicitly[Materializer])
 
         // TODO instead of binding to hardcoded things here, discovery could also be used for this binding!
         // Basically: "give me the SRV host/port for the port called `akka-bootstrap`"

--- a/management/src/test/scala/akka/management/AkkaManagementHttpEndpointSpec.scala
+++ b/management/src/test/scala/akka/management/AkkaManagementHttpEndpointSpec.scala
@@ -27,7 +27,6 @@ import akka.http.scaladsl.server.directives.Credentials
 import akka.management.scaladsl.AkkaManagement
 import akka.management.scaladsl.ManagementRouteProvider
 import akka.management.scaladsl.ManagementRouteProviderSettings
-import akka.stream.ActorMaterializer
 import akka.testkit.SocketUtil
 import com.typesafe.config.ConfigFactory
 import javax.net.ssl.KeyManagerFactory
@@ -86,7 +85,6 @@ class AkkaManagementHttpEndpointSpec extends AnyWordSpecLike with Matchers {
         )
 
         implicit val system = ActorSystem("test", config.withFallback(configClusterHttpManager).resolve())
-        implicit val mat = ActorMaterializer() // needed for toStrict
 
         val management = AkkaManagement(system)
         management.settings.Http.RouteProviders should contain(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,10 +10,8 @@ object Dependencies {
   val CrossScalaVersions = Seq(Dependencies.Scala212, Dependencies.Scala213)
 
   // Align the versions in integration-test/kubernetes-api-java/pom.xml
-  val Akka25Version = "2.5.31"
-  val Akka26Version = "2.6.9"
-  val AkkaVersion = if (CronBuild) Akka26Version else Akka25Version
-  val AkkaBinaryVersion = if (CronBuild) "2.6" else "2.5"
+  val AkkaVersion = "2.6.10"
+  val AkkaBinaryVersion = "2.6"
   // Align the versions in integration-test/kubernetes-api-java/pom.xml
   val AkkaHttp101 = "10.1.11"
   val AkkaHttp102 = "10.2.0"


### PR DESCRIPTION
This means we require akka 2.6 instead of 2.5 going forward.

Refs #783