### PR TITLE
Restructure dependencies declaration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,7 @@ lazy val `akka-discovery-kubernetes-api` = project
   .settings(
     name := "akka-discovery-kubernetes-api",
     organization := "com.lightbend.akka.discovery",
-    Dependencies.DiscoveryKubernetesApi
+    libraryDependencies := Dependencies.DiscoveryKubernetesApi
   )
 
 lazy val `akka-discovery-marathon-api` = project
@@ -50,7 +50,7 @@ lazy val `akka-discovery-marathon-api` = project
   .settings(
     name := "akka-discovery-marathon-api",
     organization := "com.lightbend.akka.discovery",
-    Dependencies.DiscoveryMarathonApi
+    libraryDependencies := Dependencies.DiscoveryMarathonApi
   )
 
 lazy val `akka-discovery-aws-api` = project
@@ -59,7 +59,7 @@ lazy val `akka-discovery-aws-api` = project
   .settings(
     name := "akka-discovery-aws-api",
     organization := "com.lightbend.akka.discovery",
-    Dependencies.DiscoveryAwsApi
+    libraryDependencies := Dependencies.DiscoveryAwsApi
   )
 
 lazy val `akka-discovery-aws-api-async` = project
@@ -68,7 +68,7 @@ lazy val `akka-discovery-aws-api-async` = project
   .settings(
     name := "akka-discovery-aws-api-async",
     organization := "com.lightbend.akka.discovery",
-    Dependencies.DiscoveryAwsApiAsync
+    libraryDependencies := Dependencies.DiscoveryAwsApiAsync
   )
 
 lazy val `akka-discovery-consul` = project
@@ -77,7 +77,7 @@ lazy val `akka-discovery-consul` = project
   .settings(
     name := "akka-discovery-consul",
     organization := "com.lightbend.akka.discovery",
-    Dependencies.DiscoveryConsul
+    libraryDependencies := Dependencies.DiscoveryConsul
   )
 
 // gathers all enabled routes and serves them (HTTP or otherwise)
@@ -86,7 +86,7 @@ lazy val `akka-management` = project
   .enablePlugins(AutomateHeaderPlugin)
   .settings(
     name := "akka-management",
-    Dependencies.ManagementHttp
+    libraryDependencies := Dependencies.ManagementHttp
   )
 
 lazy val `loglevels-logback` = project
@@ -94,7 +94,7 @@ lazy val `loglevels-logback` = project
   .enablePlugins(AutomateHeaderPlugin)
   .settings(
     name := "akka-management-loglevels-logback",
-    Dependencies.LoglevelsLogback
+    libraryDependencies := Dependencies.LoglevelsLogback
   )
   .dependsOn(`akka-management`)
 
@@ -103,7 +103,7 @@ lazy val `cluster-http` = project
   .enablePlugins(AutomateHeaderPlugin)
   .settings(
     name := "akka-management-cluster-http",
-    Dependencies.ClusterHttp
+    libraryDependencies := Dependencies.ClusterHttp
   )
   .dependsOn(`akka-management`)
 
@@ -112,7 +112,7 @@ lazy val `cluster-bootstrap` = project
   .enablePlugins(AutomateHeaderPlugin)
   .settings(
     name := "akka-management-cluster-bootstrap",
-    Dependencies.ClusterBootstrap
+    libraryDependencies := Dependencies.ClusterBootstrap
   )
   .dependsOn(`akka-management`)
 
@@ -121,7 +121,7 @@ lazy val `lease-kubernetes` = project
   .enablePlugins(AutomateHeaderPlugin)
   .settings(
     name := "akka-lease-kubernetes",
-    Dependencies.LeaseKubernetes
+    libraryDependencies := Dependencies.LeaseKubernetes
   )
   .settings(
     Defaults.itSettings
@@ -138,7 +138,7 @@ lazy val `lease-kubernetes-int-test` = project
     name := "akka-lease-kubernetes-int-test",
     skip in publish := true,
     whitesourceIgnore := true,
-    Dependencies.LeaseKubernetesTest,
+    libraryDependencies := Dependencies.LeaseKubernetesTest,
     version ~= (_.replace('+', '-')),
     dockerBaseImage := "openjdk:8-jre-alpine",
     dockerUpdateLatest := true,
@@ -153,6 +153,7 @@ lazy val `lease-kubernetes-int-test` = project
         Cmd("RUN", "chmod +x /opt/docker/bin/akka-lease-kubernetes-int-test")
       )
   )
+
 lazy val `integration-test-kubernetes-api` = project
   .in(file("integration-test/kubernetes-api"))
   .disablePlugins(BintrayPlugin)
@@ -161,7 +162,7 @@ lazy val `integration-test-kubernetes-api` = project
     skip in publish := true,
     sources in (Compile, doc) := Seq.empty,
     whitesourceIgnore := true,
-    Dependencies.BootstrapDemos
+    libraryDependencies := Dependencies.BootstrapDemos
   )
   .dependsOn(
     `akka-management`,
@@ -178,7 +179,7 @@ lazy val `integration-test-kubernetes-api-java` = project
     skip in publish := true,
     sources in (Compile, doc) := Seq.empty,
     whitesourceIgnore := true,
-    Dependencies.BootstrapDemos
+    libraryDependencies := Dependencies.BootstrapDemos
   )
   .dependsOn(
     `akka-management`,
@@ -195,7 +196,7 @@ lazy val `integration-test-kubernetes-dns` = project
     skip in publish := true,
     sources in (Compile, doc) := Seq.empty,
     whitesourceIgnore := true,
-    Dependencies.BootstrapDemos
+    libraryDependencies := Dependencies.BootstrapDemos
   )
   .dependsOn(
     `akka-management`,
@@ -269,7 +270,7 @@ lazy val `integration-test-local` = project
     skip in publish := true,
     sources in (Compile, doc) := Seq.empty,
     whitesourceIgnore := true,
-    Dependencies.BootstrapDemos
+    libraryDependencies := Dependencies.BootstrapDemos
   )
   .dependsOn(
     `akka-management`,

--- a/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/HttpContactPointRoutesSpec.scala
+++ b/cluster-bootstrap/src/test/scala/akka/management/cluster/bootstrap/contactpoint/HttpContactPointRoutesSpec.scala
@@ -8,7 +8,7 @@ import akka.cluster.{ Cluster, ClusterEvent }
 import akka.event.NoLogging
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.management.cluster.bootstrap.ClusterBootstrapSettings
-import akka.testkit.{ SocketUtil, TestProbe }
+import akka.testkit.TestProbe
 import org.scalatest.concurrent.Eventually
 import org.scalatest.time.{ Millis, Seconds, Span }
 import org.scalatest.matchers.should.Matchers

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -10,7 +10,7 @@ object Common extends AutoPlugin {
   override def requires = plugins.JvmPlugin && HeaderPlugin
 
   override lazy val projectSettings =
-    Dependencies.Common ++ Seq(
+    Seq(
       organization := "com.lightbend.akka.management",
       organizationName := "Lightbend Inc.",
       organizationHomepage := Some(url("https://www.lightbend.com/")),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -46,7 +46,7 @@ object Dependencies {
         "com.typesafe.akka" %% "akka-actor" % AkkaVersion,
         "com.typesafe.akka" %% "akka-discovery" % AkkaVersion,
         "com.orbitz.consul" % "consul-client" % "1.4.2",
-        "com.pszymczyk.consul" % "embedded-consul" % "2.2.0" % Test,
+        "com.pszymczyk.consul" % "embedded-consul" % "2.1.4" % Test,
         "org.scalatest" %% "scalatest" % ScalaTestVersion % Test,
         "com.typesafe.akka" %% "akka-testkit" % AkkaVersion % Test,
         "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion % Test,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -42,147 +42,123 @@ object Dependencies {
   )
 
   val DiscoveryConsul = Seq(
-    libraryDependencies ++= Seq(
-        "com.typesafe.akka" %% "akka-actor" % AkkaVersion,
-        "com.typesafe.akka" %% "akka-discovery" % AkkaVersion,
-        "com.orbitz.consul" % "consul-client" % "1.4.2",
-        "com.pszymczyk.consul" % "embedded-consul" % "2.1.4" % Test,
-        "org.scalatest" %% "scalatest" % ScalaTestVersion % Test,
-        "com.typesafe.akka" %% "akka-testkit" % AkkaVersion % Test,
-        "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion % Test,
-        "ch.qos.logback" % "logback-classic" % "1.2.3" % Test
-      ) ++ JacksonDatabind ++ JacksonDatatype // consul depends on insecure version of jackson
-  )
+      "com.typesafe.akka" %% "akka-actor" % AkkaVersion,
+      "com.typesafe.akka" %% "akka-discovery" % AkkaVersion,
+      "com.orbitz.consul" % "consul-client" % "1.4.2",
+      "com.pszymczyk.consul" % "embedded-consul" % "2.1.4" % Test,
+      "org.scalatest" %% "scalatest" % ScalaTestVersion % Test,
+      "com.typesafe.akka" %% "akka-testkit" % AkkaVersion % Test,
+      "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion % Test,
+      "ch.qos.logback" % "logback-classic" % "1.2.3" % Test
+    ) ++ JacksonDatabind ++ JacksonDatatype // consul depends on insecure version of jackson
 
   val DiscoveryKubernetesApi = Seq(
-    libraryDependencies ++= Seq(
-        "com.typesafe.akka" %% "akka-actor" % AkkaVersion,
-        "com.typesafe.akka" %% "akka-discovery" % AkkaVersion,
-        "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
-        "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
-        "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
-        "org.scalatest" %% "scalatest" % ScalaTestVersion % Test
-      )
+    "com.typesafe.akka" %% "akka-actor" % AkkaVersion,
+    "com.typesafe.akka" %% "akka-discovery" % AkkaVersion,
+    "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
+    "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
+    "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
+    "org.scalatest" %% "scalatest" % ScalaTestVersion % Test
   )
 
   val DiscoveryMarathonApi = Seq(
-    libraryDependencies ++= Seq(
-        "com.typesafe.akka" %% "akka-actor" % AkkaVersion,
-        "com.typesafe.akka" %% "akka-discovery" % AkkaVersion,
-        "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
-        "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
-        "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
-        "org.scalatest" %% "scalatest" % ScalaTestVersion % Test
-      )
+    "com.typesafe.akka" %% "akka-actor" % AkkaVersion,
+    "com.typesafe.akka" %% "akka-discovery" % AkkaVersion,
+    "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
+    "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
+    "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
+    "org.scalatest" %% "scalatest" % ScalaTestVersion % Test
   )
 
   val DiscoveryAwsApi = Seq(
-    libraryDependencies ++= Seq(
-        "com.typesafe.akka" %% "akka-actor" % AkkaVersion,
-        "com.typesafe.akka" %% "akka-discovery" % AkkaVersion,
-        "com.amazonaws" % "aws-java-sdk-ec2" % AwsSdkVersion,
-        "com.amazonaws" % "aws-java-sdk-ecs" % AwsSdkVersion,
-        "org.scalatest" %% "scalatest" % ScalaTestVersion % Test
-      ) ++ JacksonDatabind // aws-java-sdk depends on insecure version of jackson
-  )
+      "com.typesafe.akka" %% "akka-actor" % AkkaVersion,
+      "com.typesafe.akka" %% "akka-discovery" % AkkaVersion,
+      "com.amazonaws" % "aws-java-sdk-ec2" % AwsSdkVersion,
+      "com.amazonaws" % "aws-java-sdk-ecs" % AwsSdkVersion,
+      "org.scalatest" %% "scalatest" % ScalaTestVersion % Test
+    ) ++ JacksonDatabind // aws-java-sdk depends on insecure version of jackson
 
   val DiscoveryAwsApiAsync = Seq(
-    libraryDependencies ++= Seq(
-        "com.typesafe.akka" %% "akka-actor" % AkkaVersion,
-        "com.typesafe.akka" %% "akka-discovery" % AkkaVersion,
-        "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
-        "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
-        "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
-        "software.amazon.awssdk" % "ecs" % "2.13.76",
-        "org.scalatest" %% "scalatest" % ScalaTestVersion % Test
-      ) ++ JacksonDatabind // aws-java-sdk depends on insecure version of jackson
-  )
+      "com.typesafe.akka" %% "akka-actor" % AkkaVersion,
+      "com.typesafe.akka" %% "akka-discovery" % AkkaVersion,
+      "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
+      "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
+      "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
+      "software.amazon.awssdk" % "ecs" % "2.13.76",
+      "org.scalatest" %% "scalatest" % ScalaTestVersion % Test
+    ) ++ JacksonDatabind // aws-java-sdk depends on insecure version of jackson
 
   val ManagementHttp = Seq(
-    libraryDependencies ++= Seq(
-        "com.typesafe.akka" %% "akka-actor" % AkkaVersion,
-        "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
-        "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
-        "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
-        "com.typesafe.akka" %% "akka-testkit" % AkkaVersion % Test,
-        "com.typesafe.akka" %% "akka-cluster" % AkkaVersion % Test,
-        "com.typesafe.akka" %% "akka-http-testkit" % AkkaHttpVersion % Test,
-        "org.scalatest" %% "scalatest" % ScalaTestVersion % Test,
-        "org.scalatestplus" %% "junit-4-13" % ScalaTestPlusJUnitVersion % Test
-      )
+    "com.typesafe.akka" %% "akka-actor" % AkkaVersion,
+    "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
+    "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
+    "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
+    "com.typesafe.akka" %% "akka-testkit" % AkkaVersion % Test,
+    "com.typesafe.akka" %% "akka-cluster" % AkkaVersion % Test,
+    "com.typesafe.akka" %% "akka-http-testkit" % AkkaHttpVersion % Test,
+    "org.scalatest" %% "scalatest" % ScalaTestVersion % Test,
+    "org.scalatestplus" %% "junit-4-13" % ScalaTestPlusJUnitVersion % Test
   )
 
   val LoglevelsLogback = Seq(
-    libraryDependencies ++= Seq(
-        "com.typesafe.akka" %% "akka-actor" % AkkaVersion,
-        "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
-        "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
-        "ch.qos.logback" % "logback-classic" % "1.2.3",
-        "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
-        "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
-        "org.scalatest" %% "scalatest" % ScalaTestVersion % Test,
-        "com.typesafe.akka" %% "akka-testkit" % AkkaVersion % Test,
-        "com.typesafe.akka" %% "akka-http-testkit" % AkkaHttpVersion % Test
-      )
+    "com.typesafe.akka" %% "akka-actor" % AkkaVersion,
+    "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
+    "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
+    "ch.qos.logback" % "logback-classic" % "1.2.3",
+    "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
+    "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
+    "org.scalatest" %% "scalatest" % ScalaTestVersion % Test,
+    "com.typesafe.akka" %% "akka-testkit" % AkkaVersion % Test,
+    "com.typesafe.akka" %% "akka-http-testkit" % AkkaHttpVersion % Test
   )
 
   val ClusterHttp = Seq(
-    libraryDependencies ++= Seq(
-        "com.typesafe.akka" %% "akka-cluster" % AkkaVersion,
-        "com.typesafe.akka" %% "akka-cluster-sharding" % AkkaVersion,
-        "com.typesafe.akka" %% "akka-http-core" % AkkaHttpVersion,
-        "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
-        "com.typesafe.akka" %% "akka-testkit" % AkkaVersion % Test,
-        "org.mockito" % "mockito-all" % "1.10.19" % Test,
-        "com.typesafe.akka" %% "akka-http-testkit" % AkkaHttpVersion % Test,
-        "com.typesafe.akka" %% "akka-distributed-data" % AkkaVersion % Test,
-        "org.scalatest" %% "scalatest" % ScalaTestVersion % Test,
-        "org.scalatestplus" %% "junit-4-13" % ScalaTestPlusJUnitVersion % Test
-      )
+    "com.typesafe.akka" %% "akka-cluster" % AkkaVersion,
+    "com.typesafe.akka" %% "akka-cluster-sharding" % AkkaVersion,
+    "com.typesafe.akka" %% "akka-http-core" % AkkaHttpVersion,
+    "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
+    "com.typesafe.akka" %% "akka-testkit" % AkkaVersion % Test,
+    "org.mockito" % "mockito-all" % "1.10.19" % Test,
+    "com.typesafe.akka" %% "akka-http-testkit" % AkkaHttpVersion % Test,
+    "com.typesafe.akka" %% "akka-distributed-data" % AkkaVersion % Test,
+    "org.scalatest" %% "scalatest" % ScalaTestVersion % Test,
+    "org.scalatestplus" %% "junit-4-13" % ScalaTestPlusJUnitVersion % Test
   )
 
   val ClusterBootstrap = Seq(
-    libraryDependencies ++= Seq(
-        "com.typesafe.akka" %% "akka-discovery" % AkkaVersion,
-        "com.typesafe.akka" %% "akka-cluster" % AkkaVersion,
-        "com.typesafe.akka" %% "akka-http-core" % AkkaHttpVersion,
-        "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
-        "com.typesafe.akka" %% "akka-testkit" % AkkaVersion % Test,
-        "com.typesafe.akka" %% "akka-http-testkit" % AkkaHttpVersion % Test,
-        "com.typesafe.akka" %% "akka-distributed-data" % AkkaVersion % Test,
-        "org.scalatest" %% "scalatest" % ScalaTestVersion % Test,
-        "org.scalatestplus" %% "junit-4-13" % ScalaTestPlusJUnitVersion % Test
-      )
+    "com.typesafe.akka" %% "akka-discovery" % AkkaVersion,
+    "com.typesafe.akka" %% "akka-cluster" % AkkaVersion,
+    "com.typesafe.akka" %% "akka-http-core" % AkkaHttpVersion,
+    "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
+    "com.typesafe.akka" %% "akka-testkit" % AkkaVersion % Test,
+    "com.typesafe.akka" %% "akka-http-testkit" % AkkaHttpVersion % Test,
+    "com.typesafe.akka" %% "akka-distributed-data" % AkkaVersion % Test,
+    "org.scalatest" %% "scalatest" % ScalaTestVersion % Test,
+    "org.scalatestplus" %% "junit-4-13" % ScalaTestPlusJUnitVersion % Test
   )
 
   val LeaseKubernetes = Seq(
-    libraryDependencies ++= Seq(
-        "com.typesafe.akka" %% "akka-actor" % AkkaVersion,
-        "com.typesafe.akka" %% "akka-coordination" % AkkaVersion,
-        "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
-        "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
-        "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
-        "com.github.tomakehurst" % "wiremock-jre8" % "2.27.2" % Test,
-        "org.scalatest" %% "scalatest" % ScalaTestVersion % "it,test",
-        "org.scalatestplus" %% "junit-4-13" % ScalaTestPlusJUnitVersion % "it,test",
-        "com.typesafe.akka" %% "akka-testkit" % AkkaVersion % "it,test"
-      )
+    "com.typesafe.akka" %% "akka-actor" % AkkaVersion,
+    "com.typesafe.akka" %% "akka-coordination" % AkkaVersion,
+    "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
+    "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
+    "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
+    "com.github.tomakehurst" % "wiremock-jre8" % "2.27.2" % Test,
+    "org.scalatest" %% "scalatest" % ScalaTestVersion % "it,test",
+    "org.scalatestplus" %% "junit-4-13" % ScalaTestPlusJUnitVersion % "it,test",
+    "com.typesafe.akka" %% "akka-testkit" % AkkaVersion % "it,test"
   )
 
   val LeaseKubernetesTest = Seq(
-    libraryDependencies ++= Seq(
-        "org.scalatest" %% "scalatest" % ScalaTestVersion
-      )
+    "org.scalatest" %% "scalatest" % ScalaTestVersion
   )
 
   val BootstrapDemos = Seq(
-    libraryDependencies ++= Seq(
-        "com.typesafe.akka" %% "akka-discovery" % AkkaVersion,
-        "com.typesafe.akka" %% "akka-testkit" % AkkaVersion % Test,
-        "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
-        "ch.qos.logback" % "logback-classic" % "1.2.3",
-        "org.scalatest" %% "scalatest" % ScalaTestVersion % Test
-      )
+    "com.typesafe.akka" %% "akka-discovery" % AkkaVersion,
+    "com.typesafe.akka" %% "akka-testkit" % AkkaVersion % Test,
+    "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
+    "ch.qos.logback" % "logback-classic" % "1.2.3",
+    "org.scalatest" %% "scalatest" % ScalaTestVersion % Test
   )
 
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -31,195 +31,164 @@ object Dependencies {
   val AwsSdkVersion = "1.11.837"
   val JacksonVersion = "2.10.5"
 
-  object TestDeps {
-    val scalaTest = Seq(
-      "org.scalatest" %% "scalatest" % ScalaTestVersion,
-      "org.scalatestplus" %% "junit-4-13" % ScalaTestPlusJUnitVersion
-    )
-    val akkaTestKit = "com.typesafe.akka" %% "akka-testkit" % AkkaVersion
-  }
-
-  val Common = Seq(
-    libraryDependencies ++= TestDeps.scalaTest.map(_ % Test)
+  private val ScalaTest = Seq(
+    "org.scalatest" %% "scalatest" % ScalaTestVersion % Test,
+    "org.scalatestplus" %% "junit-4-13" % ScalaTestPlusJUnitVersion % Test
   )
-  private object DependencyGroups {
-    val AkkaActor = Seq(
-      "com.typesafe.akka" %% "akka-actor" % AkkaVersion
-    )
 
-    val AkkaDiscovery = Seq(
-      "com.typesafe.akka" %% "akka-discovery" % AkkaVersion
-    )
+  // often called-in transitively with insecure versions of databind / core
+  private val JacksonDatabind = Seq(
+    "com.fasterxml.jackson.core" % "jackson-databind" % JacksonVersion
+  )
 
-    val AkkaCoordination = Seq(
-      "com.typesafe.akka" %% "akka-coordination" % AkkaVersion
-    )
-
-    val AkkaHttpCore = Seq(
-      "com.typesafe.akka" %% "akka-http-core" % AkkaHttpVersion,
-      "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
-      "io.spray" %% "spray-json" % SprayJsonVersion // ApacheV2
-    )
-    val AkkaHttp = Seq(
-      "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
-      "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
-      "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
-      "com.typesafe.akka" %% "akka-actor" % AkkaVersion,
-      "io.spray" %% "spray-json" % SprayJsonVersion // ApacheV2
-    )
-
-    val AkkaCluster = Seq(
-      "com.typesafe.akka" %% "akka-cluster" % AkkaVersion
-    )
-
-    val AkkaSharding = Seq(
-      "com.typesafe.akka" %% "akka-cluster" % AkkaVersion,
-      "com.typesafe.akka" %% "akka-cluster-sharding" % AkkaVersion
-    )
-
-    val AkkaTesting = Seq(
-      TestDeps.akkaTestKit % "test",
-      "org.mockito" % "mockito-all" % "1.10.19" % "test" // Common Public License 1.0
-    )
-
-    val AkkaHttpTesting = Seq(
-      "com.typesafe.akka" %% "akka-http-testkit" % AkkaHttpVersion % "test"
-    )
-
-    // often called-in transitively with insecure versions of databind / core
-    val JacksonDatabind = Seq(
-      "com.fasterxml.jackson.core" % "jackson-databind" % JacksonVersion
-    )
-    val JacksonDatatype = Seq(
-      "com.fasterxml.jackson.datatype" % "jackson-datatype-guava" % JacksonVersion,
-      "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % JacksonVersion,
-      // Specifying guava dependency because older transitive dependency has security vulnerability
-      //License: Apache 2.0
-      "com.google.guava" % "guava" % "27.1-jre"
-    )
-
-    val ConsulClient = Seq(
-        //License: Apache 2.0
-        "com.orbitz.consul" % "consul-client" % "1.4.2",
-        //License: Apache 2.0
-        "com.pszymczyk.consul" % "embedded-consul" % "2.1.4" % "test",
-      ) ++ JacksonDatabind ++ JacksonDatatype // consul depends on insecure version of jackson
-
-    val AwsJavaSdkEc2Ecs = Seq(
-        "com.amazonaws" % "aws-java-sdk-ec2" % AwsSdkVersion,
-        "com.amazonaws" % "aws-java-sdk-ecs" % AwsSdkVersion
-      ) ++ JacksonDatabind // aws-java-sdk depends on insecure version of jackson
-
-    val Aws2Ecs = Seq(
-        "software.amazon.awssdk" % "ecs" % "2.13.76"
-      ) ++ JacksonDatabind // aws-java-sdk depends on insecure version of jackson
-
-    val Logging = Seq(
-      "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
-      "ch.qos.logback" % "logback-classic" % "1.2.3"
-    )
-
-    val WireMock = Seq(
-      "com.github.tomakehurst" % "wiremock-jre8" % "2.27.2" % "test" // ApacheV2
-    )
-  }
+  private val JacksonDatatype = Seq(
+    "com.fasterxml.jackson.datatype" % "jackson-datatype-guava" % JacksonVersion,
+    "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % JacksonVersion,
+    // Specifying guava dependency because older transitive dependency has security vulnerability
+    "com.google.guava" % "guava" % "27.1-jre"
+  )
 
   val DiscoveryConsul = Seq(
-    libraryDependencies ++=
-      DependencyGroups.AkkaActor ++
-      DependencyGroups.AkkaDiscovery ++
-      DependencyGroups.AkkaTesting ++
-      DependencyGroups.ConsulClient ++
-      DependencyGroups.Logging.map(_ % "test")
+    libraryDependencies ++= Seq(
+        "com.typesafe.akka" %% "akka-actor" % AkkaVersion,
+        "com.typesafe.akka" %% "akka-discovery" % AkkaVersion,
+        "com.orbitz.consul" % "consul-client" % "1.4.2",
+        "com.pszymczyk.consul" % "embedded-consul" % "2.2.0" % Test,
+        "com.typesafe.akka" %% "akka-testkit" % AkkaVersion % Test,
+        "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion % Test,
+        "ch.qos.logback" % "logback-classic" % "1.2.3" % Test
+      ) ++ ScalaTest ++
+      JacksonDatabind ++ JacksonDatatype // consul depends on insecure version of jackson
   )
 
   val DiscoveryKubernetesApi = Seq(
-    libraryDependencies ++=
-      DependencyGroups.AkkaActor ++
-      DependencyGroups.AkkaDiscovery ++
-      DependencyGroups.AkkaHttp
+    libraryDependencies ++= Seq(
+        "com.typesafe.akka" %% "akka-actor" % AkkaVersion,
+        "com.typesafe.akka" %% "akka-discovery" % AkkaVersion,
+        "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
+        "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
+        "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
+        "io.spray" %% "spray-json" % SprayJsonVersion // ApacheV2
+      ) ++ ScalaTest
   )
 
   val DiscoveryMarathonApi = Seq(
-    libraryDependencies ++=
-      DependencyGroups.AkkaActor ++
-      DependencyGroups.AkkaDiscovery ++
-      DependencyGroups.AkkaHttp
+    libraryDependencies ++= Seq(
+        "com.typesafe.akka" %% "akka-actor" % AkkaVersion,
+        "com.typesafe.akka" %% "akka-discovery" % AkkaVersion,
+        "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
+        "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
+        "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
+        "io.spray" %% "spray-json" % SprayJsonVersion // ApacheV2
+      ) ++ ScalaTest
   )
 
   val DiscoveryAwsApi = Seq(
-    libraryDependencies ++=
-      DependencyGroups.AkkaActor ++
-      DependencyGroups.AkkaDiscovery ++
-      DependencyGroups.AwsJavaSdkEc2Ecs // aws depends on insecure version
+    libraryDependencies ++= Seq(
+        "com.typesafe.akka" %% "akka-actor" % AkkaVersion,
+        "com.typesafe.akka" %% "akka-discovery" % AkkaVersion,
+        "com.amazonaws" % "aws-java-sdk-ec2" % AwsSdkVersion,
+        "com.amazonaws" % "aws-java-sdk-ecs" % AwsSdkVersion
+      ) ++ ScalaTest ++
+      JacksonDatabind // aws-java-sdk depends on insecure version of jackson
   )
 
   val DiscoveryAwsApiAsync = Seq(
-    libraryDependencies ++=
-      DependencyGroups.AkkaActor ++
-      DependencyGroups.AkkaDiscovery ++
-      DependencyGroups.AkkaHttp ++
-      DependencyGroups.Aws2Ecs
+    libraryDependencies ++= Seq(
+        "com.typesafe.akka" %% "akka-actor" % AkkaVersion,
+        "com.typesafe.akka" %% "akka-discovery" % AkkaVersion,
+        "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
+        "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
+        "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
+        "io.spray" %% "spray-json" % SprayJsonVersion,
+        "software.amazon.awssdk" % "ecs" % "2.13.76"
+      ) ++ ScalaTest ++
+      JacksonDatabind // aws-java-sdk depends on insecure version of jackson
   )
 
   val ManagementHttp = Seq(
-    libraryDependencies ++=
-      DependencyGroups.AkkaHttp ++
-      DependencyGroups.AkkaTesting ++
-      DependencyGroups.AkkaHttpTesting ++ Seq(
-        "com.typesafe.akka" %% "akka-cluster" % AkkaVersion % "test"
-      )
+    libraryDependencies ++= Seq(
+        "com.typesafe.akka" %% "akka-actor" % AkkaVersion,
+        "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
+        "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
+        "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
+        "io.spray" %% "spray-json" % SprayJsonVersion,
+        "com.typesafe.akka" %% "akka-testkit" % AkkaVersion % Test,
+        "com.typesafe.akka" %% "akka-cluster" % AkkaVersion % Test,
+        "com.typesafe.akka" %% "akka-http-testkit" % AkkaHttpVersion % Test
+      ) ++ ScalaTest
   )
 
   val LoglevelsLogback = Seq(
-    libraryDependencies ++=
-      DependencyGroups.Logging ++
-      DependencyGroups.AkkaHttp ++
-      DependencyGroups.AkkaTesting ++
-      DependencyGroups.AkkaHttpTesting
+    libraryDependencies ++= Seq(
+        "com.typesafe.akka" %% "akka-actor" % AkkaVersion,
+        "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
+        "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
+        "ch.qos.logback" % "logback-classic" % "1.2.3",
+        "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
+        "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
+        "io.spray" %% "spray-json" % SprayJsonVersion,
+        "com.typesafe.akka" %% "akka-testkit" % AkkaVersion % Test,
+        "com.typesafe.akka" %% "akka-http-testkit" % AkkaHttpVersion % Test
+      ) ++ ScalaTest
   )
 
   val ClusterHttp = Seq(
-    libraryDependencies ++=
-      DependencyGroups.AkkaSharding ++
-      DependencyGroups.AkkaHttpCore ++
-      DependencyGroups.AkkaTesting ++
-      DependencyGroups.AkkaHttpTesting ++ Seq(
-        "com.typesafe.akka" %% "akka-distributed-data" % AkkaVersion % "test"
-      )
+    libraryDependencies ++= Seq(
+        "com.typesafe.akka" %% "akka-cluster" % AkkaVersion,
+        "com.typesafe.akka" %% "akka-cluster-sharding" % AkkaVersion,
+        "com.typesafe.akka" %% "akka-http-core" % AkkaHttpVersion,
+        "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
+        "io.spray" %% "spray-json" % SprayJsonVersion,
+        "com.typesafe.akka" %% "akka-testkit" % AkkaVersion % Test,
+        "org.mockito" % "mockito-all" % "1.10.19" % Test,
+        "com.typesafe.akka" %% "akka-http-testkit" % AkkaHttpVersion % Test,
+        "com.typesafe.akka" %% "akka-distributed-data" % AkkaVersion % Test
+      ) ++ ScalaTest
   )
 
   val ClusterBootstrap = Seq(
-    libraryDependencies ++=
-      DependencyGroups.AkkaCluster ++
-      DependencyGroups.AkkaDiscovery ++
-      DependencyGroups.AkkaHttpCore ++
-      DependencyGroups.AkkaTesting ++
-      DependencyGroups.AkkaHttpTesting ++ Seq(
-        "com.typesafe.akka" %% "akka-distributed-data" % AkkaVersion % "test"
-      )
+    libraryDependencies ++= Seq(
+        "com.typesafe.akka" %% "akka-discovery" % AkkaVersion,
+        "com.typesafe.akka" %% "akka-cluster" % AkkaVersion,
+        "com.typesafe.akka" %% "akka-http-core" % AkkaHttpVersion,
+        "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
+        "io.spray" %% "spray-json" % SprayJsonVersion,
+        "com.typesafe.akka" %% "akka-testkit" % AkkaVersion % Test,
+        "com.typesafe.akka" %% "akka-http-testkit" % AkkaHttpVersion % Test,
+        "com.typesafe.akka" %% "akka-distributed-data" % AkkaVersion % Test
+      ) ++ ScalaTest
   )
 
   val LeaseKubernetes = Seq(
-    libraryDependencies ++=
-      DependencyGroups.AkkaHttp ++
-      DependencyGroups.AkkaCoordination ++
-      DependencyGroups.WireMock ++
-      TestDeps.scalaTest.map(_ % "it,test") ++
-      Seq(
-        TestDeps.akkaTestKit % "it,test"
+    libraryDependencies ++= Seq(
+        "com.typesafe.akka" %% "akka-actor" % AkkaVersion,
+        "com.typesafe.akka" %% "akka-coordination" % AkkaVersion,
+        "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
+        "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
+        "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
+        "io.spray" %% "spray-json" % SprayJsonVersion, // ApacheV2
+        "com.github.tomakehurst" % "wiremock-jre8" % "2.27.2" % Test,
+        "org.scalatest" %% "scalatest" % ScalaTestVersion % "it,test",
+        "org.scalatestplus" %% "junit-4-13" % ScalaTestPlusJUnitVersion % "it,test",
+        "com.typesafe.akka" %% "akka-testkit" % AkkaVersion % "it,test"
       )
   )
 
   val LeaseKubernetesTest = Seq(
-    libraryDependencies ++=
-      TestDeps.scalaTest
+    libraryDependencies ++= Seq(
+        "org.scalatest" %% "scalatest" % ScalaTestVersion,
+        "org.scalatestplus" %% "junit-4-13" % ScalaTestPlusJUnitVersion
+      )
   )
 
   val BootstrapDemos = Seq(
-    libraryDependencies ++= DependencyGroups.Logging ++
-      DependencyGroups.AkkaDiscovery ++
-      DependencyGroups.AkkaTesting
+    libraryDependencies ++= Seq(
+        "com.typesafe.akka" %% "akka-discovery" % AkkaVersion,
+        "com.typesafe.akka" %% "akka-testkit" % AkkaVersion % Test,
+        "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
+        "ch.qos.logback" % "logback-classic" % "1.2.3"
+      ) ++ ScalaTest
   )
 
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,15 +26,8 @@ object Dependencies {
   val ScalaTestVersion = "3.1.4"
   val ScalaTestPlusJUnitVersion = ScalaTestVersion + ".0"
 
-  val SprayJsonVersion = "1.3.5"
-
   val AwsSdkVersion = "1.11.837"
   val JacksonVersion = "2.10.5"
-
-  private val ScalaTest = Seq(
-    "org.scalatest" %% "scalatest" % ScalaTestVersion % Test,
-    "org.scalatestplus" %% "junit-4-13" % ScalaTestPlusJUnitVersion % Test
-  )
 
   // often called-in transitively with insecure versions of databind / core
   private val JacksonDatabind = Seq(
@@ -54,11 +47,11 @@ object Dependencies {
         "com.typesafe.akka" %% "akka-discovery" % AkkaVersion,
         "com.orbitz.consul" % "consul-client" % "1.4.2",
         "com.pszymczyk.consul" % "embedded-consul" % "2.2.0" % Test,
+        "org.scalatest" %% "scalatest" % ScalaTestVersion % Test,
         "com.typesafe.akka" %% "akka-testkit" % AkkaVersion % Test,
         "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion % Test,
         "ch.qos.logback" % "logback-classic" % "1.2.3" % Test
-      ) ++ ScalaTest ++
-      JacksonDatabind ++ JacksonDatatype // consul depends on insecure version of jackson
+      ) ++ JacksonDatabind ++ JacksonDatatype // consul depends on insecure version of jackson
   )
 
   val DiscoveryKubernetesApi = Seq(
@@ -68,8 +61,8 @@ object Dependencies {
         "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
         "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
         "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
-        "io.spray" %% "spray-json" % SprayJsonVersion // ApacheV2
-      ) ++ ScalaTest
+        "org.scalatest" %% "scalatest" % ScalaTestVersion % Test
+      )
   )
 
   val DiscoveryMarathonApi = Seq(
@@ -79,8 +72,8 @@ object Dependencies {
         "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
         "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
         "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
-        "io.spray" %% "spray-json" % SprayJsonVersion // ApacheV2
-      ) ++ ScalaTest
+        "org.scalatest" %% "scalatest" % ScalaTestVersion % Test
+      )
   )
 
   val DiscoveryAwsApi = Seq(
@@ -88,9 +81,9 @@ object Dependencies {
         "com.typesafe.akka" %% "akka-actor" % AkkaVersion,
         "com.typesafe.akka" %% "akka-discovery" % AkkaVersion,
         "com.amazonaws" % "aws-java-sdk-ec2" % AwsSdkVersion,
-        "com.amazonaws" % "aws-java-sdk-ecs" % AwsSdkVersion
-      ) ++ ScalaTest ++
-      JacksonDatabind // aws-java-sdk depends on insecure version of jackson
+        "com.amazonaws" % "aws-java-sdk-ecs" % AwsSdkVersion,
+        "org.scalatest" %% "scalatest" % ScalaTestVersion % Test
+      ) ++ JacksonDatabind // aws-java-sdk depends on insecure version of jackson
   )
 
   val DiscoveryAwsApiAsync = Seq(
@@ -100,10 +93,9 @@ object Dependencies {
         "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
         "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
         "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
-        "io.spray" %% "spray-json" % SprayJsonVersion,
-        "software.amazon.awssdk" % "ecs" % "2.13.76"
-      ) ++ ScalaTest ++
-      JacksonDatabind // aws-java-sdk depends on insecure version of jackson
+        "software.amazon.awssdk" % "ecs" % "2.13.76",
+        "org.scalatest" %% "scalatest" % ScalaTestVersion % Test
+      ) ++ JacksonDatabind // aws-java-sdk depends on insecure version of jackson
   )
 
   val ManagementHttp = Seq(
@@ -112,11 +104,12 @@ object Dependencies {
         "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
         "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
         "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
-        "io.spray" %% "spray-json" % SprayJsonVersion,
         "com.typesafe.akka" %% "akka-testkit" % AkkaVersion % Test,
         "com.typesafe.akka" %% "akka-cluster" % AkkaVersion % Test,
-        "com.typesafe.akka" %% "akka-http-testkit" % AkkaHttpVersion % Test
-      ) ++ ScalaTest
+        "com.typesafe.akka" %% "akka-http-testkit" % AkkaHttpVersion % Test,
+        "org.scalatest" %% "scalatest" % ScalaTestVersion % Test,
+        "org.scalatestplus" %% "junit-4-13" % ScalaTestPlusJUnitVersion % Test
+      )
   )
 
   val LoglevelsLogback = Seq(
@@ -127,10 +120,10 @@ object Dependencies {
         "ch.qos.logback" % "logback-classic" % "1.2.3",
         "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
         "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
-        "io.spray" %% "spray-json" % SprayJsonVersion,
+        "org.scalatest" %% "scalatest" % ScalaTestVersion % Test,
         "com.typesafe.akka" %% "akka-testkit" % AkkaVersion % Test,
         "com.typesafe.akka" %% "akka-http-testkit" % AkkaHttpVersion % Test
-      ) ++ ScalaTest
+      )
   )
 
   val ClusterHttp = Seq(
@@ -139,12 +132,13 @@ object Dependencies {
         "com.typesafe.akka" %% "akka-cluster-sharding" % AkkaVersion,
         "com.typesafe.akka" %% "akka-http-core" % AkkaHttpVersion,
         "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
-        "io.spray" %% "spray-json" % SprayJsonVersion,
         "com.typesafe.akka" %% "akka-testkit" % AkkaVersion % Test,
         "org.mockito" % "mockito-all" % "1.10.19" % Test,
         "com.typesafe.akka" %% "akka-http-testkit" % AkkaHttpVersion % Test,
-        "com.typesafe.akka" %% "akka-distributed-data" % AkkaVersion % Test
-      ) ++ ScalaTest
+        "com.typesafe.akka" %% "akka-distributed-data" % AkkaVersion % Test,
+        "org.scalatest" %% "scalatest" % ScalaTestVersion % Test,
+        "org.scalatestplus" %% "junit-4-13" % ScalaTestPlusJUnitVersion % Test
+      )
   )
 
   val ClusterBootstrap = Seq(
@@ -153,11 +147,12 @@ object Dependencies {
         "com.typesafe.akka" %% "akka-cluster" % AkkaVersion,
         "com.typesafe.akka" %% "akka-http-core" % AkkaHttpVersion,
         "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
-        "io.spray" %% "spray-json" % SprayJsonVersion,
         "com.typesafe.akka" %% "akka-testkit" % AkkaVersion % Test,
         "com.typesafe.akka" %% "akka-http-testkit" % AkkaHttpVersion % Test,
-        "com.typesafe.akka" %% "akka-distributed-data" % AkkaVersion % Test
-      ) ++ ScalaTest
+        "com.typesafe.akka" %% "akka-distributed-data" % AkkaVersion % Test,
+        "org.scalatest" %% "scalatest" % ScalaTestVersion % Test,
+        "org.scalatestplus" %% "junit-4-13" % ScalaTestPlusJUnitVersion % Test
+      )
   )
 
   val LeaseKubernetes = Seq(
@@ -167,7 +162,6 @@ object Dependencies {
         "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
         "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
         "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
-        "io.spray" %% "spray-json" % SprayJsonVersion, // ApacheV2
         "com.github.tomakehurst" % "wiremock-jre8" % "2.27.2" % Test,
         "org.scalatest" %% "scalatest" % ScalaTestVersion % "it,test",
         "org.scalatestplus" %% "junit-4-13" % ScalaTestPlusJUnitVersion % "it,test",
@@ -177,8 +171,7 @@ object Dependencies {
 
   val LeaseKubernetesTest = Seq(
     libraryDependencies ++= Seq(
-        "org.scalatest" %% "scalatest" % ScalaTestVersion,
-        "org.scalatestplus" %% "junit-4-13" % ScalaTestPlusJUnitVersion
+        "org.scalatest" %% "scalatest" % ScalaTestVersion
       )
   )
 
@@ -187,8 +180,9 @@ object Dependencies {
         "com.typesafe.akka" %% "akka-discovery" % AkkaVersion,
         "com.typesafe.akka" %% "akka-testkit" % AkkaVersion % Test,
         "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
-        "ch.qos.logback" % "logback-classic" % "1.2.3"
-      ) ++ ScalaTest
+        "ch.qos.logback" % "logback-classic" % "1.2.3",
+        "org.scalatest" %% "scalatest" % ScalaTestVersion % Test
+      )
   )
 
 }


### PR DESCRIPTION
Maybe it is just me but the structure in `Dependencies` encrypts what dependencies are actually used/available/exported in each module.

This makes the dependencies explicit by less indirection.