### PR TITLE
Allow sbt to run in parallel (but not in tests)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,6 @@ lazy val `akka-management-root` = project
     docs
   )
   .settings(
-    parallelExecution in GlobalScope := false,
     publish / skip := true
   )
 

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -76,6 +76,7 @@ object Common extends AutoPlugin {
             )
         }),
       autoAPIMappings := true,
+      Test / parallelExecution := false,
       // show full stack traces and test case durations
       testOptions in Test += Tests.Argument("-oDF"),
       // -v Log "test run started" / "test started" / "test run finished" events on log level "info" instead of "debug".


### PR DESCRIPTION
[`32de629` (#205)](https://github.com/akka/akka-management/pull/205/commits/32de6296bb5858f8a59f4937bfd3de767422a76a) switched off all parallel execution in sbt.

With this only tests run sequentially.