### PR TITLE
correction of Scala version in dependencies

### DIFF
--- a/docs/src/main/paradox/discovery/aws.md
+++ b/docs/src/main/paradox/discovery/aws.md
@@ -55,7 +55,7 @@ This is a separate JAR file:
   symbol1=AkkaManagementVersion
   value1=$project.version$
   group="com.lightbend.akka.discovery"
-  artifact="akka-discovery-aws-api_2.12"
+  artifact="akka-discovery-aws-api_$scala.binary.version$"
   version=AkkaManagementVersion
 }
 
@@ -169,7 +169,7 @@ preview SDK. The disadvantage is that the mainstream SDK does blocking IO.
   symbol1=AkkaManagementVersion
   value1=$project.version$
   group="com.lightbend.akka.discovery"
-  artifact="akka-discovery-aws-api_2.12"
+  artifact="akka-discovery-aws-api_$scala.binary.version$"
   version=AkkaManagementVersion
 }
 
@@ -201,7 +201,7 @@ Once the async AWS SDK is out of preview it is likely that the
   symbol1=AkkaManagementVersion
   value1=$project.version$
   group="com.lightbend.akka.discovery"
-  artifact="akka-discovery-aws-api-async_2.12"
+  artifact="akka-discovery-aws-api-async_$scala.binary.version$"
   version=AkkaManagementVersion
 }
 

--- a/docs/src/main/paradox/discovery/consul.md
+++ b/docs/src/main/paradox/discovery/consul.md
@@ -20,7 +20,7 @@ If you are using Consul to do the service discovery this would allow you to base
   symbol1=AkkaManagementVersion
   value1=$project.version$
   group="com.lightbend.akka.discovery"
-  artifact="akka-discovery-consul_2.12"
+  artifact="akka-discovery-consul_$scala.binary.version$"
   version=AkkaManagementVersion
 }
 

--- a/docs/src/main/paradox/discovery/kubernetes.md
+++ b/docs/src/main/paradox/discovery/kubernetes.md
@@ -16,7 +16,7 @@ First, add the dependency on the component:
   symbol1=AkkaManagementVersion
   value1=$project.version$
   group="com.lightbend.akka.discovery"
-  artifact="akka-discovery-kubernetes-api_2.12"
+  artifact="akka-discovery-kubernetes-api_$scala.binary.version$"
   version=AkkaManagementVersion
 }
 

--- a/docs/src/main/paradox/discovery/marathon.md
+++ b/docs/src/main/paradox/discovery/marathon.md
@@ -29,7 +29,7 @@ This is a separate JAR file:
   symbol1=AkkaManagementVersion
   value1=$project.version$
   group="com.lightbend.akka.discovery"
-  artifact="akka-discovery-marathon-api_2.12"
+  artifact="akka-discovery-marathon-api_$scala.binary.version$"
   version=AkkaManagementVersion
 }
 

--- a/docs/src/main/paradox/kubernetes-deployment/forming-a-cluster.md
+++ b/docs/src/main/paradox/kubernetes-deployment/forming-a-cluster.md
@@ -34,7 +34,7 @@ Add the following dependencies to your application:
   artifact2=akka-management-cluster-bootstrap_$scala.binary.version$
   version2=AkkaManagementVersion
   group3="com.lightbend.akka.discovery"
-  artifact3="akka-discovery-kubernetes-api_2.12"
+  artifact3="akka-discovery-kubernetes-api_$scala.binary.version$"
   version3=AkkaManagementVersion
 }
 


### PR DESCRIPTION
Was not correct for Maven and Gradle in some places, such as https://doc.akka.io/docs/akka-management/current/kubernetes-deployment/forming-a-cluster.html#bootstrap-and-management-dependencies