### PR TITLE
Avoid touching filesystem in test 

### DIFF
--- a/lease-kubernetes/src/main/resources/reference.conf
+++ b/lease-kubernetes/src/main/resources/reference.conf
@@ -35,7 +35,7 @@ akka.coordination.lease.kubernetes {
     # having been updated
     heartbeat-timeout = 120s
 
-    # The individual timeout for each HTTP request. Defaults to 2/5 of the lease-operation-timoeut
+    # The individual timeout for each HTTP request. Defaults to 2/5 of the lease-operation-timeout
     # Can't be greater than then lease-operation-timeout
     api-server-request-timeout = ""
 

--- a/lease-kubernetes/src/main/scala/akka/coordination/lease/kubernetes/internal/KubernetesApiImpl.scala
+++ b/lease-kubernetes/src/main/scala/akka/coordination/lease/kubernetes/internal/KubernetesApiImpl.scala
@@ -239,10 +239,10 @@ PUTs must contain resourceVersions. Response:
 
   private def makeRequest(request: HttpRequest, timeoutMsg: String): Future[HttpResponse] = {
     val response =
-      (if (settings.secure)
+      if (settings.secure)
         http.singleRequest(request, httpsContext)
       else
-        http.singleRequest(request))
+        http.singleRequest(request)
 
     // make sure we always consume response body (in case of timeout)
     val strictResponse = response.flatMap(_.toStrict(settings.bodyReadTimeout))

--- a/lease-kubernetes/src/main/scala/akka/coordination/lease/kubernetes/internal/KubernetesApiImpl.scala
+++ b/lease-kubernetes/src/main/scala/akka/coordination/lease/kubernetes/internal/KubernetesApiImpl.scala
@@ -238,16 +238,19 @@ PUTs must contain resourceVersions. Response:
   }
 
   private def makeRequest(request: HttpRequest, timeoutMsg: String): Future[HttpResponse] = {
-    val httpRequest =
-      if (settings.secure)
+    val response =
+      (if (settings.secure)
         http.singleRequest(request, httpsContext)
       else
-        http.singleRequest(request)
+        http.singleRequest(request))
+
+    // make sure we always consume response body (in case of timeout)
+    val strictResponse = response.flatMap(_.toStrict(settings.bodyReadTimeout))
 
     val timeout = after(settings.apiServerRequestTimeout, using = system.scheduler)(
       Future.failed(new LeaseTimeoutException(s"$timeoutMsg. Is the API server up?")))
 
-    Future.firstCompletedOf(Seq(httpRequest, timeout))
+    Future.firstCompletedOf(Seq(strictResponse, timeout))
   }
 
   private def toLeaseResource(lcr: LeaseCustomResource) = {
@@ -297,7 +300,7 @@ PUTs must contain resourceVersions. Response:
   /**
    * This uses blocking IO, and so should only be used to read configuration at startup.
    */
-  private def readConfigVarFromFilesystem(path: String, name: String): Option[String] = {
+  protected def readConfigVarFromFilesystem(path: String, name: String): Option[String] = {
     val file = Paths.get(path)
     if (Files.exists(file)) {
       try {

--- a/lease-kubernetes/src/test/scala/akka/coordination/lease/kubernetes/KubernetesApiSpec.scala
+++ b/lease-kubernetes/src/test/scala/akka/coordination/lease/kubernetes/KubernetesApiSpec.scala
@@ -14,7 +14,7 @@ import com.github.tomakehurst.wiremock.client.WireMock
 import org.scalatest.concurrent.ScalaFutures
 import com.github.tomakehurst.wiremock.client.WireMock._
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
-import org.scalatest.{ BeforeAndAfterAll, BeforeAndAfterEach }
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 
 import scala.concurrent.duration._
 import org.scalatest.matchers.should.Matchers
@@ -44,7 +44,10 @@ class KubernetesApiSpec
 
   implicit val patience: PatienceConfig = PatienceConfig(testKitSettings.DefaultTimeout.duration)
 
-  val underTest = new KubernetesApiImpl(system, settings)
+  val underTest = new KubernetesApiImpl(system, settings) {
+    // avoid touching slow CI filesystem
+    override protected def readConfigVarFromFilesystem(path: String, name: String): Option[String] = None
+  }
   val leaseName = "lease-1"
   val client1 = "client-1"
   val client2 = "client-2"

--- a/lease-kubernetes/src/test/scala/akka/coordination/lease/kubernetes/KubernetesApiSpec.scala
+++ b/lease-kubernetes/src/test/scala/akka/coordination/lease/kubernetes/KubernetesApiSpec.scala
@@ -14,7 +14,7 @@ import com.github.tomakehurst.wiremock.client.WireMock
 import org.scalatest.concurrent.ScalaFutures
 import com.github.tomakehurst.wiremock.client.WireMock._
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
-import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
+import org.scalatest.{ BeforeAndAfterAll, BeforeAndAfterEach }
 
 import scala.concurrent.duration._
 import org.scalatest.matchers.should.Matchers


### PR DESCRIPTION
Refs #768

Lazy init of stuff in KubernetesApiImpl depending on a fs read is probably the reason the first test fails.

Additionally made sure response entity is consumed on timeout.
