### PR TITLE
The beta version will be removed in Kubernetes 1.22

### DIFF
--- a/docs/src/main/paradox/kubernetes-lease.md
+++ b/docs/src/main/paradox/kubernetes-lease.md
@@ -52,30 +52,9 @@ Kubernetes:
 kubectl apply -f lease.yml
 ```
 
-OpenShift
-
-```
-oc apply -f lease.yml
-```
-
 Where lease.yml contains:
 
-```yaml
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: leases.akka.io
-spec:
-  group: akka.io
-  version: v1
-  scope: Namespaced
-  names:
-    plural: leases
-    singular: lease
-    kind: Lease
-    shortNames:
-    - le
-```
+@@snip[lease.yaml](/lease-kubernetes/lease.yml)
 
 #### Role based access control
 
@@ -121,12 +100,6 @@ Kubernetes:
 kubelctl create -f sbr-lease.yml -n <YOUR_NAMESPACE>
 ```
 
-OpenShift (from your project):
-
-```
-oc create -f sbr-lease.yml
-```
-
 Where `sbr-lease.yml` contains:
 
 ```yml
@@ -138,6 +111,12 @@ spec:
   owner: ""
   time: 0
 
+```
+
+To get the current leases the fully qualified name must be uses as Kubernetes has since added a Lease type.
+
+```
+kubectl get leases.akka.io
 ```
 
 #### Enable in SBR

--- a/lease-kubernetes/lease.yml
+++ b/lease-kubernetes/lease.yml
@@ -1,11 +1,27 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>
   name: leases.akka.io
 spec:
   group: akka.io
-  version: v1
+  versions:
+   - name: v1
+     storage: true
+     served: true
+     schema:
+       openAPIV3Schema:
+         type: object
+         properties:
+           spec:
+             type: object
+             properties:
+               owner:
+                 type: string
+               version:
+                 type: string
+               time:
+                 type: integer
   scope: Namespaced
   names:
     # plural name to be used in the URL: /apis/<group>/<version>/<plural>


### PR DESCRIPTION
* Added a schema
* Tested that leases created with the old CRD work as expected
* Documented touse the fully qualified name as k8s now has its own Lease type