### PR TITLE
cluster-http: Add a route for observing cluster events

### DIFF
--- a/cluster-http/src/main/scala/akka/management/cluster/ClusterDomainEventServerSentEventEncoder.scala
+++ b/cluster-http/src/main/scala/akka/management/cluster/ClusterDomainEventServerSentEventEncoder.scala
@@ -61,12 +61,12 @@ object ClusterDomainEventServerSentEventEncoder extends SprayJsonSupport with De
         roleLeaderChanged.leader match {
           case Some(address) =>
             sse(
-              "LeaderChanged",
+              "RoleLeaderChanged",
               JsObject("role" -> JsString(roleLeaderChanged.role), "address" -> encode(address))
             )
 
           case None =>
-            sse("LeaderChanged", JsObject("role" -> JsString(roleLeaderChanged.role)))
+            sse("RoleLeaderChanged", JsObject("role" -> JsString(roleLeaderChanged.role)))
         }
 
       case ClusterEvent.ClusterShuttingDown =>

--- a/cluster-http/src/main/scala/akka/management/cluster/ClusterDomainEventServerSentEventEncoder.scala
+++ b/cluster-http/src/main/scala/akka/management/cluster/ClusterDomainEventServerSentEventEncoder.scala
@@ -46,6 +46,9 @@ object ClusterDomainEventServerSentEventEncoder extends SprayJsonSupport with De
 
           case ClusterEvent.MemberRemoved(member, previousStatus) =>
             sse("MemberRemoved", JsObject("member" -> encode(member), "previousStatus" -> encode(previousStatus)))
+
+          case _ =>
+            None
         }
 
       case leaderChanged: ClusterEvent.LeaderChanged =>
@@ -90,8 +93,8 @@ object ClusterDomainEventServerSentEventEncoder extends SprayJsonSupport with De
         }
 
       case _ =>
-        // @TODO these are either internal, or added but forgot to update this module
-        // @TODO how should we handle them? maybe leave this as FIXME for now?
+        // these are either internal events we don't want to expose, or new events
+        // that this code is unaware of. either way, let's ignore them
 
         None
     }
@@ -113,6 +116,7 @@ object ClusterDomainEventServerSentEventEncoder extends SprayJsonSupport with De
       case MemberStatus.Exiting  => "Exiting"
       case MemberStatus.Down     => "Down"
       case MemberStatus.Removed  => "Removed"
+      case other                 => other.toString
     }
   )
 

--- a/cluster-http/src/main/scala/akka/management/cluster/ClusterDomainEventServerSentEventEncoder.scala
+++ b/cluster-http/src/main/scala/akka/management/cluster/ClusterDomainEventServerSentEventEncoder.scala
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2017-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.management.cluster
+
+import akka.actor.Address
+import akka.cluster.{ ClusterEvent, Member, MemberStatus, UniqueAddress }
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import akka.http.scaladsl.model.sse.ServerSentEvent
+import spray.json.{ DefaultJsonProtocol, JsArray, JsNumber, JsObject, JsString, JsValue }
+
+/**
+ * Encodes a supplied [[ClusterEvent.ClusterDomainEvent]] into a [[ServerSentEvent]].
+ */
+object ClusterDomainEventServerSentEventEncoder extends SprayJsonSupport with DefaultJsonProtocol {
+  def encode(event: ClusterEvent.ClusterDomainEvent): Option[ServerSentEvent] = {
+    def sse(eventType: String, value: JsObject): Some[ServerSentEvent] =
+      Some(
+        ServerSentEvent(
+          data = value.copy(fields = value.fields.updated("type", JsString(eventType))).compactPrint,
+          eventType = Some(eventType)
+        )
+      )
+
+    event match {
+      case memberEvent: ClusterEvent.MemberEvent =>
+        memberEvent match {
+          case ClusterEvent.MemberJoined(member) =>
+            sse("MemberJoined", JsObject("member" -> encode(member)))
+
+          case ClusterEvent.MemberWeaklyUp(member) =>
+            sse("MemberWeaklyUp", JsObject("member" -> encode(member)))
+
+          case ClusterEvent.MemberUp(member) =>
+            sse("MemberUp", JsObject("member" -> encode(member)))
+
+          case ClusterEvent.MemberLeft(member) =>
+            sse("MemberLeft", JsObject("member" -> encode(member)))
+
+          case ClusterEvent.MemberExited(member) =>
+            sse("MemberExited", JsObject("member" -> encode(member)))
+
+          case ClusterEvent.MemberDowned(member) =>
+            sse("MemberDowned", JsObject("member" -> encode(member)))
+
+          case ClusterEvent.MemberRemoved(member, previousStatus) =>
+            sse("MemberRemoved", JsObject("member" -> encode(member), "previousStatus" -> encode(previousStatus)))
+        }
+
+      case leaderChanged: ClusterEvent.LeaderChanged =>
+        leaderChanged.leader match {
+          case Some(address) =>
+            sse("LeaderChanged", JsObject("address" -> encode(address)))
+
+          case None =>
+            sse("LeaderChanged", JsObject.empty)
+        }
+
+      case roleLeaderChanged: ClusterEvent.RoleLeaderChanged =>
+        roleLeaderChanged.leader match {
+          case Some(address) =>
+            sse(
+              "LeaderChanged",
+              JsObject("role" -> JsString(roleLeaderChanged.role), "address" -> encode(address))
+            )
+
+          case None =>
+            sse("LeaderChanged", JsObject("role" -> JsString(roleLeaderChanged.role)))
+        }
+
+      case ClusterEvent.ClusterShuttingDown =>
+        sse("ClusterShuttingDown", JsObject.empty)
+
+      case reachabilityEvent: ClusterEvent.ReachabilityEvent =>
+        reachabilityEvent match {
+          case ClusterEvent.UnreachableMember(member) =>
+            sse("UnreachableMember", JsObject("member" -> encode(member)))
+
+          case ClusterEvent.ReachableMember(member) =>
+            sse("ReachableMember", JsObject("member" -> encode(member)))
+        }
+
+      case dataCenterReachabilityEvent: ClusterEvent.DataCenterReachabilityEvent =>
+        dataCenterReachabilityEvent match {
+          case ClusterEvent.UnreachableDataCenter(dataCenter) =>
+            sse("UnreachableDataCenter", JsObject("dataCenter" -> JsString(dataCenter)))
+          case ClusterEvent.ReachableDataCenter(dataCenter) =>
+            sse("ReachableDataCenter", JsObject("dataCenter" -> JsString(dataCenter)))
+        }
+
+      case _ =>
+        // @TODO these are either internal, or added but forgot to update this module
+        // @TODO how should we handle them? maybe leave this as FIXME for now?
+
+        None
+    }
+  }
+
+  private def encode(address: Address): JsValue = JsString(address.toString)
+
+  private def encode(address: UniqueAddress): JsValue = JsObject(
+    "address" -> encode(address.address),
+    "longUid" -> JsNumber(address.longUid)
+  )
+
+  private def encode(memberStatus: MemberStatus): JsValue = JsString(
+    memberStatus match {
+      case MemberStatus.Joining  => "Joining"
+      case MemberStatus.WeaklyUp => "WeaklyUp"
+      case MemberStatus.Up       => "Up"
+      case MemberStatus.Leaving  => "Leaving"
+      case MemberStatus.Exiting  => "Exiting"
+      case MemberStatus.Down     => "Down"
+      case MemberStatus.Removed  => "Removed"
+    }
+  )
+
+  private def encode(member: Member): JsValue = JsObject(
+    "uniqueAddress" -> encode(member.uniqueAddress),
+    "status" -> encode(member.status),
+    "roles" -> JsArray(member.roles.toVector.map(JsString.apply)),
+    "dataCenter" -> JsString(member.dataCenter)
+  )
+}

--- a/cluster-http/src/test/scala/akka/management/cluster/ClusterDomainEventServerSentEventEncoderSpec.scala
+++ b/cluster-http/src/test/scala/akka/management/cluster/ClusterDomainEventServerSentEventEncoderSpec.scala
@@ -1,0 +1,161 @@
+/*
+ * Copyright (C) 2017-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+import akka.actor.Address
+import akka.cluster.MemberStatus
+import akka.cluster.{ ClusterEvent, Member, UniqueAddress }
+import akka.http.scaladsl.model.sse.ServerSentEvent
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+package akka.cluster.management {
+  // `Member`'s constructor is private[cluster], hence this
+  object TestHelpers {
+    def newMember(uniqueAddress: UniqueAddress, upNumber: Int, status: MemberStatus, roles: Set[String]): Member =
+      new Member(uniqueAddress, upNumber, status, roles)
+  }
+}
+
+package akka.management.cluster {
+
+  class ClusterDomainEventServerSentEventEncoderSpec extends AnyWordSpec with Matchers {
+    import akka.cluster.management.TestHelpers._
+
+    "Encoder" must {
+      "work" in {
+        val dc = "dc-one"
+        val address1 = Address("akka", "Main", "hostname.com", 3311)
+        val uniqueAddress1 = UniqueAddress(address1, 1L)
+
+        ClusterDomainEventServerSentEventEncoder.encode(
+          ClusterEvent.MemberJoined(newMember(uniqueAddress1, 1, MemberStatus.Joining, Set("one", "two", dc)))
+        ) shouldEqual Some(
+          ServerSentEvent(
+            """{"member":{"dataCenter":"one","roles":["one","two","dc-one"],"status":"Joining","uniqueAddress":{"address":"akka://Main@hostname.com:3311","longUid":1}},"type":"MemberJoined"}""",
+            "MemberJoined"
+          )
+        )
+
+        ClusterDomainEventServerSentEventEncoder.encode(
+          ClusterEvent.MemberWeaklyUp(newMember(uniqueAddress1, 1, MemberStatus.WeaklyUp, Set("one", "two", dc)))
+        ) shouldEqual Some(
+          ServerSentEvent(
+            """{"member":{"dataCenter":"one","roles":["one","two","dc-one"],"status":"WeaklyUp","uniqueAddress":{"address":"akka://Main@hostname.com:3311","longUid":1}},"type":"MemberWeaklyUp"}""",
+            "MemberWeaklyUp"
+          )
+        )
+
+        ClusterDomainEventServerSentEventEncoder.encode(
+          ClusterEvent.MemberUp(newMember(uniqueAddress1, 1, MemberStatus.Up, Set("one", "two", dc)))
+        ) shouldEqual Some(
+          ServerSentEvent(
+            """{"member":{"dataCenter":"one","roles":["one","two","dc-one"],"status":"Up","uniqueAddress":{"address":"akka://Main@hostname.com:3311","longUid":1}},"type":"MemberUp"}""",
+            "MemberUp"
+          )
+        )
+
+        ClusterDomainEventServerSentEventEncoder.encode(
+          ClusterEvent.MemberLeft(newMember(uniqueAddress1, 1, MemberStatus.Leaving, Set("one", "two", dc)))
+        ) shouldEqual Some(
+          ServerSentEvent(
+            """{"member":{"dataCenter":"one","roles":["one","two","dc-one"],"status":"Leaving","uniqueAddress":{"address":"akka://Main@hostname.com:3311","longUid":1}},"type":"MemberLeft"}""",
+            "MemberLeft"
+          )
+        )
+
+        ClusterDomainEventServerSentEventEncoder.encode(
+          ClusterEvent.MemberExited(newMember(uniqueAddress1, 1, MemberStatus.Exiting, Set("one", "two", dc)))
+        ) shouldEqual Some(
+          ServerSentEvent(
+            """{"member":{"dataCenter":"one","roles":["one","two","dc-one"],"status":"Exiting","uniqueAddress":{"address":"akka://Main@hostname.com:3311","longUid":1}},"type":"MemberExited"}""",
+            "MemberExited"
+          )
+        )
+
+        ClusterDomainEventServerSentEventEncoder.encode(
+          ClusterEvent.MemberDowned(newMember(uniqueAddress1, 1, MemberStatus.Down, Set("one", "two", dc)))
+        ) shouldEqual Some(
+          ServerSentEvent(
+            """{"member":{"dataCenter":"one","roles":["one","two","dc-one"],"status":"Down","uniqueAddress":{"address":"akka://Main@hostname.com:3311","longUid":1}},"type":"MemberDowned"}""",
+            "MemberDowned"
+          )
+        )
+
+        ClusterDomainEventServerSentEventEncoder.encode(
+          ClusterEvent
+            .MemberRemoved(newMember(uniqueAddress1, 1, MemberStatus.Removed, Set("one", "two", dc)), MemberStatus.Down)
+        ) shouldEqual Some(
+          ServerSentEvent(
+            """{"member":{"dataCenter":"one","roles":["one","two","dc-one"],"status":"Removed","uniqueAddress":{"address":"akka://Main@hostname.com:3311","longUid":1}},"previousStatus":"Down","type":"MemberRemoved"}""",
+            "MemberRemoved"
+          )
+        )
+
+        ClusterDomainEventServerSentEventEncoder.encode(
+          ClusterEvent.LeaderChanged(Some(address1))
+        ) shouldEqual Some(
+          ServerSentEvent(
+            """{"address":"akka://Main@hostname.com:3311","type":"LeaderChanged"}""",
+            "LeaderChanged"
+          )
+        )
+
+        ClusterDomainEventServerSentEventEncoder.encode(
+          ClusterEvent.RoleLeaderChanged("test-role", Some(address1))
+        ) shouldEqual Some(
+          ServerSentEvent(
+            """{"address":"akka://Main@hostname.com:3311","role":"test-role","type":"RoleLeaderChanged"}""",
+            "RoleLeaderChanged"
+          )
+        )
+
+        ClusterDomainEventServerSentEventEncoder.encode(
+          ClusterEvent.ClusterShuttingDown
+        ) shouldEqual Some(
+          ServerSentEvent(
+            """{"type":"ClusterShuttingDown"}""",
+            "ClusterShuttingDown"
+          )
+        )
+
+        ClusterDomainEventServerSentEventEncoder.encode(
+          ClusterEvent.UnreachableMember(newMember(uniqueAddress1, 1, MemberStatus.Up, Set("one", "two", dc)))
+        ) shouldEqual Some(
+          ServerSentEvent(
+            """{"member":{"dataCenter":"one","roles":["one","two","dc-one"],"status":"Up","uniqueAddress":{"address":"akka://Main@hostname.com:3311","longUid":1}},"type":"UnreachableMember"}""",
+            "UnreachableMember"
+          )
+        )
+
+        ClusterDomainEventServerSentEventEncoder.encode(
+          ClusterEvent.ReachableMember(newMember(uniqueAddress1, 1, MemberStatus.Up, Set("one", "two", dc)))
+        ) shouldEqual Some(
+          ServerSentEvent(
+            """{"member":{"dataCenter":"one","roles":["one","two","dc-one"],"status":"Up","uniqueAddress":{"address":"akka://Main@hostname.com:3311","longUid":1}},"type":"ReachableMember"}""",
+            "ReachableMember"
+          )
+        )
+
+        ClusterDomainEventServerSentEventEncoder.encode(
+          ClusterEvent.UnreachableDataCenter(dc)
+        ) shouldEqual Some(
+          ServerSentEvent(
+            """{"dataCenter":"dc-one","type":"UnreachableDataCenter"}""",
+            "UnreachableDataCenter"
+          )
+        )
+
+        ClusterDomainEventServerSentEventEncoder.encode(
+          ClusterEvent.ReachableDataCenter(dc)
+        ) shouldEqual Some(
+          ServerSentEvent(
+            """{"dataCenter":"dc-one","type":"ReachableDataCenter"}""",
+            "ReachableDataCenter"
+          )
+        )
+      }
+    }
+
+  }
+}

--- a/docs/src/main/paradox/cluster-http-management.md
+++ b/docs/src/main/paradox/cluster-http-management.md
@@ -60,6 +60,7 @@ are only enabled if `akka.management.http.route-providers-read-only` is set to `
 
 | Path                         | HTTP method | Required form fields | Description
 | ---------------------------- | ----------- | -------------------- | -----------
+| `/cluster/domain-events`     | GET         | None                 | Returns cluster domain events as they occur, in JSON-encoded SSE format.
 | `/cluster/members/`          | GET         | None                 | Returns the status of the Cluster in JSON format.
 | `/cluster/members/`          | POST        | address: `{address}` | Executes join operation in cluster for the provided `{address}`.
 | `/cluster/members/{address}` | GET         | None                 | Returns the status of `{address}` in the Cluster in JSON format.
@@ -71,6 +72,59 @@ are only enabled if `akka.management.http.route-providers-read-only` is set to `
 The expected format of `address` follows the Cluster URI convention. Example: `akka://Main@myhostname.com:3311`
 
 In the paths `address` is also allowed to be provided without the protocol prefix. Example: `Main@myhostname.com:3311`
+
+### Get /cluster/domain-events request query parameters
+
+| Query Parameter | Description
+| --------------- | -----------
+| type            | Optional. Specify event type(s) to include in response (see table). If not specified, all event types are included.
+
+| Event Type                  | Description
+| --------------------------- | -----------
+| ClusterDomainEvent          | cluster domain event (parent)
+| MemberEvent                 | membership event (parent)
+| MemberJoined                | membership event - joined
+| MemberWeaklyUp              | membership event - transitioned to WeaklyUp
+| MemberUp                    | membership event - transitioned to Up
+| MemberLeft                  | membership event - left
+| MemberExited                | membership event - exited
+| MemberDowned                | membership event - downed
+| MemberRemoved               | membership event - removed
+| LeaderChanged               | cluster's leader has changed
+| RoleLeaderChanged           | cluster's role leader has changed
+| ClusterShuttingDown         | cluster is shutting down
+| ReachabilityEvent           | reachability event (parent)
+| UnreachableMember           | reachability event - member now unreachable
+| ReachableMember             | reachability event - member now reachable
+| DataCenterReachabilityEvent | DC reachability event (parent)
+| UnreachableDataCenter       | DC reachability event - DC now unreachable
+| ReachableDataCenter         | DC reachability event - DC now reachable
+
+Example request:
+
+    GET /cluster/domain-events?type=MemberUp&type=LeaderChanged HTTP/1.1
+    Host: 192.168.1.23:8558
+
+Example response:
+
+    HTTP/1.1 200 OK
+    Server: akka-http/10.2.2
+    Date: Mon, 11 Jan 2021 21:02:37 GMT
+    Transfer-Encoding: chunked
+    Content-Type: text/event-stream
+
+    data:{"member":{"dataCenter":"default","roles":["dc-default"],"status":"Up","uniqueAddress":{"address":"akka://default@127.0.0.1:2551","longUid":-2440990093160003086}},"type":"MemberUp"}
+    event:MemberUp
+
+    data:{"address":"akka://default@127.0.0.1:2551","type":"LeaderChanged"}
+    event:LeaderChanged
+
+### Get /cluster/domain-events responses
+
+| Response code | Description
+| ------------- | -----------
+| 200           | Cluster events in Server-Sent-Event format (JSON)
+| 500           | Something went wrong.
 
 ### Get /cluster/members responses
 


### PR DESCRIPTION
This PR adds a new route to cluster-http, `/cluster/domain-events`, that streams cluster events as Server Sent Events, JSON encoded. Please see the included documentation for route parameters, response format, etc.

ref: #540
