### PR TITLE
Terminate AS otherwise remains in sbt

### DIFF
--- a/cluster-http/src/test/scala/akka/management/cluster/scaladsl/ClusterMembershipCheckSpec.scala
+++ b/cluster-http/src/test/scala/akka/management/cluster/scaladsl/ClusterMembershipCheckSpec.scala
@@ -25,6 +25,7 @@ class ClusterMembershipCheckSpec
         new ClusterMembershipCheckSettings(Set(MemberStatus.Up)))
 
       chc().futureValue shouldEqual false
+      system.terminate()
     }
     "be unhealthy if current state is one of healthy states" in {
       val chc =

--- a/cluster-http/src/test/scala/akka/management/cluster/scaladsl/ClusterMembershipCheckSpec.scala
+++ b/cluster-http/src/test/scala/akka/management/cluster/scaladsl/ClusterMembershipCheckSpec.scala
@@ -7,6 +7,7 @@ package akka.management.cluster.scaladsl
 import akka.actor.ActorSystem
 import akka.cluster.MemberStatus
 import akka.testkit.TestKit
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
@@ -15,7 +16,12 @@ class ClusterMembershipCheckSpec
     extends TestKit(ActorSystem("ClusterHealthCheck"))
     with AnyWordSpecLike
     with Matchers
-    with ScalaFutures {
+    with ScalaFutures
+    with BeforeAndAfterAll {
+
+  override def afterAll(): Unit = {
+    shutdown(system)
+  }
 
   "Cluster Health" should {
     "be unhealthy if current state not one of healthy states" in {
@@ -25,7 +31,6 @@ class ClusterMembershipCheckSpec
         new ClusterMembershipCheckSettings(Set(MemberStatus.Up)))
 
       chc().futureValue shouldEqual false
-      system.terminate()
     }
     "be unhealthy if current state is one of healthy states" in {
       val chc =


### PR DESCRIPTION
Otherwise:

```
[info] shutting down sbt server
[INFO] [02/25/2021 13:16:16.100] [ClusterHealthCheck-akka.actor.default-dispatcher-2] [akka.cluster.Cluster(akka://ClusterHealthCheck)] Cluster Node [akka.tcp://ClusterHealthCheck@127.0.0.1:59531] - Exiting completed
[INFO] [02/25/2021 13:16:16.100] [ClusterHealthCheck-akka.actor.default-dispatcher-15] [akka.cluster.Cluster(akka://ClusterHealthCheck)] Cluster Node [akka.tcp://ClusterHealthCheck@127.0.0.1:59532] - Exiting completed
[INFO] [02/25/2021 13:16:16.101] [ClusterHealthCheck-akka.actor.default-dispatcher-2] [akka.cluster.Cluster(akka://ClusterHealthCheck)] Cluster Node [akka.tcp://ClusterHealthCheck@127.0.0.1:59531] - Shutting down...
[INFO] [02/25/2021 13:16:16.101] [ClusterHealthCheck-akka.actor.default-dispatcher-15] [akka.cluster.Cluster(akka://ClusterHealthCheck)] Cluster Node [akka.tcp://ClusterHealthCheck@127.0.0.1:59532] - Shutting down...
[INFO] [02/25/2021 13:16:16.101] [ClusterHealthCheck-akka.actor.default-dispatcher-2] [akka.cluster.Cluster(akka://ClusterHealthCheck)] Cluster Node [akka.tcp://ClusterHealthCheck@127.0.0.1:59531] - Successfully shut down
[WARN] [02/25/2021 13:16:16.101] [ClusterHealthCheck-akka.actor.default-dispatcher-15] [akka.cluster.Cluster(akka://ClusterHealthCheck)] Could not unregister Cluster JMX MBean with name=akka:type=Cluster as it was not found. If you are running multiple clusters in the same JVM, set 'akka.cluster.jmx.multi-mbeans-in-same-jvm = on' in config
[INFO] [02/25/2021 13:16:16.101] [ClusterHealthCheck-akka.actor.default-dispatcher-15] [akka.cluster.Cluster(akka://ClusterHealthCheck)] Cluster Node [akka.tcp://ClusterHealthCheck@127.0.0.1:59532] - Successfully shut down
[INFO] [02/25/2021 13:16:16.115] [ClusterHealthCheck-akka.remote.default-remote-dispatcher-6] [akka.tcp://ClusterHealthCheck@127.0.0.1:59532/system/remoting-terminator] Shutting down remote daemon.
[INFO] [02/25/2021 13:16:16.115] [ClusterHealthCheck-akka.remote.default-remote-dispatcher-13] [akka.tcp://ClusterHealthCheck@127.0.0.1:59531/system/remoting-terminator] Shutting down remote daemon.
...
```