### PR TITLE
Fix missing lease log args

### DIFF
--- a/lease-kubernetes/src/main/scala/akka/coordination/lease/kubernetes/KubernetesLease.scala
+++ b/lease-kubernetes/src/main/scala/akka/coordination/lease/kubernetes/KubernetesLease.scala
@@ -68,7 +68,9 @@ class KubernetesLease private[akka] (system: ExtendedActorSystem, leaseTaken: At
     s"kubernetesLease${KubernetesLease.leaseCounter.incrementAndGet}"
   )
   if (leaseName != settings.leaseName) {
-    logger.info("Original lease name [{}] sanitized for kubernetes: [{}]")
+    logger.info(
+      "Original lease name [{}] sanitized for kubernetes: [{}]",
+      Array[Object](settings.leaseName, leaseName): _*)
   }
   logger.debug(
     "Starting kubernetes lease actor [{}] for lease [{}], owner [{}]",


### PR DESCRIPTION
Fixes a small issue where a log call wasn't passed any arguments in the lease.
