### PR TITLE
Link to Akka Cloud Platform (backport)

### DIFF
--- a/docs/src/main/paradox/kubernetes-deployment/index.md
+++ b/docs/src/main/paradox/kubernetes-deployment/index.md
@@ -1,5 +1,9 @@
 # Deploying Akka Cluster to Kubernetes
 
+[Akka Cloud Platform](https://developer.lightbend.com/docs/akka-platform-guide/deployment/index.html) is the easiest way to deploy an Akka Cluster application to Amazon Elastic Kubernetes Service (EKS) or Google Kubernetes Engine (GKE).
+
+Alternatively, you can deploy to Kubernetes according to this guide, but that requires more expertise of Kubernetes.
+
 For this guide we will be using the Akka Cluster in Kubernetes sample. 
 It is available for both:
 


### PR DESCRIPTION
backport to 1.0 so that we get it out in docs of that release also

(cherry picked from commit 146274dd874b8bc89e3b438300c6d7bf208a6273)

