### PR TITLE
Use the latest jabba

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
   # make comparing to origin/master work
   - git remote set-branches --add origin master && git fetch
   # using jabba for custom jdk management
-  - curl -sL https://raw.githubusercontent.com/shyiko/jabba/0.11.1/install.sh | bash && . ~/.jabba/jabba.sh
+  - curl -sL https://git.io/jabba | bash && . ~/.jabba/jabba.sh
   - jabba install adopt@1.8-0
   - jabba install adopt@1.11-0
 


### PR DESCRIPTION
This uses the jabba script from master. This is needed because the
latest release, 0.11.2, has a problem.