### PR TITLE
cluster-http: Expose shard entity type keys

### DIFF
--- a/cluster-http/src/main/mima-filters/1.1.1.backwards.excludes
+++ b/cluster-http/src/main/mima-filters/1.1.1.backwards.excludes
@@ -1,0 +1,2 @@
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.management.cluster.ClusterHttpManagementJsonProtocol.akka$management$cluster$ClusterHttpManagementJsonProtocol$_setter_$shardEntityTypeKeysFormat_=")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.management.cluster.ClusterHttpManagementJsonProtocol.shardEntityTypeKeysFormat")

--- a/cluster-http/src/main/scala/akka/management/cluster/ClusterHttpManagementProtocol.scala
+++ b/cluster-http/src/main/scala/akka/management/cluster/ClusterHttpManagementProtocol.scala
@@ -24,6 +24,7 @@ final case class ClusterMembers(
     oldest: Option[String],
     oldestPerRole: Map[String, String])
 final case class ClusterHttpManagementMessage(message: String)
+final case class ShardEntityTypeKeys(entityTypeKeys: immutable.Set[String])
 final case class ShardRegionInfo(shardId: String, numEntities: Int)
 final case class ShardDetails(regions: immutable.Seq[ShardRegionInfo])
 
@@ -52,6 +53,7 @@ trait ClusterHttpManagementJsonProtocol extends SprayJsonSupport with DefaultJso
   implicit val clusterMembersFormat: RootJsonFormat[ClusterMembers] = jsonFormat6(ClusterMembers)
   implicit val clusterMemberMessageFormat: RootJsonFormat[ClusterHttpManagementMessage] =
     jsonFormat1(ClusterHttpManagementMessage)
+  implicit val shardEntityTypeKeysFormat: RootJsonFormat[ShardEntityTypeKeys] = jsonFormat1(ShardEntityTypeKeys)
   implicit val shardRegionInfoFormat: RootJsonFormat[ShardRegionInfo] = jsonFormat2(ShardRegionInfo)
   implicit val shardDetailsFormat: RootJsonFormat[ShardDetails] = jsonFormat1(ShardDetails)
 }

--- a/cluster-http/src/main/scala/akka/management/cluster/scaladsl/ClusterHttpManagementRoutes.scala
+++ b/cluster-http/src/main/scala/akka/management/cluster/scaladsl/ClusterHttpManagementRoutes.scala
@@ -215,6 +215,13 @@ object ClusterHttpManagementRoutes extends ClusterHttpManagementJsonProtocol {
 
   }
 
+  private def routeGetShardTypeNames(cluster: Cluster) =
+    get {
+      complete {
+        ShardEntityTypeKeys(ClusterSharding(cluster.system).shardTypeNames)
+      }
+    }
+
   private def routeGetShardInfo(cluster: Cluster, shardRegionName: String) =
     get {
       extractExecutionContext { implicit executor =>
@@ -261,6 +268,9 @@ object ClusterHttpManagementRoutes extends ClusterHttpManagementJsonProtocol {
         },
         pathPrefix("domain-events") {
           routeGetClusterDomainEvents(cluster)
+        },
+        path("shards") {
+          routeGetShardTypeNames(cluster)
         },
         pathPrefix("shards" / Remaining) { shardRegionName =>
           routeGetShardInfo(cluster, shardRegionName)

--- a/cluster-http/src/test/scala/akka/cluster/http/management/scaladsl/ClusterHttpManagementRoutesSpec.scala
+++ b/cluster-http/src/test/scala/akka/cluster/http/management/scaladsl/ClusterHttpManagementRoutesSpec.scala
@@ -337,9 +337,73 @@ class ClusterHttpManagementRoutesSpec
       }
     }
 
+    "return shard type names" when {
+      "calling GET /cluster/shards" in {
+        import scala.concurrent.duration._
+
+        import akka.pattern.ask
+
+        val config = ConfigFactory.parseString(
+          """
+            |akka.cluster {
+            |  auto-down-unreachable-after = 0s
+            |  periodic-tasks-initial-delay = 120 seconds // turn off scheduled tasks
+            |  publish-stats-interval = 0 s # always, when it happens
+            |  failure-detector.implementation-class = akka.cluster.FailureDetectorPuppet
+            |  sharding.state-store-mode = ddata
+            |}
+            |akka.actor.provider = "cluster"
+            |akka.remote.log-remote-lifecycle-events = off
+            |akka.remote.netty.tcp.port = 0
+            |akka.remote.artery.canonical.port = 0
+           """.stripMargin
+        )
+        val configClusterHttpManager = ConfigFactory.parseString(
+          """
+            |akka.management.http.hostname = "127.0.0.1"
+            |akka.management.http.port = 20100
+          """.stripMargin
+        )
+
+        implicit val system = ActorSystem("test", config.withFallback(configClusterHttpManager))
+        val cluster = Cluster(system)
+        val selfAddress = system.asInstanceOf[ExtendedActorSystem].provider.getDefaultAddress
+        cluster.join(selfAddress)
+        cluster.clusterCore ! LeaderActionsTick
+
+        val name = "TestShardRegion"
+        val shardRegion = ClusterSharding(system).start(
+          name,
+          TestShardedActor.props,
+          ClusterShardingSettings(system),
+          TestShardedActor.extractEntityId,
+          TestShardedActor.extractShardId
+        )
+
+        implicit val t = ScalatestTimeout(5.seconds)
+
+        shardRegion.ask("hello")(Timeout(3.seconds)).mapTo[String].futureValue(t)
+
+        val clusterHttpManagement = ClusterHttpManagementRouteProvider(system)
+        val settings = ManagementRouteProviderSettings(selfBaseUri = "http://127.0.0.1:20100", readOnly = false)
+        val binding = Http().newServerAt("127.0.0.1", 20100).bind(clusterHttpManagement.routes(settings)).futureValue
+
+        val responseGetShardEntityTypeKeys =
+          Http().singleRequest(HttpRequest(uri = s"http://127.0.0.1:20100/cluster/shards")).futureValue(t)
+        responseGetShardEntityTypeKeys.entity.getContentType shouldEqual ContentTypes.`application/json`
+        responseGetShardEntityTypeKeys.status shouldEqual StatusCodes.OK
+        val unmarshaledGetShardEntityTypeKeys =
+          Unmarshal(responseGetShardEntityTypeKeys.entity).to[ShardEntityTypeKeys].futureValue
+        unmarshaledGetShardEntityTypeKeys shouldEqual ShardEntityTypeKeys(Set(name))
+
+        binding.unbind().futureValue
+        system.terminate()
+      }
+    }
+
     "return shard region details" when {
 
-      "calling GET /cluster/shard_regions/{name}" in {
+      "calling GET /cluster/shards/{name}" in {
         import scala.concurrent.duration._
 
         import akka.pattern.ask

--- a/docs/src/main/paradox/cluster-http-management.md
+++ b/docs/src/main/paradox/cluster-http-management.md
@@ -207,6 +207,18 @@ Example response:
 
     Downing akka.tcp://test@10.10.10.10:111
 
+### Get /cluster/shard responses
+
+| Response code | Description
+| ------------- | -----------
+| 200           | Shard entity type keys in JSON format
+
+Example response:
+
+{
+  "entityTypeKeys": ["ShoppingCart"]
+}
+
 ### Get /cluster/shards/{name} responses
 
 | Response code | Description


### PR DESCRIPTION
Adds a new route to cluster-http, exposing entity type keys.

From HTTP perspective, output of this route can be provided to
`/cluster/shards/{name}` to programatically grab data.

