### PR TITLE
Remove may-change marker on aws module

### DIFF
--- a/discovery-aws-api/src/main/mima-filters/1.1.0.backwards.excludes
+++ b/discovery-aws-api/src/main/mima-filters/1.1.0.backwards.excludes
@@ -1,0 +1,4 @@
+# making things final/private to ease keeping compatibility when removing may-change
+ProblemFilters.exclude[FinalClassProblem]("akka.discovery.awsapi.ecs.EcsServiceDiscovery")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.discovery.awsapi.ecs.EcsServiceDiscovery.getContainerAddress")
+ProblemFilters.exclude[FinalClassProblem]("akka.discovery.awsapi.ec2.Ec2TagBasedServiceDiscovery")

--- a/discovery-aws-api/src/main/mima-filters/1.1.0.backwards.excludes
+++ b/discovery-aws-api/src/main/mima-filters/1.1.0.backwards.excludes
@@ -2,3 +2,4 @@
 ProblemFilters.exclude[FinalClassProblem]("akka.discovery.awsapi.ecs.EcsServiceDiscovery")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.discovery.awsapi.ecs.EcsServiceDiscovery.getContainerAddress")
 ProblemFilters.exclude[FinalClassProblem]("akka.discovery.awsapi.ec2.Ec2TagBasedServiceDiscovery")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.discovery.awsapi.ec2.Ec2TagBasedServiceDiscovery.ec2Client")

--- a/discovery-aws-api/src/main/resources/reference.conf
+++ b/discovery-aws-api/src/main/resources/reference.conf
@@ -5,7 +5,6 @@
 akka.discovery {
   # Set the following in your application.conf if you want to use this discovery mechanism:
   # method = aws-api-ec2-tag-based
-  # ApiMayChange
   aws-api-ec2-tag-based {
 
     # FQCN of a class that extends com.amazonaws.ClientConfiguration with either a no arguments constructor
@@ -30,7 +29,6 @@ akka.discovery {
 
   # Set the following in your application.conf if you want to use this discovery mechanism:
   # method = aws-api-ecs
-  # ApiMayChange
   aws-api-ecs {
 
     class = akka.discovery.awsapi.ecs.EcsServiceDiscovery

--- a/discovery-aws-api/src/main/scala/akka/discovery/awsapi/ec2/Ec2TagBasedServiceDiscovery.scala
+++ b/discovery-aws-api/src/main/scala/akka/discovery/awsapi/ec2/Ec2TagBasedServiceDiscovery.scala
@@ -26,8 +26,6 @@ import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.{ Failure, Success, Try }
 
-import akka.annotation.ApiMayChange
-
 /** INTERNAL API */
 @InternalApi private[ec2] object Ec2TagBasedServiceDiscovery {
 
@@ -44,8 +42,7 @@ import akka.annotation.ApiMayChange
 
 }
 
-@ApiMayChange
-class Ec2TagBasedServiceDiscovery(system: ExtendedActorSystem) extends ServiceDiscovery {
+final class Ec2TagBasedServiceDiscovery(system: ExtendedActorSystem) extends ServiceDiscovery {
 
   private val log = Logging(system, classOf[Ec2TagBasedServiceDiscovery])
 
@@ -89,7 +86,7 @@ class Ec2TagBasedServiceDiscovery(system: ExtendedActorSystem) extends ServiceDi
       }
   }
 
-  protected val ec2Client: AmazonEC2 = {
+  private val ec2Client: AmazonEC2 = {
     val clientConfiguration = clientConfigFqcn match {
       case Some(fqcn) =>
         getCustomClientConfigurationInstance(fqcn) match {
@@ -120,7 +117,7 @@ class Ec2TagBasedServiceDiscovery(system: ExtendedActorSystem) extends ServiceDi
   }
 
   @tailrec
-  private final def getInstances(
+  private def getInstances(
       client: AmazonEC2,
       filters: List[Filter],
       nextToken: Option[String],

--- a/discovery-aws-api/src/main/scala/akka/discovery/awsapi/ecs/EcsServiceDiscovery.scala
+++ b/discovery-aws-api/src/main/scala/akka/discovery/awsapi/ecs/EcsServiceDiscovery.scala
@@ -24,10 +24,7 @@ import scala.concurrent.{ ExecutionContext, Future }
 import scala.concurrent.duration._
 import scala.util.Try
 
-import akka.annotation.ApiMayChange
-
-@ApiMayChange
-class EcsServiceDiscovery(system: ActorSystem) extends ServiceDiscovery {
+final class EcsServiceDiscovery(system: ActorSystem) extends ServiceDiscovery {
 
   private[this] val config = system.settings.config.getConfig("akka.discovery.aws-api-ecs")
   private[this] val cluster = config.getString("cluster")
@@ -73,7 +70,6 @@ class EcsServiceDiscovery(system: ActorSystem) extends ServiceDiscovery {
 
 }
 
-@ApiMayChange
 object EcsServiceDiscovery {
 
   // InetAddress.getLocalHost.getHostAddress throws an exception when running
@@ -84,7 +80,7 @@ object EcsServiceDiscovery {
   // metadata file does not get set when running on Fargate. So this is our
   // only option for determining what the canonical Akka and akka-management
   // hostname values should be set to.
-  def getContainerAddress: Either[String, InetAddress] =
+  private[awsapi] def getContainerAddress: Either[String, InetAddress] =
     NetworkInterface.getNetworkInterfaces.asScala
       .flatMap(_.getInetAddresses.asScala)
       .filterNot(_.isLoopbackAddress)

--- a/docs/src/main/paradox/discovery/aws.md
+++ b/docs/src/main/paradox/discovery/aws.md
@@ -3,8 +3,6 @@
 @@@ warning
 
 This module is community maintained and the Lightbend subscription doesn't cover support for this module.
-  It is also marked as @extref:[may change](akka:common/may-change.html).
-  That means that the API, configuration or semantics can change without warning or deprecation period.
 
 @@@
 


### PR DESCRIPTION
AWS module has been stable for quite a while and most if not all actual API is configuration,
by marking a few classed final/methods private I think we can remove the may change marker and
see it as stable.