### PR TITLE
Give KubernetesApiSpec more time to release the lease

### DIFF
--- a/lease-kubernetes/src/main/resources/reference.conf
+++ b/lease-kubernetes/src/main/resources/reference.conf
@@ -43,7 +43,7 @@ akka.coordination.lease.kubernetes {
     # set to false for plain text with no auth
     secure-api-server = true
 
-    # The amount of time to wait for a lease to be aquired or released. This includes all requests to the API
+    # The amount of time to wait for a lease to be acquired or released. This includes all requests to the API
     # server that are required. If this timeout is hit then the lease *may* be taken due to the response being lost
     # on the way back from the API server but will be reported as not taken and can be safely retried.
     lease-operation-timeout = 5s

--- a/lease-kubernetes/src/test/resources/application.conf
+++ b/lease-kubernetes/src/test/resources/application.conf
@@ -1,0 +1,3 @@
+akka.coordination.lease.kubernetes {
+    lease-operation-timeout = 10s
+}

--- a/lease-kubernetes/src/test/resources/application.conf
+++ b/lease-kubernetes/src/test/resources/application.conf
@@ -1,3 +1,0 @@
-akka.coordination.lease.kubernetes {
-    lease-operation-timeout = 10s
-}

--- a/lease-kubernetes/src/test/scala/akka/coordination/lease/kubernetes/KubernetesApiSpec.scala
+++ b/lease-kubernetes/src/test/scala/akka/coordination/lease/kubernetes/KubernetesApiSpec.scala
@@ -5,7 +5,6 @@
 package akka.coordination.lease.kubernetes
 
 import scala.concurrent.duration._
-
 import akka.Done
 import akka.actor.ActorSystem
 import akka.coordination.lease.kubernetes.internal.KubernetesApiImpl
@@ -15,6 +14,7 @@ import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock._
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
+import com.typesafe.config.ConfigFactory
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.ScalaFutures
@@ -22,7 +22,14 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
 class KubernetesApiSpec
-    extends TestKit(ActorSystem("KubernetesApiSpec"))
+    extends TestKit(
+      ActorSystem(
+        "KubernetesApiSpec",
+        ConfigFactory.parseString("""akka.coordination.lease.kubernetes {
+        |    lease-operation-timeout = 10s
+        |}
+        |""".stripMargin)
+      ))
     with ScalaFutures
     with AnyWordSpecLike
     with BeforeAndAfterAll


### PR DESCRIPTION
api-server-request-timeout is 2/5th of lease-operation-timeout

Fixes #937