### PR TITLE
Load multiple ca certificates from file for kubernetes api discovery

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -110,8 +110,7 @@ lazy val `akka-management-pki` = project
   .settings(
     name := "akka-management-pki",
     libraryDependencies := Dependencies.ManagementPki,
-    // Don't enable mima until 1.1.1
-    mimaPreviousArtifacts := Set.empty
+    mimaPreviousArtifactsSet
   )
 
 lazy val `loglevels-logback` = project

--- a/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/KubernetesApiServiceDiscovery.scala
+++ b/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/KubernetesApiServiceDiscovery.scala
@@ -105,7 +105,7 @@ class KubernetesApiServiceDiscovery(implicit system: ActorSystem) extends Servic
   private val log = Logging(system, getClass)
 
   private val sslContext = {
-    val certificate = PemManagersProvider.loadCertificate(settings.apiCaPath)
+    val certificates = PemManagersProvider.loadCertificates(settings.apiCaPath)
 
     val factory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm)
     val keyStore = KeyStore.getInstance("PKCS12")
@@ -113,7 +113,7 @@ class KubernetesApiServiceDiscovery(implicit system: ActorSystem) extends Servic
     factory.init(keyStore, Array.empty)
     val km: Array[KeyManager] = factory.getKeyManagers
     val tm: Array[TrustManager] =
-      PemManagersProvider.buildTrustManagers(certificate)
+      PemManagersProvider.buildTrustManagers(certificates)
     val random: SecureRandom = new SecureRandom
     val sslContext = SSLContext.getInstance("TLSv1.2")
     sslContext.init(km, tm, random)

--- a/lease-kubernetes/src/main/scala/akka/coordination/lease/kubernetes/internal/KubernetesApiImpl.scala
+++ b/lease-kubernetes/src/main/scala/akka/coordination/lease/kubernetes/internal/KubernetesApiImpl.scala
@@ -52,14 +52,14 @@ import javax.net.ssl.TrustManager
   private val http = Http()(system)
 
   private lazy val sslContext = {
-    val certificate = PemManagersProvider.loadCertificate(settings.apiCaPath)
+    val certificates = PemManagersProvider.loadCertificates(settings.apiCaPath)
     val factory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm)
     val keyStore = KeyStore.getInstance("PKCS12")
     keyStore.load(null)
     factory.init(keyStore, Array.empty)
     val km: Array[KeyManager] = factory.getKeyManagers
     val tm: Array[TrustManager] =
-      PemManagersProvider.buildTrustManagers(certificate)
+      PemManagersProvider.buildTrustManagers(certificates)
     val random: SecureRandom = new SecureRandom
     val sslContext = SSLContext.getInstance("TLSv1.2")
     sslContext.init(km, tm, random)

--- a/management-pki/src/main/scala/akka/pki/kubernetes/PemManagersProvider.scala
+++ b/management-pki/src/main/scala/akka/pki/kubernetes/PemManagersProvider.scala
@@ -37,7 +37,7 @@ private[akka] object PemManagersProvider {
   @InternalApi def buildTrustManagers(cacerts: Iterable[Certificate]): Array[TrustManager] = {
     val trustStore = KeyStore.getInstance("JKS")
     trustStore.load(null)
-    cacerts.foreach(cert => trustStore.setCertificateEntry("cacert-"+Random.alphanumeric.take(6).mkString(""),cert))
+    cacerts.foreach(cert => trustStore.setCertificateEntry("cacert-" + Random.alphanumeric.take(6).mkString(""), cert))
 
     val tmf =
       TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm)


### PR DESCRIPTION
This PR will load multiple CA certificates from a file provided to the kubernetes api discovery. This is necessary because in case of OpenShift, the cluster will have multiple CAs and the ca.crt file will thus contain multiple certificates.

There are two things I would like to bring up for discussion.

1. Every certificate needs a unique key when added to the trust store. Before this PR the key was the atomic string "cacert". To create a unique key I now append a random string of 6 chars. I don't know if this is the best solution. 
2. The PemManagersProvider is copied from Akka-HTTP. So this PR will introduce a difference to the source in Akka-HTTP. Maybe this issue should also be fixed in Akka-HTTP.

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References #947
