### PR TITLE
Correct documentation

### DIFF
--- a/docs/src/main/paradox/index.md
+++ b/docs/src/main/paradox/index.md
@@ -1,7 +1,7 @@
 # Akka Management
 
 Akka Management is a suite of tools for operating Akka Clusters.
-The current version may be used with Akka 2.5 or 2.6.
+The current version may only be used with Akka 2.6.
 
 ## Overview
 


### PR DESCRIPTION
The front page of the documentation stated that the current version of Akka Management could be used with either Akka 2.5 or 2.6. I tested this locally, and it does not launch with 2.5, fails with a NoSuchMethodError

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References #xxxx
