### PR TITLE
Swap order of directives in Cluster Bootstrap

### DIFF
--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/contactpoint/HttpClusterBootstrapRoutes.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/contactpoint/HttpClusterBootstrapRoutes.scala
@@ -53,7 +53,7 @@ final class HttpClusterBootstrapRoutes(settings: ClusterBootstrapSettings) exten
 
   /** Scala API */
   val routes: Route =
-    (get & path("bootstrap" / "seed-nodes")) {
+    (path("bootstrap" / "seed-nodes") & get) {
       toStrictEntity(1.second) { // always drain everything
         routeGetSeedNodes
       }


### PR DESCRIPTION
Swapping the order of the `get` and `path` directives in the Cluster Bootstrap routes so that a rejection will prefer 404 Not Found over 405 Method Not Allowed if both method and path are wrong.
