### PR TITLE
upgrade logback to 1.2.9

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -101,7 +101,7 @@ object Dependencies {
     "com.typesafe.akka" %% "akka-actor" % AkkaVersion,
     "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
     "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
-    "ch.qos.logback" % "logback-classic" % "1.2.7",
+    "ch.qos.logback" % "logback-classic" % "1.2.9",
     "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
     "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
     "org.scalatest" %% "scalatest" % ScalaTestVersion % Test,


### PR DESCRIPTION
Release v1.1.1 is still using logback 1.2.3 which is affect by https://nvd.nist.gov/vuln/detail/CVE-2021-42550

The fix is in v1.2.8, but in the meantime there is already a v1.2.9, so going for it instead.