### PR TITLE
fix: ipv6 match host

### DIFF
--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/SelfAwareJoinDecider.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/SelfAwareJoinDecider.scala
@@ -75,7 +75,11 @@ import scala.concurrent.duration._
   /**
    * Checks for both host name and IP address for discovery mechanisms that return both.
    */
-  protected def hostMatches(host: String, target: ResolvedTarget): Boolean =
-    host == target.host || target.address.map(_.getHostAddress).contains(host.replaceAll("[\\[\\]]", ""))
+  protected def hostMatches(host: String, target: ResolvedTarget): Boolean = {
+    val hostWithoutBracket = host.replaceAll("[\\[\\]]", "")
+    host == target.host || hostWithoutBracket == target.host || target.address
+      .map(_.getHostAddress)
+      .contains(hostWithoutBracket)
+  }
 
 }


### PR DESCRIPTION
host match will fail in ipv6 environment. Fix it by replace all `[` and `]`.
