### PR TITLE
Document typos

### DIFF
--- a/docs/src/main/paradox/cluster-http-management.md
+++ b/docs/src/main/paradox/cluster-http-management.md
@@ -39,7 +39,7 @@ a later version than $akka.version$ can be used.
   artifact=akka-cluster-sharding_$scala.binary.version$
   version=AkkaVersion
   group2=com.typesafe.akka
-  artifact2=akka-discovery
+  artifact2=akka-discovery_$scala.binary.version$
   version2=AkkaVersion
 }
 


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
Signed-off-by: Al-assad yulin.ying@outlook.com
<br>

The reference to the akka-discovery dependency in the [Cluster Http Management documentation](https://doc.akka.io/docs/akka-management/current/cluster-http-management.html#dependencies) should contains the scala binary version likes `"com.typesafe.akka" %% "akka-discovery" % AkkaVersion`
<img width="1357" alt="image" src="https://user-images.githubusercontent.com/22493821/156518995-1a9da811-c46c-4040-8980-989530bb10e7.png">

<br>