### PR TITLE
cluster-bootstrap: Add AKKA_CLUSTER_BOOTSTRAP_PORT_NAME env var

### DIFF
--- a/cluster-bootstrap/src/main/resources/reference.conf
+++ b/cluster-bootstrap/src/main/resources/reference.conf
@@ -34,6 +34,7 @@ akka.management {
       # If set to "", `None` is passed to the discovery mechanism and
       # ${akka.management.http.port} is assumed.
       port-name = ""
+      port-name= ${?AKKA_CLUSTER_BOOTSTRAP_PORT_NAME}
 
       # The protocol passed to discovery.
       # If set to "" None is passed.


### PR DESCRIPTION
Adds env var `AKKA_CLUSTER_BOOTSTRAP_PORT_NAME` to specify port name
used in bootstrap.

To be used alongside the existing env var, `AKKA_CLUSTER_BOOTSTRAP_SERVICE_NAME`