### PR TITLE
chore: renovate GH workflows

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -8,13 +8,16 @@ on:
       - release-*
     tags-ignore: [ v.* ]
 
+permissions:
+  contents: read
+
 jobs:
   check-code-style:
     name: Check Code Style
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
@@ -25,13 +28,13 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
 
-      - name: Set up JDK 11
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.11.0-9
-
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v5
+        uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: temurin:1.11.0
 
       - name: Code style check, compilation and binary-compatibility check
         run: sbt "scalafmtCheckAll;headerCheckAll;+Test/compile;+IntegrationTest/compile;mimaReportBinaryIssues"
@@ -41,7 +44,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
 
@@ -51,13 +54,13 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
 
-      - name: Set up JDK 11
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.11.0-9
-
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v5
+        uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 17
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: temurin:1.17.0
 
       - name: Create all API docs for artifacts/website and all reference docs
         run: sbt "unidoc; docs/paradox"

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '0 0 * * 0' # At 00:00 on Sunday
 
+permissions:
+  contents: read
+
 jobs:
   fossa:
     name: Fossa
@@ -12,22 +15,22 @@ jobs:
     if: github.repository == 'akka/akka-management'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
 
-      - name: Set up JDK 11
-        uses: olafurpg/setup-scala@v13
-        with:
-          java-version: adopt@1.11
-
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 17
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: temurin:1.17
 
       - name: FOSSA policy check
         run: |-
-          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/spectrometer/master/install.sh | bash
+          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash
           fossa analyze && fossa test
         env:
           FOSSA_API_KEY: "${{secrets.FOSSA_API_KEY}}"

--- a/.github/workflows/integration-tests-kube-api.yml
+++ b/.github/workflows/integration-tests-kube-api.yml
@@ -40,8 +40,8 @@ jobs:
           jvm: temurin:1.11.0
 
       - name: Setup Minikube
-        // https://github.com/manusa/actions-setup-minikube/releases
-        // v2.7.1
+        # https://github.com/manusa/actions-setup-minikube/releases
+        # v2.7.1
         uses: manusa/actions-setup-minikube@4582844dcacbf482729f8d7ef696f515d2141bb9
         with:
           minikube version: 'v1.21.0'

--- a/.github/workflows/integration-tests-kube-api.yml
+++ b/.github/workflows/integration-tests-kube-api.yml
@@ -10,6 +10,9 @@ on:
   schedule:
     - cron: '0 2 * * *'  # every day 2am
 
+permissions:
+  contents: read
+
 jobs:
    integration-test:
     name: Integration Tests for Kubernetes API
@@ -18,7 +21,7 @@ jobs:
       fail-fast: false    
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
 
@@ -28,16 +31,18 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
 
-      - name: Set up JDK adopt@1.11.0-9
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.11.0-9
-
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v5
+        uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: temurin:1.11.0
 
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.7.0
+        // https://github.com/manusa/actions-setup-minikube/releases
+        // v2.7.1
+        uses: manusa/actions-setup-minikube@4582844dcacbf482729f8d7ef696f515d2141bb9
         with:
           minikube version: 'v1.21.0'
           kubernetes version: 'v1.21.0'

--- a/.github/workflows/integration-tests-kube-dns.yml
+++ b/.github/workflows/integration-tests-kube-dns.yml
@@ -40,8 +40,8 @@ jobs:
           jvm: temurin:1.11.0
 
       - name: Setup Minikube
-        // https://github.com/manusa/actions-setup-minikube/releases
-        // v2.7.1
+        # https://github.com/manusa/actions-setup-minikube/releases
+        # v2.7.1
         uses: manusa/actions-setup-minikube@4582844dcacbf482729f8d7ef696f515d2141bb9
         with:
           minikube version: 'v1.21.0'

--- a/.github/workflows/integration-tests-kube-dns.yml
+++ b/.github/workflows/integration-tests-kube-dns.yml
@@ -10,6 +10,9 @@ on:
   schedule:
     - cron: '0 2 * * *'  # every day 2am
 
+permissions:
+  contents: read
+
 jobs:
    integration-test:
     name: Integration Tests for Kubernetes DNS
@@ -18,7 +21,7 @@ jobs:
       fail-fast: false    
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
 
@@ -28,16 +31,18 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
 
-      - name: Set up JDK adopt@1.11.0-9
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.11.0-9
-
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v5
+        uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: temurin:1.11.0
 
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.7.0
+        // https://github.com/manusa/actions-setup-minikube/releases
+        // v2.7.1
+        uses: manusa/actions-setup-minikube@4582844dcacbf482729f8d7ef696f515d2141bb9
         with:
           minikube version: 'v1.21.0'
           kubernetes version: 'v1.21.0'

--- a/.github/workflows/integration-tests-lease.yml
+++ b/.github/workflows/integration-tests-lease.yml
@@ -10,6 +10,9 @@ on:
   schedule:
     - cron: '0 2 * * *'  # every day 2am
 
+permissions:
+  contents: read
+
 jobs:
    integration-test:
     name: Integration test for Kubernetes Lease
@@ -18,7 +21,7 @@ jobs:
       fail-fast: false    
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
 
@@ -28,16 +31,21 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
 
-      - name: Set up JDK adopt@1.11.0-9
-        uses: olafurpg/setup-scala@v10
+      - name: Cache Coursier cache
+        uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1.3.0
         with:
-          java-version: adopt@1.11.0-9
+          jvm: temurin:1.11.0
 
       - name: Cache Coursier cache
         uses: coursier/cache-action@v5
 
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.7.0
+        // https://github.com/manusa/actions-setup-minikube/releases
+        // v2.7.1
+        uses: manusa/actions-setup-minikube@4582844dcacbf482729f8d7ef696f515d2141bb9
         with:
           minikube version: 'v1.21.0'
           kubernetes version: 'v1.21.0'

--- a/.github/workflows/integration-tests-lease.yml
+++ b/.github/workflows/integration-tests-lease.yml
@@ -43,8 +43,8 @@ jobs:
         uses: coursier/cache-action@v5
 
       - name: Setup Minikube
-        // https://github.com/manusa/actions-setup-minikube/releases
-        // v2.7.1
+        # https://github.com/manusa/actions-setup-minikube/releases
+        # v2.7.1
         uses: manusa/actions-setup-minikube@4582844dcacbf482729f8d7ef696f515d2141bb9
         with:
           minikube version: 'v1.21.0'

--- a/.github/workflows/integration-tests-maven.yml
+++ b/.github/workflows/integration-tests-maven.yml
@@ -9,6 +9,9 @@ on:
     tags-ignore: [ v.* ]
     # Different than its sibilings, we don't configure this workflow to run as a cron job.
 
+permissions:
+  contents: read
+
 jobs:
    integration-test:
     name: Integration Tests for Kubernetes API with Maven
@@ -17,7 +20,7 @@ jobs:
       fail-fast: false    
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
 
@@ -27,16 +30,18 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
 
-      - name: Set up JDK adopt@1.11.0-9
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.11.0-9
-
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v5
+        uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: temurin:1.11.0
 
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.7.0
+        // https://github.com/manusa/actions-setup-minikube/releases
+        // v2.7.1
+        uses: manusa/actions-setup-minikube@4582844dcacbf482729f8d7ef696f515d2141bb9
         with:
           minikube version: 'v1.21.0'
           kubernetes version: 'v1.21.0'

--- a/.github/workflows/integration-tests-maven.yml
+++ b/.github/workflows/integration-tests-maven.yml
@@ -39,8 +39,8 @@ jobs:
           jvm: temurin:1.11.0
 
       - name: Setup Minikube
-        // https://github.com/manusa/actions-setup-minikube/releases
-        // v2.7.1
+        # https://github.com/manusa/actions-setup-minikube/releases
+        # v2.7.1
         uses: manusa/actions-setup-minikube@4582844dcacbf482729f8d7ef696f515d2141bb9
         with:
           minikube version: 'v1.21.0'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,11 +7,19 @@ on:
       - main
       - release-*
 
+permissions:
+  contents: read
+
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
+    if: github.repository == 'akka/akka-management'
+    permissions:
+      contents: write
     steps:
-      # Drafts your next Release notes as Pull Requests are merged into "main"
-      - uses: release-drafter/release-drafter@v5
+      # Drafts your next Release notes as Pull Requests are merged
+      # https://github.com/release-drafter/release-drafter/releases
+      # v5.21.1
+      - uses: release-drafter/release-drafter@6df64e4ba4842c203c604c1f45246c5863410adb
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
       - release-*
     tags: ["*"]
 
+permissions:
+  contents: read
+
 jobs:
   release:
     # runs on main repo only
@@ -18,7 +21,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
@@ -29,13 +32,13 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
 
-      - name: Setup Scala with JDK 8
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.8
-
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v5
+        uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: temurin:1.11.0.17
 
       - name: Publish artifacts for all Scala versions
         env:
@@ -54,7 +57,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
@@ -65,13 +68,13 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
 
-      - name: Setup Scala with JDK 11
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.11
-
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v5
+        uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 17
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: temurin:1.17.0
 
       - name: Publish API and reference documentation
         env:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -10,6 +10,9 @@ on:
   schedule:
     - cron: '0 2 * * *'  # every day 2am
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Build and Test
@@ -18,11 +21,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { java-version: adopt@1.8,  sbt-opts: '' }
-          - { java-version: adopt@1.11, sbt-opts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
+          - { jdkVersion: "1.8.0",  jvmName: "temurin:1.8.0",  extraOpts: '' }
+          - { jdkVersion: "1.11.0", jvmName: "temurin:1.11.0", extraOpts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
+          - { jdkVersion: "1.17.0", jvmName: "temurin:1.17.0", extraOpts: '' }
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
 
@@ -32,21 +36,21 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
 
-      - name: Setup JDK ${{ matrix.java-version }}
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: ${{ matrix.java-version }}
-
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v5
+        uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK ${{ matrix.jdkVersion }}
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: ${{ matrix.jvmName }}
 
       # hack to solve "Cannot assign requested address" issue - https://github.community/t/github-action-and-oserror-errno-99-cannot-assign-requested-address/173973/1
       - name: Add the current IP address, long hostname and short hostname record to /etc/hosts file
         run: |
           echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
 
-      - name: Run tests with default Scala and Java ${{ matrix.java-version }}
-        run: sbt "test" ${{ matrix.sbt-opts }}
+      - name: Run tests with default Scala and Java ${{ matrix.jdkVersion }}
+        run: sbt "test" ${{ matrix.extraOpts }}
 
       - name: Print logs on failure
         if: ${{ failure() }}

--- a/cluster-http/src/test/scala/akka/cluster/http/management/scaladsl/ClusterHttpManagementRoutesSpec.scala
+++ b/cluster-http/src/test/scala/akka/cluster/http/management/scaladsl/ClusterHttpManagementRoutesSpec.scala
@@ -8,7 +8,6 @@ package akka.cluster.http.management.scaladsl
 
 import scala.collection.immutable._
 import scala.concurrent.Promise
-
 import akka.actor.Actor
 import akka.actor.ActorSystem
 import akka.actor.Address
@@ -35,10 +34,10 @@ import akka.util.ByteString
 import akka.util.Timeout
 import akka.util.Version
 import com.typesafe.config.ConfigFactory
-import org.mockito.Matchers._
-import org.mockito.Mockito._
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{doNothing, mock, when}
 import org.scalatest.concurrent.Eventually
-import org.scalatest.concurrent.PatienceConfiguration.{ Timeout => ScalatestTimeout }
+import org.scalatest.concurrent.PatienceConfiguration.{Timeout => ScalatestTimeout}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.Millis

--- a/cluster-http/src/test/scala/akka/cluster/http/management/scaladsl/ClusterHttpManagementRoutesSpec.scala
+++ b/cluster-http/src/test/scala/akka/cluster/http/management/scaladsl/ClusterHttpManagementRoutesSpec.scala
@@ -35,9 +35,9 @@ import akka.util.Timeout
 import akka.util.Version
 import com.typesafe.config.ConfigFactory
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.{doNothing, mock, when}
+import org.mockito.Mockito.{ doNothing, mock, when }
 import org.scalatest.concurrent.Eventually
-import org.scalatest.concurrent.PatienceConfiguration.{Timeout => ScalatestTimeout}
+import org.scalatest.concurrent.PatienceConfiguration.{ Timeout => ScalatestTimeout }
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.Millis

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -132,7 +132,7 @@ object Dependencies {
     "com.typesafe.akka" %% "akka-http-core" % AkkaHttpVersion,
     "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
     "com.typesafe.akka" %% "akka-testkit" % AkkaVersion % Test,
-    "org.mockito" % "mockito-all" % "1.10.19" % Test,
+    "org.mockito" % "mockito-core" % "4.9.0" % Test,
     "com.typesafe.akka" %% "akka-http-testkit" % AkkaHttpVersion % Test,
     "com.typesafe.akka" %% "akka-distributed-data" % AkkaVersion % Test,
     "org.scalatest" %% "scalatest" % ScalaTestVersion % Test,


### PR DESCRIPTION
Update to current versions of GH actions before Node 12 is discontinued.
* Replace `olafurpg/setup-scala` with `coursier/setup-action`
* Locking "privately owned" actions to their git hash 
* Current Fossa CLI install URL
* Explicit permissions (see https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)
* Upgrade Mockito to 4.9.0 to become JDK17 friendly

Refs https://github.com/akka/akka/pull/31730