### PR TITLE
ci: fix flaky RU kubernetes test

### DIFF
--- a/integration-test/scripts/rollingupdate-kubernetes-test.sh
+++ b/integration-test/scripts/rollingupdate-kubernetes-test.sh
@@ -37,7 +37,8 @@ do
   # Get the list of pods matching the namespace and app name, and are in the Running state
   pod_list=$(kubectl get pods -n $NAMESPACE | grep $APP_NAME | grep Running | awk '{ print $1 }')
   annotated_count=0
-  echo "## Pod List:\n$pod_list\n##"
+  pod_annotation_array=()
+  echo -e "## Pod List:\n$pod_list\n##"
 
   for pod_name in $pod_list
   do


### PR DESCRIPTION
Fix https://github.com/akka/akka-management/issues/1148

Easy to reproduce if using a smaller sleep between retries. The list of annotated pods was being carried between attempts leading to issues if not all pods were annotated on the same run. 
