### PR TITLE
fix: prevent extensions to fail  with cyclic initialization

### DIFF
--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/ClusterBootstrap.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/ClusterBootstrap.scala
@@ -82,7 +82,7 @@ final class ClusterBootstrap(implicit system: ExtendedActorSystem) extends Exten
       }
       try {
         AkkaManagement(system).start().failed.foreach(autostartFailed)
-        ClusterBootstrap(system).start()
+        start()
       } catch {
         case NonFatal(ex) => autostartFailed(ex)
       }

--- a/rolling-update-kubernetes/src/main/scala/akka/rollingupdate/kubernetes/AppVersionRevision.scala
+++ b/rolling-update-kubernetes/src/main/scala/akka/rollingupdate/kubernetes/AppVersionRevision.scala
@@ -58,7 +58,7 @@ final class AppVersionRevision(implicit system: ExtendedActorSystem) extends Ext
   if (autostart) {
     log.info("AppVersionRevision loaded through 'akka.extensions' auto-starting itself.")
     try {
-      AppVersionRevision(system).start()
+      start()
     } catch {
       case NonFatal(ex) =>
         log.error(ex, "Failed to autostart AppVersionRevision extension")

--- a/rolling-update-kubernetes/src/main/scala/akka/rollingupdate/kubernetes/PodDeletionCost.scala
+++ b/rolling-update-kubernetes/src/main/scala/akka/rollingupdate/kubernetes/PodDeletionCost.scala
@@ -67,7 +67,7 @@ final class PodDeletionCost(implicit system: ExtendedActorSystem) extends Extens
   if (autostart) {
     log.info("PodDeletionCost loaded through 'akka.extensions' auto-starting itself.")
     try {
-      PodDeletionCost(system).start()
+      start()
     } catch {
       case NonFatal(ex) =>
         log.error(ex, "Failed to autostart PodDeletionCost extension")


### PR DESCRIPTION
I verified this with the `AppVersionRevision` extension.

Assuming the same for the other two extensions, however I find it strange this did not surface before, for the `ClusterBootstrap` one.
