### PR TITLE
Fix references to ManagementRouteProvider

### DIFF
--- a/docs/src/main/paradox/akka-management.md
+++ b/docs/src/main/paradox/akka-management.md
@@ -190,7 +190,7 @@ and even trigger joining/leaving/downing decisions via HTTP calls to these route
 logic for these are implemented inside the `akka-management-cluster-http`.
 
 Management route providers should be regular extensions that additionally extend the
-`akka.management.scaladsl.ManagementRoutesProvider` or `akka.management.javadsl.ManagementRoutesProvider`
+`akka.management.scaladsl.ManagementRouteProvider` or `akka.management.javadsl.ManagementRouteProvider`
 interface.
 
 Libraries may register routes into the management routes by defining entries to this setting
@@ -205,7 +205,7 @@ akka.management.http.routes {
 Where the `name` of the entry should be unique to allow different route providers to be registered
 by different libraries and applications.
 
-The FQCN is the fully qualified class name of the `ManagementRoutesProvider`.
+The FQCN is the fully qualified class name of the `ManagementRouteProvider`.
 
 Route providers included by a library (from reference.conf) can be excluded by an application
 by using `""` or `null` as the FQCN of the named entry, for example:

--- a/management/src/main/resources/reference.conf
+++ b/management/src/main/resources/reference.conf
@@ -37,8 +37,8 @@ akka.management {
 
     # Definition of management route providers which shall contribute routes to the management HTTP endpoint.
     # Management route providers should be regular extensions that aditionally extend the
-    # `akka.management.scaladsl.ManagementRoutesProvider` or
-    # `akka.management.javadsl.ManagementRoutesProvider` interface.
+    # `akka.management.scaladsl.ManagementRouteProvider` or
+    # `akka.management.javadsl.ManagementRouteProvider` interface.
     #
     # Libraries may register routes into the management routes by defining entries to this setting
     # the library `reference.conf`:
@@ -50,7 +50,7 @@ akka.management {
     # Where the `name` of the entry should be unique to allow different route providers to be registered
     # by different libraries and applications.
     #
-    # The FQCN is the fully qualified class name of the `ManagementRoutesProvider`.
+    # The FQCN is the fully qualified class name of the `ManagementRouteProvider`.
     #
     # By default the `akka.management.HealthCheckRoutes` is enabled, see `health-checks` section of how
     # configure specific readiness and liveness checks.


### PR DESCRIPTION
- replace misspelled `ManagementRoutesProvider` references with the actual class name `ManagementRouteProvider` in docs & reference.conf