### PR TITLE
bump: Jackson 2.15.2

### DIFF
--- a/integration-test/aws-api-ec2/build.sbt
+++ b/integration-test/aws-api-ec2/build.sbt
@@ -6,6 +6,6 @@ libraryDependencies += "com.amazonaws" % "aws-java-sdk-cloudformation" % "1.12.5
 
 libraryDependencies += "com.amazonaws" % "aws-java-sdk-autoscaling" % "1.12.539" % IntegrationTest
 
-libraryDependencies += "com.fasterxml.jackson.core" % "jackson-databind" % "2.13.4.2" // aws SDK depends on insecure jackson
+libraryDependencies += "com.fasterxml.jackson.core" % "jackson-databind" % "2.15.2" // aws SDK depends on insecure jackson
 
 libraryDependencies += "org.scalatest" %% "scalatest" % Dependencies.ScalaTestVersion % IntegrationTest

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,8 +19,8 @@ object Dependencies {
   val ScalaTestPlusJUnitVersion = ScalaTestVersion + ".0"
 
   val AwsSdkVersion = "1.12.539"
-  val JacksonVersion = "2.13.4"
-  val JacksonDatabindVersion = "2.13.4.2"
+  val JacksonVersion = "2.15.2"
+  val JacksonDatabindVersion = "2.15.2"
 
   val Log4j2Version = "2.20.0"
 


### PR DESCRIPTION
Use same Jackson version as in upcoming Akka 2.9. Targeting next minor release.