### PR TITLE
chore: scala-steward pin Jackson 2.15

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -2,7 +2,7 @@ pullRequests.frequency = "@monthly"
 
 updates.pin = [
   # To be updated in tandem with upstream Akka
-  {groupId = "com.fasterxml.jackson.core", version = "2.11."}
+  {groupId = "com.fasterxml.jackson.core", version = "2.15."}
   {groupId = "org.scalatest", artifactId = "scalatest", version = "3.2."}
 ]
 


### PR DESCRIPTION
* the dependency is already on 2.15.2
