### PR TITLE
fix: Fail if too long lease name, #910

### DIFF
--- a/lease-kubernetes/src/main/resources/reference.conf
+++ b/lease-kubernetes/src/main/resources/reference.conf
@@ -47,4 +47,8 @@ akka.coordination.lease.kubernetes {
     # server that are required. If this timeout is hit then the lease *may* be taken due to the response being lost
     # on the way back from the API server but will be reported as not taken and can be safely retried.
     lease-operation-timeout = 5s
+
+    # For backwards compatibility to support rolling update. Truncation of lease name may cause conflicting names
+    # of different lease resources.
+    allow-lease-name-truncation = off
 }

--- a/lease-kubernetes/src/main/scala/akka/coordination/lease/kubernetes/KubernetesSettings.scala
+++ b/lease-kubernetes/src/main/scala/akka/coordination/lease/kubernetes/KubernetesSettings.scala
@@ -52,7 +52,8 @@ private[akka] object KubernetesSettings {
       config.getString("namespace-path"),
       apiServerRequestTimeout,
       secure = config.getBoolean("secure-api-server"),
-      apiServerRequestTimeout / 2)
+      apiServerRequestTimeout / 2,
+      config.getBoolean("allow-lease-name-truncation"))
 
   }
 }
@@ -70,4 +71,5 @@ private[akka] class KubernetesSettings(
     val namespacePath: String,
     val apiServerRequestTimeout: FiniteDuration,
     val secure: Boolean = true,
-    val bodyReadTimeout: FiniteDuration = 1.second)
+    val bodyReadTimeout: FiniteDuration = 1.second,
+    val allowLeaseNameTruncation: Boolean = false)


### PR DESCRIPTION
* for backwards compatibility it's possible to allow old behavior with config, e.g. to support rolling update

Refs #910

Requires a way to define custom lease names, which is added in https://github.com/akka/akka/pull/32122
