### PR TITLE
docs: refer to the correct Akka binary version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -389,6 +389,7 @@ lazy val docs = project
         "canonical.base_url" -> "https://doc.akka.io/docs/akka-management/current",
         "scala.binary.version" -> scalaBinaryVersion.value,
         "akka.version" -> Dependencies.AkkaVersion,
+        "akka.binary.version" -> Dependencies.AkkaBinaryVersion,
         "extref.akka.base_url" -> s"https://doc.akka.io/docs/akka/current/%s",
         "scaladoc.akka.base_url" -> s"https://doc.akka.io/api/akka/current/",
         "extref.akka-http.base_url" -> s"https://doc.akka.io/docs/akka-http/${Dependencies.AkkaHttpBinaryVersion}/%s",

--- a/docs/src/main/paradox/index.md
+++ b/docs/src/main/paradox/index.md
@@ -1,7 +1,7 @@
 # Akka Management
 
 Akka Management is a suite of tools for operating Akka Clusters.
-The current version may only be used with Akka 2.7.
+The current version may only be used with Akka $akka.binary.version$.
 
 ## Overview
 


### PR DESCRIPTION
It currently refers to Akka 2.7, but should say 2.9.

https://doc.akka.io/docs/akka-management/current/index.html