### PR TITLE
feat: Native-image metadata and docs

### DIFF
--- a/.github/workflows/native-image-tests.yml
+++ b/.github/workflows/native-image-tests.yml
@@ -35,9 +35,11 @@ jobs:
           jvm: temurin:1.11
 
       - name: Gather version
+        # some cleanup of the sbt output to get the version sbt will use when publishing below
         run: |-
-          echo `git describe --tags | sed -e "s/v\(.*\)-\([0-9][0-9]*\).*/\\1+\\2-/"``git rev-parse HEAD | head -c8`-SNAPSHOT > ~/.version
-          cat ~/.version
+          sbt "akka-management/version" --batch --no-colors | tail -n 1 | cut -f 2 -d ' ' | tr -d '\n' > ~/.version
+          echo [$(cat ~/.version)]
+          # useful for debugging: hexdump -c ~/.version
 
       - name: Publish artifacts locally
         run: |-

--- a/.github/workflows/native-image-tests.yml
+++ b/.github/workflows/native-image-tests.yml
@@ -43,14 +43,12 @@ jobs:
         run: |-
           sbt "publishLocal; publishM2"
 
-      #- name: Akka Management native image test app build
-      #  run: |-
-      #    cd native-image-tests/grpc-scala
-      #    sbt nativeImage -Dakka.grpc.version=`cat ~/.version`
-      #    # run the binary, netty client backend
-      #    target/native-image/grpc-scala
-      #    # akka-http client backend
-      #    target/native-image/grpc-scala akka-http-client
+      - name: Akka Management native image test app build
+        run: |-
+          cd native-image-tests
+          sbt nativeImage -Dakka.management.version=`cat ~/.version`
+          # run the binary to see it can bootstrap a cluster
+          target/native-image/native-image-tests
 
       - name: Email on failure
         if: ${{ failure() }}

--- a/cluster-bootstrap/src/main/resources/META-INF/native-image/com.lightbend.akka.management/akka-management-cluster-bootstrap/reflect-config.json
+++ b/cluster-bootstrap/src/main/resources/META-INF/native-image/com.lightbend.akka.management/akka-management-cluster-bootstrap/reflect-config.json
@@ -1,0 +1,43 @@
+[
+  {
+    "name": "akka.management.cluster.bootstrap.LowestAddressJoinDecider",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": ["akka.actor.ActorSystem", "akka.management.cluster.bootstrap.ClusterBootstrapSettings"]
+      }
+    ]
+  },
+  {
+    "name": "akka.management.cluster.bootstrap.ClusterBootstrap$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "akka.management.cluster.bootstrap.ClusterBootstrap",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": ["akka.actor.ExtendedActorSystem"]
+      }
+    ]
+  },
+  {
+    "name": "akka.management.cluster.bootstrap.contactpoint.HttpBootstrapJsonProtocol$SeedNode",
+    "allDeclaredFields": true,
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "akka.management.cluster.bootstrap.contactpoint.HttpBootstrapJsonProtocol$ClusterMember",
+    "allDeclaredFields": true,
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "akka.management.cluster.bootstrap.contactpoint.HttpBootstrapJsonProtocol$SeedNodes",
+    "allDeclaredFields": true,
+    "queryAllPublicMethods": true
+  }
+]

--- a/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/contactpoint/HttpBootstrapJsonProtocol.scala
+++ b/cluster-bootstrap/src/main/scala/akka/management/cluster/bootstrap/contactpoint/HttpBootstrapJsonProtocol.scala
@@ -19,6 +19,8 @@ trait HttpBootstrapJsonProtocol extends SprayJsonSupport with DefaultJsonProtoco
 
     override def write(obj: Address): JsValue = JsString(obj.toString)
   }
+
+  // If adding more formats here, remember to also add in META-INF/native-image reflect config
   implicit val SeedNodeFormat: RootJsonFormat[SeedNode] = jsonFormat1(SeedNode.apply)
   implicit val ClusterMemberFormat: RootJsonFormat[ClusterMember] = jsonFormat4(ClusterMember.apply)
   implicit val ClusterMembersFormat: RootJsonFormat[SeedNodes] = jsonFormat2(SeedNodes.apply)

--- a/cluster-http/src/main/resources/META-INF/native-image/com.lightbend.akka.management/akka-management-cluster-http/reflect-config.json
+++ b/cluster-http/src/main/resources/META-INF/native-image/com.lightbend.akka.management/akka-management-cluster-http/reflect-config.json
@@ -1,0 +1,57 @@
+[
+  {
+    "name": "akka.management.cluster.ClusterHttpManagementRouteProvider$",
+    "fields": [ {
+      "name": "MODULE$"
+    } ]
+  },
+  {
+    "name": "akka.management.cluster.javadsl.ClusterMembershipCheck",
+    "methods": [{
+      "name": "<init>",
+      "parameterTypes": ["akka.actor.ActorSystem"]
+    }]
+  },
+  {
+    "name": "akka.management.cluster.scaladsl.ClusterMembershipCheck",
+    "methods": [{
+      "name": "<init>",
+      "parameterTypes": ["akka.actor.ActorSystem"]
+    }]
+  },
+  {
+    "name": "akka.management.cluster.ClusterUnreachableMember",
+    "allDeclaredFields": true,
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "akka.management.cluster.ClusterMember",
+    "allDeclaredFields": true,
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "akka.management.cluster.ClusterMembers",
+    "allDeclaredFields": true,
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "akka.management.cluster.ClusterHttpManagementMessage",
+    "allDeclaredFields": true,
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "akka.management.cluster.ShardEntityTypeKeys",
+    "allDeclaredFields": true,
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "akka.management.cluster.ShardRegionInfo",
+    "allDeclaredFields": true,
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "akka.management.cluster.ShardDetails",
+    "allDeclaredFields": true,
+    "queryAllPublicMethods": true
+  }
+]

--- a/cluster-http/src/main/scala/akka/management/cluster/ClusterHttpManagementProtocol.scala
+++ b/cluster-http/src/main/scala/akka/management/cluster/ClusterHttpManagementProtocol.scala
@@ -47,6 +47,7 @@ final case class ShardDetails(regions: immutable.Seq[ShardRegionInfo])
 }
 
 trait ClusterHttpManagementJsonProtocol extends SprayJsonSupport with DefaultJsonProtocol {
+  // If adding more formats here, remember to also add in META-INF/native-image reflect config
   implicit val clusterUnreachableMemberFormat: RootJsonFormat[ClusterUnreachableMember] =
     jsonFormat2(ClusterUnreachableMember.apply)
   implicit val clusterMemberFormat: RootJsonFormat[ClusterMember] = jsonFormat4(ClusterMember.apply)

--- a/discovery-kubernetes-api/src/main/resources/META-INF/native-image/com.lightbend.akka.management/akka-discovery-kubernetes-api/reflect-config.json
+++ b/discovery-kubernetes-api/src/main/resources/META-INF/native-image/com.lightbend.akka.management/akka-discovery-kubernetes-api/reflect-config.json
@@ -1,0 +1,48 @@
+[
+  {
+    "name": "akka.discovery.kubernetes.KubernetesApiServiceDiscovery",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "akka.actor.ActorSystem"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "akka.discovery.kubernetes.PodList$ContainerPort",
+    "allDeclaredFields": true,
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "akka.discovery.kubernetes.PodList.Container",
+    "allDeclaredFields": true,
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "akka.discovery.kubernetes.PodList.PodSpec",
+    "allDeclaredFields": true,
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "akka.discovery.kubernetes.PodList.ContainerStatus",
+    "allDeclaredFields": true,
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "akka.discovery.kubernetes.PodList.PodStatus",
+    "allDeclaredFields": true,
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "akka.discovery.kubernetes.PodList.Pod",
+    "allDeclaredFields": true,
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "akka.discovery.kubernetes.PodList.Metadata",
+    "allDeclaredFields": true,
+    "queryAllPublicMethods": true
+  }
+]

--- a/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/JsonFormat.scala
+++ b/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/JsonFormat.scala
@@ -13,6 +13,7 @@ import spray.json._
  * INTERNAL API
  */
 @InternalApi private[akka] object JsonFormat extends SprayJsonSupport with DefaultJsonProtocol {
+  // If adding more formats here, remember to also add in META-INF/native-image reflect config
   implicit val containerPortFormat: JsonFormat[ContainerPort] = jsonFormat2(ContainerPort.apply)
   implicit val containerFormat: JsonFormat[Container] = jsonFormat2(Container.apply)
   implicit val podSpecFormat: JsonFormat[PodSpec] = jsonFormat1(PodSpec.apply)

--- a/docs/src/main/paradox/cluster-jmx-management.md
+++ b/docs/src/main/paradox/cluster-jmx-management.md
@@ -1,4 +1,4 @@
 # Built-in JMX Management
 
 Akka has built-in JMX beans which you can use to manage the cluster, read more about them in the Akka
-documentation: @extref:[Cluster Usage: JMX](akka:cluster-usage.html#cluster-jmx)
+documentation: @extref:[Cluster Usage: JMX](akka:additional/operations.html#jmx)

--- a/docs/src/main/paradox/index.md
+++ b/docs/src/main/paradox/index.md
@@ -36,4 +36,5 @@ Various parts of Akka management can be used together for deploying Akka Cluster
   - [Akka Cluster Management (JMX)](cluster-jmx-management.md)
   - [Dynamic Log Levels](loglevels/index.md)
   - [Akka Coordination Lease for Kubernetes](kubernetes-lease.md)
+  - [Native Image](native-image.md)
 @@@

--- a/docs/src/main/paradox/native-image.md
+++ b/docs/src/main/paradox/native-image.md
@@ -5,9 +5,9 @@ Building native images with Akka HTTP is supported out of the box for the follow
  * akka-management
  * akka-management-cluster-bootstrap
  * akka-management-cluster-http
- * akka-management-discovery-kubernetes-api
+ * akka-discovery-kubernetes-api
  * akka-lease-kubernetes
- * akka-rolling-upgrade-kubernetes
+ * akka-rolling-update-kubernetes
 
 Other modules can likely be used but will require figuring out and adding additional native-image metadata.
 

--- a/docs/src/main/paradox/native-image.md
+++ b/docs/src/main/paradox/native-image.md
@@ -1,6 +1,6 @@
 # Building Native Images
 
-Building native images with Akka HTTP is supported out of the box for the following modules:
+Building native images with Akka Management is supported out of the box for the following modules:
 
  * akka-management
  * akka-management-cluster-bootstrap

--- a/docs/src/main/paradox/native-image.md
+++ b/docs/src/main/paradox/native-image.md
@@ -1,0 +1,14 @@
+# Building Native Images
+
+Building native images with Akka HTTP is supported out of the box for the following modules:
+
+ * akka-management
+ * akka-management-cluster-bootstrap
+ * akka-management-cluster-http
+ * akka-management-discovery-kubernetes-api
+ * akka-lease-kubernetes
+ * akka-rolling-upgrade-kubernetes
+
+Other modules can likely be used but will require figuring out and adding additional native-image metadata.
+
+For details about building native images with Akka in general, see the @extref[Akka Documentation](akka:additional/native-image.html).

--- a/integration-test/dns-api-mesos/build.sbt
+++ b/integration-test/dns-api-mesos/build.sbt
@@ -14,4 +14,4 @@ libraryDependencies += "com.lightbend.akka.management" %% "akka-management-clust
 libraryDependencies += "com.lightbend.akka.management" %% "akka-management-cluster-http" % akkaManagementVersion(
   version.value)
 
-libraryDependencies += "com.typesafe.akka" %% "akka-discovery" % "2.9.0"
+libraryDependencies += "com.typesafe.akka" %% "akka-discovery" % "2.9.2"

--- a/integration-test/kubernetes-api-java/pom.xml
+++ b/integration-test/kubernetes-api-java/pom.xml
@@ -17,8 +17,8 @@
   <properties>
     <encoding>UTF-8</encoding>
     <maven.compiler.release>11</maven.compiler.release>
-    <akka.version>2.9.0</akka.version>
-    <akka.http.version>10.6.0</akka.http.version>
+    <akka.version>2.9.2</akka.version>
+    <akka.http.version>10.6.1</akka.http.version>
     <akka-management.version>1.5.0</akka-management.version>
     <scala.binary.version>2.13</scala.binary.version>
   </properties>

--- a/lease-kubernetes/src/main/resources/META-INF/native-image/com.lightbend.akka.management/akka-lease-kubernetes/reflect-config.json
+++ b/lease-kubernetes/src/main/resources/META-INF/native-image/com.lightbend.akka.management/akka-lease-kubernetes/reflect-config.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "akka.coordination.lease.kubernetes.KubernetesLease",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": ["akka.coordination.lease.LeaseSettings", "akka.actor.ExtendedActorSystem"]
+      }
+    ]
+  },
+  {
+    "name": "akka.coordination.lease.kubernetes.internal.LeaseCustomResource",
+    "allDeclaredFields": true,
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "akka.coordination.lease.kubernetes.internal.Metadata",
+    "allDeclaredFields": true,
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "akka.coordination.lease.kubernetes.internal.Spec",
+    "allDeclaredFields": true,
+    "queryAllPublicMethods": true
+  }
+]

--- a/lease-kubernetes/src/main/scala/akka/coordination/lease/kubernetes/internal/KubernetesJsonSupport.scala
+++ b/lease-kubernetes/src/main/scala/akka/coordination/lease/kubernetes/internal/KubernetesJsonSupport.scala
@@ -35,6 +35,7 @@ case class Spec(owner: String, time: Long)
  */
 @InternalApi
 trait KubernetesJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
+  // If adding more formats here, remember to also add in META-INF/native-image reflect config
   implicit val metadataFormat: JsonFormat[Metadata] = jsonFormat2(Metadata.apply)
   implicit val specFormat: JsonFormat[Spec] = jsonFormat2(Spec.apply)
   implicit val leaseCustomResourceFormat: RootJsonFormat[LeaseCustomResource] = jsonFormat4(LeaseCustomResource.apply)

--- a/management/src/main/resources/META-INF/native-image/com.lightbend.akka.management/akka-management/reflect-config.json
+++ b/management/src/main/resources/META-INF/native-image/com.lightbend.akka.management/akka-management/reflect-config.json
@@ -1,0 +1,15 @@
+[
+  {
+    "name": "akka.management.scaladsl.AkkaManagement$",
+    "fields": [ {
+      "name": "MODULE$"
+    } ]
+  },
+  {
+    "name": "akka.management.HealthCheckRoutes",
+    "methods": [{
+      "name": "<init>",
+      "parameterTypes": ["akka.actor.ExtendedActorSystem"]
+    }]
+  }
+]

--- a/native-image-tests/.gitignore
+++ b/native-image-tests/.gitignore
@@ -1,0 +1,12 @@
+target/
+
+.settings
+.project
+.classpath
+
+.idea
+*.iml
+
+.metals
+.bloop
+.bsp

--- a/native-image-tests/build.sbt
+++ b/native-image-tests/build.sbt
@@ -1,0 +1,51 @@
+name := "native-image-tests"
+
+version := "1.0"
+
+scalaVersion := s"2.13.12"
+
+resolvers += "Akka library repository".at("https://repo.akka.io/maven")
+
+lazy val akkaVersion = sys.props.getOrElse("akka.version", "2.9.1")
+lazy val akkaHttpVersion = sys.props.getOrElse("akka.http.version", "10.6.0")
+
+// Note: this default isn't really used anywhere so not important to bump
+lazy val akkaManagementVersion = sys.props.getOrElse("akka.management.version", "1.5.0")
+
+// Run in a separate JVM, to make sure sbt waits until all threads have
+// finished before returning.
+// If you want to keep the application running while executing other
+// sbt tasks, consider https://github.com/spray/sbt-revolver/
+fork := true
+
+libraryDependencies ++= Seq(
+  "com.typesafe.akka" %% "akka-actor-typed" % akkaVersion,
+  "com.typesafe.akka" %% "akka-cluster-typed" % akkaVersion,
+  "com.typesafe.akka" %% "akka-cluster" % akkaVersion,
+  "com.typesafe.akka" %% "akka-discovery" % akkaVersion,
+  "com.typesafe.akka" %% "akka-persistence" % akkaVersion,
+  "com.typesafe.akka" %% "akka-cluster-sharding" % akkaVersion,
+  "com.typesafe.akka" %% "akka-remote" % akkaVersion,
+  "com.typesafe.akka" %% "akka-http" % akkaHttpVersion,
+  "com.typesafe.akka" %% "akka-http-core" % akkaHttpVersion,
+  "com.typesafe.akka" %% "akka-http-spray-json" % akkaHttpVersion,
+  "com.lightbend.akka.management" %% "akka-management" % akkaManagementVersion,
+  "com.lightbend.akka.management" %% "akka-management-cluster-bootstrap" % akkaManagementVersion,
+  "com.lightbend.akka.management" %% "akka-management-cluster-http" % akkaManagementVersion,
+  "com.lightbend.akka.discovery" %% "akka-discovery-kubernetes-api" % akkaManagementVersion,
+  "com.lightbend.akka.management" %% "akka-lease-kubernetes" % akkaManagementVersion,
+  "com.lightbend.akka.management" %% "akka-rolling-update-kubernetes" % akkaManagementVersion,
+  "ch.qos.logback" % "logback-classic" % "1.2.13"
+)
+
+// useful for investigations: sbt nativeImageRunAgent
+
+// GraalVM native image build
+enablePlugins(NativeImagePlugin)
+nativeImageJvm := "graalvm-community"
+nativeImageVersion := "21.0.2"
+nativeImageOptions := Seq(
+  "--no-fallback",
+  "--verbose",
+  "-Dakka.native-image.debug=true"
+)

--- a/native-image-tests/build.sbt
+++ b/native-image-tests/build.sbt
@@ -2,7 +2,7 @@ name := "native-image-tests"
 
 version := "1.0"
 
-scalaVersion := s"2.13.12"
+scalaVersion := "2.13.12"
 
 resolvers += "Akka library repository".at("https://repo.akka.io/maven")
 
@@ -47,5 +47,6 @@ nativeImageVersion := "21.0.2"
 nativeImageOptions := Seq(
   "--no-fallback",
   "--verbose",
+  "--initialize-at-build-time=ch.qos.logback",
   "-Dakka.native-image.debug=true"
 )

--- a/native-image-tests/build.sbt
+++ b/native-image-tests/build.sbt
@@ -6,8 +6,8 @@ scalaVersion := "2.13.12"
 
 resolvers += "Akka library repository".at("https://repo.akka.io/maven")
 
-lazy val akkaVersion = sys.props.getOrElse("akka.version", "2.9.1")
-lazy val akkaHttpVersion = sys.props.getOrElse("akka.http.version", "10.6.0")
+lazy val akkaVersion = sys.props.getOrElse("akka.version", "2.9.2")
+lazy val akkaHttpVersion = sys.props.getOrElse("akka.http.version", "10.6.1")
 
 // Note: this default isn't really used anywhere so not important to bump
 lazy val akkaManagementVersion = sys.props.getOrElse("akka.management.version", "1.5.0")

--- a/native-image-tests/project/build.properties
+++ b/native-image-tests/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.9.8

--- a/native-image-tests/project/plugins.sbt
+++ b/native-image-tests/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scalameta" % "sbt-native-image" % "0.3.4")

--- a/native-image-tests/src/main/resources/application.conf
+++ b/native-image-tests/src/main/resources/application.conf
@@ -35,3 +35,6 @@ akka {
     downing-provider-class = "akka.cluster.sbr.SplitBrainResolverProvider"
   }
 }
+
+# just to keep the class name out of graalvms sight
+pod-cost-class = "akka.rollingupdate.kubernetes.PodDeletionCost"

--- a/native-image-tests/src/main/resources/application.conf
+++ b/native-image-tests/src/main/resources/application.conf
@@ -1,0 +1,37 @@
+akka {
+  actor.provider = "cluster"
+  extensions = ["akka.management.cluster.bootstrap.ClusterBootstrap"]
+
+
+  discovery {
+    aggregate {
+      discovery-methods = ["kubernetes-api", "config"]
+    }
+    config.services.local-cluster.endpoints = [
+      {
+        host = "127.0.0.1"
+        port = 8558
+      }
+    ]
+  }
+
+
+  management {
+    http.hostname = "127.0.0.1"
+    http.port = 8558
+    cluster.bootstrap {
+      contact-point-discovery {
+        # to allow easier testing, we aggregate kubernetes-api and then use config as a fallback,
+        # native-image-brokenness would cause class not found or linker error, so k8 api discovery failing because
+        # not running inside k8 means things likely works as expected (not a watertight check though)
+        discovery-method = aggregate
+        service-name = "local-cluster"
+        required-contact-point-nr = 1
+      }
+    }
+  }
+
+  cluster {
+    downing-provider-class = "akka.cluster.sbr.SplitBrainResolverProvider"
+  }
+}

--- a/native-image-tests/src/main/resources/logback.xml
+++ b/native-image-tests/src/main/resources/logback.xml
@@ -1,0 +1,20 @@
+<configuration>
+    <!-- This is a development logging configuration that logs to standard out, for an example of a production
+        logging config, see the Akka docs: https://doc.akka.io/docs/akka/2.6/typed/logging.html#logback -->
+    <appender name="STDOUT" target="System.out" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>[%date{ISO8601}] [%level] [%logger] [%thread] [%X{akkaSource}] - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="ASYNC" class="ch.qos.logback.classic.AsyncAppender">
+        <queueSize>1024</queueSize>
+        <neverBlock>true</neverBlock>
+        <appender-ref ref="STDOUT" />
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="ASYNC"/>
+    </root>
+
+</configuration>

--- a/native-image-tests/src/main/resources/logback.xml
+++ b/native-image-tests/src/main/resources/logback.xml
@@ -7,14 +7,8 @@
         </encoder>
     </appender>
 
-    <appender name="ASYNC" class="ch.qos.logback.classic.AsyncAppender">
-        <queueSize>1024</queueSize>
-        <neverBlock>true</neverBlock>
-        <appender-ref ref="STDOUT" />
-    </appender>
-
     <root level="INFO">
-        <appender-ref ref="ASYNC"/>
+        <appender-ref ref="STDOUT"/>
     </root>
 
 </configuration>

--- a/native-image-tests/src/main/scala/com/lightbend/Main.scala
+++ b/native-image-tests/src/main/scala/com/lightbend/Main.scala
@@ -1,16 +1,40 @@
 package com.lightbend
 
+import akka.actor.ExtendedActorSystem
+import akka.actor.ExtensionId
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.Behavior
 import akka.actor.typed.scaladsl.Behaviors
 import akka.cluster.typed.Cluster
 import akka.cluster.typed.SelfUp
 import akka.cluster.typed.Subscribe
+import akka.coordination.lease.LeaseSettings
 import akka.management.scaladsl.AkkaManagement
 
 import scala.concurrent.duration.DurationInt
 
 object RootBehavior {
+
+  def checkK8Lease(system: ActorSystem[_]): Unit = {
+    // this throws if not all spray-json metadata in place
+    new akka.coordination.lease.kubernetes.internal.KubernetesJsonSupport {}
+
+    // we can't really set up the lease but it is expected to be constructed via config/reflection, so let's check access
+    // that native-image can't guess
+    val exensionNameClass = system.settings.config.getString("akka.coordination.lease.kubernetes.lease-class")
+    val clazz = system.dynamicAccess.getClassFor[akka.coordination.lease.scaladsl.Lease](exensionNameClass).get
+    // we cant really call it though, but would get a NoSuchMethod here if it can't be found
+    clazz.getConstructor(classOf[LeaseSettings], classOf[ExtendedActorSystem])
+
+  }
+
+  def checkK8RollingUpdate(system: ActorSystem[_]): Unit = {
+    // this throws if not all spray-json metadata in place
+    new akka.rollingupdate.kubernetes.KubernetesJsonSupport {}
+    val extensionClazzName = system.settings.config.getString("pod-cost-class")
+    system.dynamicAccess.getObjectFor[ExtensionId[_]](extensionClazzName).get
+  }
+
   def apply(): Behavior[AnyRef] = Behaviors.setup { context =>
     Behaviors.withTimers { timers =>
       // Note that some exceptions in the log from k8 api discovery is expected, see application.conf
@@ -18,8 +42,9 @@ object RootBehavior {
       timers.startSingleTimer("Timeout", 30.seconds)
       Cluster(context.system).subscriptions ! Subscribe(context.self, classOf[SelfUp])
 
-      // FIXME cover k8 lease
-      // FIXME cover rolling-update
+      // best effort coverage of k8 lease and rolling update without actually using them
+      checkK8RollingUpdate(context.system)
+      checkK8Lease(context.system)
 
       Behaviors.receiveMessagePartial {
         case SelfUp(_) =>

--- a/native-image-tests/src/main/scala/com/lightbend/Main.scala
+++ b/native-image-tests/src/main/scala/com/lightbend/Main.scala
@@ -1,0 +1,42 @@
+package com.lightbend
+
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.Behavior
+import akka.actor.typed.scaladsl.Behaviors
+import akka.cluster.typed.Cluster
+import akka.cluster.typed.SelfUp
+import akka.cluster.typed.Subscribe
+import akka.management.scaladsl.AkkaManagement
+
+import scala.concurrent.duration.DurationInt
+
+object RootBehavior {
+  def apply(): Behavior[AnyRef] = Behaviors.setup { context =>
+    Behaviors.withTimers { timers =>
+      // Note that some exceptions in the log from k8 api discovery is expected, see application.conf
+      AkkaManagement(context.system).start()
+      timers.startSingleTimer("Timeout", 30.seconds)
+      Cluster(context.system).subscriptions ! Subscribe(context.self, classOf[SelfUp])
+
+      // FIXME cover k8 lease
+      // FIXME cover rolling-update
+
+      Behaviors.receiveMessagePartial {
+        case SelfUp(_) =>
+          context.log.info("Managed to bootstrap cluster, shutting down")
+          Behaviors.stopped
+
+        case "Timeout" =>
+          context.log.error("Didn't manage to bootstrap within 30s, something is off")
+          System.exit(1)
+          Behaviors.same
+      }
+    }
+  }
+}
+
+object Main extends App {
+
+  val system: ActorSystem[AnyRef] = ActorSystem(RootBehavior(), "ManagementNativeImageTests")
+
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,10 +8,10 @@ object Dependencies {
   val CrossScalaVersions = Seq(Scala213, Scala3)
 
   // Align the versions in integration-test/kubernetes-api-java/pom.xml
-  val AkkaVersion = "2.9.0"
+  val AkkaVersion = "2.9.2"
   val AkkaBinaryVersion = "2.9"
   // Align the versions in integration-test/kubernetes-api-java/pom.xml
-  val AkkaHttpVersion = "10.6.0"
+  val AkkaHttpVersion = "10.6.1"
   val AkkaHttpBinaryVersion = "10.6"
 
   val ScalaTestVersion = "3.2.18"

--- a/rolling-update-kubernetes/src/main/resources/META-INF/native-image/com.lightbend.akka.management/akka-rolling-upgrade-kubernetes/reflect-config.json
+++ b/rolling-update-kubernetes/src/main/resources/META-INF/native-image/com.lightbend.akka.management/akka-rolling-upgrade-kubernetes/reflect-config.json
@@ -1,0 +1,77 @@
+[
+  {
+    "name": "akka.rollingupdate.kubernetes.AppVersionRevision$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "akka.rollingupdate.kubernetes.PodDeletionCost$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "akka.management.cluster.bootstrap.ClusterBootstrap",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": ["akka.actor.ExtendedActorSystem"]
+      }
+    ]
+  },
+  {
+    "name": "akka.rollingupdate.kubernetes.Metadata",
+    "allDeclaredFields": true,
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "akka.rollingupdate.kubernetes.PodCost",
+    "allDeclaredFields": true,
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "akka.rollingupdate.kubernetes.Spec",
+    "allDeclaredFields": true,
+    "queryAllPublicMethods": true
+  },
+   {
+    "name": "akka.rollingupdate.kubernetes.PodCostCustomResource",
+    "allDeclaredFields": true,
+    "queryAllPublicMethods": true
+  },
+   {
+    "name": "akka.rollingupdate.kubernetes.PodOwnerRef",
+    "allDeclaredFields": true,
+    "queryAllPublicMethods": true
+  },
+   {
+    "name": "akka.rollingupdate.kubernetes.PodMetadata",
+    "allDeclaredFields": true,
+    "queryAllPublicMethods": true
+  },
+   {
+    "name": "akka.rollingupdate.kubernetes.Pod",
+    "allDeclaredFields": true,
+    "queryAllPublicMethods": true
+  },
+   {
+    "name": "akka.rollingupdate.kubernetes.ReplicaAnnotation",
+    "allDeclaredFields": true,
+    "queryAllPublicMethods": true
+  },
+   {
+    "name": "akka.rollingupdate.kubernetes.ReplicaSetMetadata",
+    "allDeclaredFields": true,
+    "queryAllPublicMethods": true
+  },
+   {
+    "name": "akka.rollingupdate.kubernetes.ReplicaSet",
+    "allDeclaredFields": true,
+    "queryAllPublicMethods": true
+  }
+]

--- a/rolling-update-kubernetes/src/main/scala/akka/rollingupdate/kubernetes/KubernetesJsonSupport.scala
+++ b/rolling-update-kubernetes/src/main/scala/akka/rollingupdate/kubernetes/KubernetesJsonSupport.scala
@@ -75,6 +75,7 @@ case class Spec(pods: immutable.Seq[PodCost])
  */
 @InternalApi
 trait KubernetesJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
+  // If adding more formats here, remember to also add in META-INF/native-image reflect config
   implicit val metadataFormat: JsonFormat[Metadata] = jsonFormat2(Metadata.apply)
   implicit val podCostFormat: JsonFormat[PodCost] = jsonFormat5(PodCost.apply)
   implicit val specFormat: JsonFormat[Spec] = jsonFormat1(Spec.apply)


### PR DESCRIPTION
Depends on upstream https://github.com/akka/akka/pull/32308 and https://github.com/akka/akka-http/pull/4349 

Test is passing locally, not completely water tight but hopefully good enough, it avoids another CI job on actual k8 which has been a repeated pain.