### PR TITLE
Add dependencies to same version check

### DIFF
--- a/management/src/main/scala/akka/management/scaladsl/AkkaManagement.scala
+++ b/management/src/main/scala/akka/management/scaladsl/AkkaManagement.scala
@@ -62,9 +62,11 @@ final class AkkaManagement(implicit private[akka] val system: ExtendedActorSyste
       "akka-discovery-marathon-api",
       "akka-discovery-aws-api-async",
       "akka-discovery-kubernetes-api",
+      "akka-lease-kubernetes",
       "akka-management",
       "akka-management-cluster-bootstrap",
-      "akka-management-cluster-http"
+      "akka-management-cluster-http",
+      "akka-rolling-update-kubernetes"
     ),
     logWarning = true
   )


### PR DESCRIPTION
Applying this PR will add the (newer) akka-lease-kubernetes and akka-rolling-update-kubernetes dependencies to the same version check. I think maybe this was missed when the modules were introduced.