### PR TITLE
build: License change date for 1.5.2, Akka and HTTP bumps, sample updates

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -3,7 +3,7 @@ Business Source License 1.1
 Parameters
 
 Licensor:             Lightbend, Inc.
-Licensed Work:        Akka Management 1.5.1
+Licensed Work:        Akka Management 1.5.2
                       This license applies to all sub directories and files
                       UNLESS another license file is present in a sub
                       directory, then that other license applies to all files
@@ -19,7 +19,7 @@ Additional Use Grant:
     Connecting to a Play Framework websocket and/or Play Framework
     request/response bodies for server and play-ws client.
 
-Change Date:          2027-02-28
+Change Date:          2027-05-13
 
 Change License:       Apache License, Version 2.0
 

--- a/integration-test/dns-api-mesos/build.sbt
+++ b/integration-test/dns-api-mesos/build.sbt
@@ -14,4 +14,4 @@ libraryDependencies += "com.lightbend.akka.management" %% "akka-management-clust
 libraryDependencies += "com.lightbend.akka.management" %% "akka-management-cluster-http" % akkaManagementVersion(
   version.value)
 
-libraryDependencies += "com.typesafe.akka" %% "akka-discovery" % "2.9.2"
+libraryDependencies += "com.typesafe.akka" %% "akka-discovery" % "2.9.3"

--- a/integration-test/kubernetes-api-java/pom.xml
+++ b/integration-test/kubernetes-api-java/pom.xml
@@ -17,8 +17,8 @@
   <properties>
     <encoding>UTF-8</encoding>
     <maven.compiler.release>11</maven.compiler.release>
-    <akka.version>2.9.2</akka.version>
-    <akka.http.version>10.6.1</akka.http.version>
+    <akka.version>2.9.3</akka.version>
+    <akka.http.version>10.6.3</akka.http.version>
     <akka-management.version>1.5.0</akka-management.version>
     <scala.binary.version>2.13</scala.binary.version>
   </properties>

--- a/native-image-tests/build.sbt
+++ b/native-image-tests/build.sbt
@@ -6,8 +6,8 @@ scalaVersion := "2.13.13"
 
 resolvers += "Akka library repository".at("https://repo.akka.io/maven")
 
-lazy val akkaVersion = sys.props.getOrElse("akka.version", "2.9.2")
-lazy val akkaHttpVersion = sys.props.getOrElse("akka.http.version", "10.6.1")
+lazy val akkaVersion = sys.props.getOrElse("akka.version", "2.9.3")
+lazy val akkaHttpVersion = sys.props.getOrElse("akka.http.version", "10.6.3")
 
 // Note: this default isn't really used anywhere so not important to bump
 lazy val akkaManagementVersion = sys.props.getOrElse("akka.management.version", "1.5.0")

--- a/samples/akka-sample-cluster-kubernetes-java/pom.xml
+++ b/samples/akka-sample-cluster-kubernetes-java/pom.xml
@@ -10,8 +10,8 @@
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
     <encoding>UTF-8</encoding>
-    <akka.version>2.9.2</akka.version>
-    <akka-management.version>1.5.1</akka-management.version>
+    <akka.version>2.9.3</akka.version>
+    <akka-management.version>1.5.2</akka-management.version>
     <akka-http.version>10.6.2</akka-http.version>
     <scala.binary.version>2.13</scala.binary.version>
     <version.number>${git.commit.time}-${git.commit.id.abbrev}</version.number>

--- a/samples/akka-sample-cluster-kubernetes-scala/build.sbt
+++ b/samples/akka-sample-cluster-kubernetes-scala/build.sbt
@@ -4,8 +4,8 @@ name := "akka-sample-cluster-kubernetes"
 
 scalaVersion := "2.13.13"
 lazy val akkaHttpVersion = "10.6.2"
-lazy val akkaVersion = "2.9.2"
-lazy val akkaManagementVersion = "1.5.1"
+lazy val akkaVersion = "2.9.3"
+lazy val akkaManagementVersion = "1.5.2"
 
 // make version compatible with docker for publishing
 ThisBuild / dynverSeparator := "-"


### PR DESCRIPTION
Refs https://github.com/akka/akka-management/issues/1289

Akka 2.9.3
Akka HTTP 10.6.3 
Samples bumped to 1.5.2 so will not pass

Never mind the branch name, got the version wrong there...