### PR TITLE
chore: Exclude samples from FOSSA scanning

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -6,3 +6,4 @@ paths:
   exclude:
     - ./integration-test
     - ./native-image-tests
+    - samples


### PR DESCRIPTION
We don't need FOSSA to scan projects in samples directory, so configure to exclude this directory

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References lightbend/akka-meta/issues#488
