### PR TITLE
feat: configurable choice of annotations for rolling update revision

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ target/
 
 # attachments created by scripts/prepare-downloads.sh
 docs/src/main/paradox/attachments
+
+# Metals detritus
+project/project

--- a/.gitignore
+++ b/.gitignore
@@ -12,11 +12,12 @@ target/
 *.class
 *.log
 
-.metals
 .vscode
 
 # attachments created by scripts/prepare-downloads.sh
 docs/src/main/paradox/attachments
 
 # Metals detritus
-project/project
+.metals
+metals.sbt
+**/project/project

--- a/docs/src/main/paradox/rolling-updates.md
+++ b/docs/src/main/paradox/rolling-updates.md
@@ -237,7 +237,7 @@ Java
 
 #### Configuration
 
-The following configuration is required, more details for each and additional configurations can be found in [reference.conf](https://github.com/akka/akka-management/blob/main/rolling-updates-kubernetes/src/main/resources/reference.conf):
+The following configuration is required, more details for each and additional configurations can be found in [reference.conf](https://github.com/akka/akka-management/blob/main/rolling-update-kubernetes/src/main/resources/reference.conf):
 
 * `akka.rollingupdate.kubernetes.pod-name`: this can be provided by setting `KUBERNETES_POD_NAME` environment variable to `metadata.name` on the Kubernetes container spec.
 

--- a/integration-test/rolling-update-kubernetes/src/test/scala/akka/rollingupdate/kubernetes/KubernetesApiIntegrationTest.scala
+++ b/integration-test/rolling-update-kubernetes/src/test/scala/akka/rollingupdate/kubernetes/KubernetesApiIntegrationTest.scala
@@ -64,7 +64,7 @@ class KubernetesApiIntegrationTest
       crName = None,
       cleanupAfter = 60.seconds
     ),
-    revisionAnnotations = KubernetesJsonSupport.defaultRevisionAnnotations.revisionAnnotations
+    revisionAnnotation = KubernetesJsonSupport.defaultRevisionAnnotation.revisionAnnotation
   )
 
   private val underTest =

--- a/integration-test/rolling-update-kubernetes/src/test/scala/akka/rollingupdate/kubernetes/KubernetesApiIntegrationTest.scala
+++ b/integration-test/rolling-update-kubernetes/src/test/scala/akka/rollingupdate/kubernetes/KubernetesApiIntegrationTest.scala
@@ -64,7 +64,7 @@ class KubernetesApiIntegrationTest
       crName = None,
       cleanupAfter = 60.seconds
     ),
-    revisionAnnotation = KubernetesJsonSupport.defaultRevisionAnnotation.revisionAnnotation
+    revisionAnnotation = "deployment.kubernetes.io/revision"
   )
 
   private val underTest =

--- a/integration-test/rolling-update-kubernetes/src/test/scala/akka/rollingupdate/kubernetes/KubernetesApiIntegrationTest.scala
+++ b/integration-test/rolling-update-kubernetes/src/test/scala/akka/rollingupdate/kubernetes/KubernetesApiIntegrationTest.scala
@@ -63,7 +63,8 @@ class KubernetesApiIntegrationTest
       enabled = true,
       crName = None,
       cleanupAfter = 60.seconds
-    )
+    ),
+    revisionAnnotations = KubernetesJsonSupport.defaultRevisionAnnotations.revisionAnnotations
   )
 
   private val underTest =

--- a/rolling-update-kubernetes/src/main/resources/reference.conf
+++ b/rolling-update-kubernetes/src/main/resources/reference.conf
@@ -34,10 +34,10 @@ akka.rollingupdate.kubernetes {
     pod-name = ""
     pod-name = ${?KUBERNETES_POD_NAME}
 
-	# Annotations to check to determine the revision.  The first one in the list which matches
-	# wins.  The default is suitable for "vanilla" Kubernetes Deployments, but other CI/CD systems
-	# may set a different annotation.
-	revision-annotation = [ "deployment.kubernetes.io/revision" ]
+    # Annotations to check to determine the revision.  The first one in the list which matches
+    # wins.  The default is suitable for "vanilla" Kubernetes Deployments, but other CI/CD systems
+    # may set a different annotation.
+    revision-annotation = [ "deployment.kubernetes.io/revision" ]
 
     secure-api-server = true
 

--- a/rolling-update-kubernetes/src/main/resources/reference.conf
+++ b/rolling-update-kubernetes/src/main/resources/reference.conf
@@ -34,6 +34,11 @@ akka.rollingupdate.kubernetes {
     pod-name = ""
     pod-name = ${?KUBERNETES_POD_NAME}
 
+	# Annotations to check to determine the revision.  The first one in the list which matches
+	# wins.  The default is suitable for "vanilla" Kubernetes Deployments, but other CI/CD systems
+	# may set a different annotation.
+	revision-annotation = [ "deployment.kubernetes.io/revision" ]
+
     secure-api-server = true
 
     # Configuration for the Pod Deletion Cost extension

--- a/rolling-update-kubernetes/src/main/resources/reference.conf
+++ b/rolling-update-kubernetes/src/main/resources/reference.conf
@@ -35,7 +35,7 @@ akka.rollingupdate.kubernetes {
     pod-name = ${?KUBERNETES_POD_NAME}
 
     # Annotations to check to determine the revision.  The default is suitable for "vanilla"
-	# Kubernetes Deployments, but other CI/CD systems may set a different annotation.
+    # Kubernetes Deployments, but other CI/CD systems may set a different annotation.
     revision-annotation = "deployment.kubernetes.io/revision"
 
     secure-api-server = true

--- a/rolling-update-kubernetes/src/main/resources/reference.conf
+++ b/rolling-update-kubernetes/src/main/resources/reference.conf
@@ -34,10 +34,9 @@ akka.rollingupdate.kubernetes {
     pod-name = ""
     pod-name = ${?KUBERNETES_POD_NAME}
 
-    # Annotations to check to determine the revision.  The first one in the list which matches
-    # wins.  The default is suitable for "vanilla" Kubernetes Deployments, but other CI/CD systems
-    # may set a different annotation.
-    revision-annotation = [ "deployment.kubernetes.io/revision" ]
+    # Annotations to check to determine the revision.  The default is suitable for "vanilla"
+	# Kubernetes Deployments, but other CI/CD systems may set a different annotation.
+    revision-annotation = "deployment.kubernetes.io/revision"
 
     secure-api-server = true
 

--- a/rolling-update-kubernetes/src/main/scala/akka/rollingupdate/kubernetes/KubernetesApiImpl.scala
+++ b/rolling-update-kubernetes/src/main/scala/akka/rollingupdate/kubernetes/KubernetesApiImpl.scala
@@ -55,6 +55,8 @@ import scala.util.control.NonFatal
 
   import system.dispatcher
 
+  override val _revisionAnnotations = settings
+
   private implicit val sys: ActorSystem = system
   private val log = Logging(system, classOf[KubernetesApiImpl])
   private val http = Http()(system)
@@ -93,6 +95,7 @@ import scala.util.control.NonFatal
       case HttpResponse(status, _, e, _) =>
         e.discardBytes()
         throw new PodCostException(s"Request failed with status=$status")
+      // Can we make this exhaustive?
     }
   }
 
@@ -213,7 +216,7 @@ PUTs must contain resourceVersions. Response:
         case None              => Future.failed(new ReadRevisionException("No replica name found"))
       }
 
-      val revision = replicaSet.map(_.metadata.annotations.`deployment.kubernetes.io/revision`)
+      val revision = replicaSet.map(_.metadata.annotations.revision)
       revision.map(Some(_)).recoverWith {
         case ex =>
           if (tries >= maxTries) {

--- a/rolling-update-kubernetes/src/main/scala/akka/rollingupdate/kubernetes/KubernetesApiImpl.scala
+++ b/rolling-update-kubernetes/src/main/scala/akka/rollingupdate/kubernetes/KubernetesApiImpl.scala
@@ -55,7 +55,7 @@ import scala.util.control.NonFatal
 
   import system.dispatcher
 
-  override val _revisionAnnotation: HasRevisionAnnotation = settings
+  override val revisionAnnotation = settings.revisionAnnotation
 
   private implicit val sys: ActorSystem = system
   private val log = Logging(system, classOf[KubernetesApiImpl])

--- a/rolling-update-kubernetes/src/main/scala/akka/rollingupdate/kubernetes/KubernetesApiImpl.scala
+++ b/rolling-update-kubernetes/src/main/scala/akka/rollingupdate/kubernetes/KubernetesApiImpl.scala
@@ -55,7 +55,7 @@ import scala.util.control.NonFatal
 
   import system.dispatcher
 
-  override val _revisionAnnotations = settings
+  override val _revisionAnnotation: HasRevisionAnnotation = settings
 
   private implicit val sys: ActorSystem = system
   private val log = Logging(system, classOf[KubernetesApiImpl])

--- a/rolling-update-kubernetes/src/main/scala/akka/rollingupdate/kubernetes/KubernetesJsonSupport.scala
+++ b/rolling-update-kubernetes/src/main/scala/akka/rollingupdate/kubernetes/KubernetesJsonSupport.scala
@@ -78,9 +78,7 @@ case class Spec(pods: immutable.Seq[PodCost])
  */
 @InternalApi
 trait KubernetesJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
-  val _revisionAnnotations: HasRevisionAnnotations = new HasRevisionAnnotations {
-    def revisionAnnotations = Seq("deployment.kubernetes.io/revision")
-  }
+  val _revisionAnnotations: HasRevisionAnnotations = KubernetesJsonSupport.defaultRevisionAnnotations
 
   // If adding more formats here, remember to also add in META-INF/native-image reflect config
   implicit val metadataFormat: JsonFormat[Metadata] = jsonFormat2(Metadata.apply)
@@ -124,4 +122,10 @@ trait KubernetesJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
 
   implicit val replicaSetMedatataFormat: JsonFormat[ReplicaSetMetadata] = jsonFormat1(ReplicaSetMetadata.apply)
   implicit val podReplicaSetFormat: RootJsonFormat[ReplicaSet] = jsonFormat1(ReplicaSet.apply)
+}
+
+private[kubernetes] object KubernetesJsonSupport {
+  val defaultRevisionAnnotations: HasRevisionAnnotations = new HasRevisionAnnotations {
+    val revisionAnnotations = Seq("deployment.kubernetes.io/revision")
+  }
 }

--- a/rolling-update-kubernetes/src/main/scala/akka/rollingupdate/kubernetes/KubernetesJsonSupport.scala
+++ b/rolling-update-kubernetes/src/main/scala/akka/rollingupdate/kubernetes/KubernetesJsonSupport.scala
@@ -10,13 +10,16 @@ import akka.annotation.InternalApi
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import spray.json.DefaultJsonProtocol
 import spray.json.JsonFormat
+import spray.json.JsObject
 import spray.json.RootJsonFormat
+import spray.json.JsString
+import spray.json.JsValue
 
 /**
  * INTERNAL API
  */
 @InternalApi
-case class ReplicaAnnotation(`deployment.kubernetes.io/revision`: String)
+case class ReplicaAnnotation(revision: String, source: String, otherAnnotations: Map[String, JsValue])
 
 /**
  * INTERNAL API
@@ -75,6 +78,10 @@ case class Spec(pods: immutable.Seq[PodCost])
  */
 @InternalApi
 trait KubernetesJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
+  val _revisionAnnotations: HasRevisionAnnotations = new HasRevisionAnnotations {
+    def revisionAnnotations = Seq("deployment.kubernetes.io/revision")
+  }
+
   // If adding more formats here, remember to also add in META-INF/native-image reflect config
   implicit val metadataFormat: JsonFormat[Metadata] = jsonFormat2(Metadata.apply)
   implicit val podCostFormat: JsonFormat[PodCost] = jsonFormat5(PodCost.apply)
@@ -86,7 +93,35 @@ trait KubernetesJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
   implicit val podMetadataFormat: JsonFormat[PodMetadata] = jsonFormat1(PodMetadata.apply)
   implicit val podFormat: RootJsonFormat[Pod] = jsonFormat1(Pod.apply)
 
-  implicit val replicaAnnotationFormat: JsonFormat[ReplicaAnnotation] = jsonFormat1(ReplicaAnnotation.apply)
+  implicit val replicaAnnotationFormat: RootJsonFormat[ReplicaAnnotation] =
+    new RootJsonFormat[ReplicaAnnotation] {
+      // Not sure if we ever write this out, but if we do, this will let us write out exactly what we took in
+      def write(ra: ReplicaAnnotation): JsValue =
+        if (ra.revision.nonEmpty && ra.source.nonEmpty) {
+          JsObject(ra.otherAnnotations + (ra.source -> JsString(ra.revision)))
+        } else JsObject(ra.otherAnnotations)
+
+      def read(json: JsValue): ReplicaAnnotation = {
+        json match {
+          case JsObject(fields) =>
+            _revisionAnnotations.revisionAnnotations.find { annotation =>
+              fields.get(annotation).exists(_.isInstanceOf[JsString])
+            } match {
+              case Some(winningAnnotation) =>
+                ReplicaAnnotation(
+                  fields(winningAnnotation).asInstanceOf[JsString].value,
+                  winningAnnotation,
+                  fields - winningAnnotation)
+
+              case None =>
+                ReplicaAnnotation("", "", fields)
+            }
+
+          case _ => spray.json.deserializationError("expected an object")
+        }
+      }
+    }
+
   implicit val replicaSetMedatataFormat: JsonFormat[ReplicaSetMetadata] = jsonFormat1(ReplicaSetMetadata.apply)
   implicit val podReplicaSetFormat: RootJsonFormat[ReplicaSet] = jsonFormat1(ReplicaSet.apply)
 }

--- a/rolling-update-kubernetes/src/main/scala/akka/rollingupdate/kubernetes/KubernetesJsonSupport.scala
+++ b/rolling-update-kubernetes/src/main/scala/akka/rollingupdate/kubernetes/KubernetesJsonSupport.scala
@@ -78,7 +78,7 @@ case class Spec(pods: immutable.Seq[PodCost])
  */
 @InternalApi
 trait KubernetesJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
-  val _revisionAnnotation: HasRevisionAnnotation = KubernetesJsonSupport.defaultRevisionAnnotation
+  val revisionAnnotation: String
 
   // If adding more formats here, remember to also add in META-INF/native-image reflect config
   implicit val metadataFormat: JsonFormat[Metadata] = jsonFormat2(Metadata.apply)
@@ -102,10 +102,9 @@ trait KubernetesJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
       def read(json: JsValue): ReplicaAnnotation = {
         json match {
           case JsObject(fields) =>
-            val annotation = _revisionAnnotation.revisionAnnotation
-            fields.get(annotation) match {
+            fields.get(revisionAnnotation) match {
               case Some(JsString(foundRevision)) =>
-                ReplicaAnnotation(foundRevision, annotation, fields - annotation)
+                ReplicaAnnotation(foundRevision, revisionAnnotation, fields - revisionAnnotation)
 
               case _ =>
                 ReplicaAnnotation("", "", fields)
@@ -118,10 +117,4 @@ trait KubernetesJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
 
   implicit val replicaSetMedatataFormat: JsonFormat[ReplicaSetMetadata] = jsonFormat1(ReplicaSetMetadata.apply)
   implicit val podReplicaSetFormat: RootJsonFormat[ReplicaSet] = jsonFormat1(ReplicaSet.apply)
-}
-
-private[kubernetes] object KubernetesJsonSupport {
-  val defaultRevisionAnnotation: HasRevisionAnnotation = new HasRevisionAnnotation {
-    val revisionAnnotation = "deployment.kubernetes.io/revision"
-  }
 }

--- a/rolling-update-kubernetes/src/main/scala/akka/rollingupdate/kubernetes/KubernetesSettings.scala
+++ b/rolling-update-kubernetes/src/main/scala/akka/rollingupdate/kubernetes/KubernetesSettings.scala
@@ -50,7 +50,7 @@ private[kubernetes] object KubernetesSettings {
       config.getBoolean("secure-api-server"),
       config.getDuration("api-service-request-timeout").asScala,
       customResourceSettings,
-      config.getStringList("revision-annotation").asScala.toList
+      config.getString("revision-annotation")
     )
   }
 }
@@ -70,16 +70,16 @@ private[kubernetes] class KubernetesSettings(
     val secure: Boolean,
     val apiServiceRequestTimeout: FiniteDuration,
     val customResourceSettings: CustomResourceSettings,
-    val revisionAnnotations: Seq[String],
+    val revisionAnnotation: String,
     val bodyReadTimeout: FiniteDuration = 1.second
-) extends HasRevisionAnnotations
+) extends HasRevisionAnnotation
 
 /**
  * INTERNAL API
  */
 @InternalApi
-private[kubernetes] trait HasRevisionAnnotations {
-  def revisionAnnotations: Seq[String]
+private[kubernetes] trait HasRevisionAnnotation {
+  def revisionAnnotation: String
 }
 
 /**

--- a/rolling-update-kubernetes/src/main/scala/akka/rollingupdate/kubernetes/KubernetesSettings.scala
+++ b/rolling-update-kubernetes/src/main/scala/akka/rollingupdate/kubernetes/KubernetesSettings.scala
@@ -72,15 +72,7 @@ private[kubernetes] class KubernetesSettings(
     val customResourceSettings: CustomResourceSettings,
     val revisionAnnotation: String,
     val bodyReadTimeout: FiniteDuration = 1.second
-) extends HasRevisionAnnotation
-
-/**
- * INTERNAL API
- */
-@InternalApi
-private[kubernetes] trait HasRevisionAnnotation {
-  def revisionAnnotation: String
-}
+)
 
 /**
  * INTERNAL API

--- a/rolling-update-kubernetes/src/main/scala/akka/rollingupdate/kubernetes/KubernetesSettings.scala
+++ b/rolling-update-kubernetes/src/main/scala/akka/rollingupdate/kubernetes/KubernetesSettings.scala
@@ -4,10 +4,12 @@
 
 package akka.rollingupdate.kubernetes
 
-import scala.concurrent.duration._
 import akka.util.JavaDurationConverters._
 import akka.annotation.InternalApi
 import com.typesafe.config.Config
+
+import scala.concurrent.duration._
+import scala.jdk.CollectionConverters.ListHasAsScala
 
 /**
  * INTERNAL API
@@ -47,7 +49,8 @@ private[kubernetes] object KubernetesSettings {
       config.getString("pod-name"),
       config.getBoolean("secure-api-server"),
       config.getDuration("api-service-request-timeout").asScala,
-      customResourceSettings
+      customResourceSettings,
+      config.getStringList("revision-annotation").asScala.toList
     )
   }
 }
@@ -67,8 +70,17 @@ private[kubernetes] class KubernetesSettings(
     val secure: Boolean,
     val apiServiceRequestTimeout: FiniteDuration,
     val customResourceSettings: CustomResourceSettings,
+    val revisionAnnotations: Seq[String],
     val bodyReadTimeout: FiniteDuration = 1.second
-)
+) extends HasRevisionAnnotations
+
+/**
+ * INTERNAL API
+ */
+@InternalApi
+private[kubernetes] trait HasRevisionAnnotations {
+  def revisionAnnotations: Seq[String]
+}
 
 /**
  * INTERNAL API

--- a/rolling-update-kubernetes/src/test/scala/akka/rollingupdate/kubernetes/PodDeletionCostAnnotatorCrSpec.scala
+++ b/rolling-update-kubernetes/src/test/scala/akka/rollingupdate/kubernetes/PodDeletionCostAnnotatorCrSpec.scala
@@ -115,7 +115,8 @@ class PodDeletionCostAnnotatorCrSpec
       podName = podName,
       secure = false,
       apiServiceRequestTimeout = 2.seconds,
-      customResourceSettings = new CustomResourceSettings(enabled = false, crName = None, 60.seconds)
+      customResourceSettings = new CustomResourceSettings(enabled = false, crName = None, 60.seconds),
+      revisionAnnotations = Seq("deployment.kubernetes.io/revision")
     )
   }
 

--- a/rolling-update-kubernetes/src/test/scala/akka/rollingupdate/kubernetes/PodDeletionCostAnnotatorCrSpec.scala
+++ b/rolling-update-kubernetes/src/test/scala/akka/rollingupdate/kubernetes/PodDeletionCostAnnotatorCrSpec.scala
@@ -116,7 +116,7 @@ class PodDeletionCostAnnotatorCrSpec
       secure = false,
       apiServiceRequestTimeout = 2.seconds,
       customResourceSettings = new CustomResourceSettings(enabled = false, crName = None, 60.seconds),
-      revisionAnnotations = Seq("deployment.kubernetes.io/revision")
+      revisionAnnotation = "deployment.kubernetes.io/revision"
     )
   }
 

--- a/rolling-update-kubernetes/src/test/scala/akka/rollingupdate/kubernetes/PodDeletionCostAnnotatorSpec.scala
+++ b/rolling-update-kubernetes/src/test/scala/akka/rollingupdate/kubernetes/PodDeletionCostAnnotatorSpec.scala
@@ -89,7 +89,8 @@ class PodDeletionCostAnnotatorSpec
       podName = podName,
       secure = false,
       apiServiceRequestTimeout = 2.seconds,
-      customResourceSettings = new CustomResourceSettings(enabled = false, crName = None, 60.seconds)
+      customResourceSettings = new CustomResourceSettings(enabled = false, crName = None, 60.seconds),
+      revisionAnnotations = Seq("deployment.kubernetes.io/revision")
     )
   }
 

--- a/rolling-update-kubernetes/src/test/scala/akka/rollingupdate/kubernetes/PodDeletionCostAnnotatorSpec.scala
+++ b/rolling-update-kubernetes/src/test/scala/akka/rollingupdate/kubernetes/PodDeletionCostAnnotatorSpec.scala
@@ -90,7 +90,7 @@ class PodDeletionCostAnnotatorSpec
       secure = false,
       apiServiceRequestTimeout = 2.seconds,
       customResourceSettings = new CustomResourceSettings(enabled = false, crName = None, 60.seconds),
-      revisionAnnotations = Seq("deployment.kubernetes.io/revision")
+      revisionAnnotation = "deployment.kubernetes.io/revision"
     )
   }
 


### PR DESCRIPTION
References #1302 

Adds a config setting `akka.rollingupdate.kubernetes.revision-annotation` to allow configurability (default is the prior behavior).  From there it's just dealing with Spray JSON.  Admittedly it's been a while (ever?) since I've done Spray JSON trickery, but (with apologies to Tolstoy) "all happy typeclass-and-AST JSON libraries are alike".

I don't have a k8s cluster handy to test, mind.