### PR TITLE
Only request running pods from Kubernetes API

### DIFF
--- a/discovery-azure-api/src/main/scala/akka/discovery/azureapi/rbac/aks/AzureRbacAksServiceDiscovery.scala
+++ b/discovery-azure-api/src/main/scala/akka/discovery/azureapi/rbac/aks/AzureRbacAksServiceDiscovery.scala
@@ -185,7 +185,7 @@ final class AzureRbacAksServiceDiscovery(implicit system: ExtendedActorSystem) e
     for {
       ks <- kubernetesSetup
       token <- fetchAccessToken.map(_.getToken)
-      request <- podRequest(token, ks.namespace, selector)
+      request <- podRequest(token, ks.namespace, selector, true)
       pods <- pods(ks.ctx, request, resolveTimeout)
     } yield {
       val addresses =
@@ -209,7 +209,7 @@ final class AzureRbacAksServiceDiscovery(implicit system: ExtendedActorSystem) e
     val host = settings.apiServiceHost
     val port = settings.apiServicePort
     val path = Uri.Path.Empty / "api" / "v1" / "namespaces" / namespace / "pods"
-    val query = Uri.Query("labelSelector" -> labelSelector)
+    val query = Uri.Query("labelSelector" -> labelSelector, "fieldSelector" -> "status.phase==Running")
     val uri = Uri.from(scheme = "https", host = host, port = port).withPath(path).withQuery(query)
 
     Future(HttpRequest(uri = uri, headers = List(Authorization(OAuth2BearerToken(token)))))

--- a/discovery-azure-api/src/main/scala/akka/discovery/azureapi/rbac/aks/AzureRbacAksServiceDiscovery.scala
+++ b/discovery-azure-api/src/main/scala/akka/discovery/azureapi/rbac/aks/AzureRbacAksServiceDiscovery.scala
@@ -185,7 +185,7 @@ final class AzureRbacAksServiceDiscovery(implicit system: ExtendedActorSystem) e
     for {
       ks <- kubernetesSetup
       token <- fetchAccessToken.map(_.getToken)
-      request <- podRequest(token, ks.namespace, selector, true)
+      request <- podRequest(token, ks.namespace, selector)
       pods <- pods(ks.ctx, request, resolveTimeout)
     } yield {
       val addresses =

--- a/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/KubernetesApiServiceDiscovery.scala
+++ b/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/KubernetesApiServiceDiscovery.scala
@@ -221,7 +221,7 @@ class KubernetesApiServiceDiscovery(implicit system: ActorSystem) extends Servic
       port <- Try(portStr.toInt).toOption
     } yield {
       val path = Uri.Path.Empty / "api" / "v1" / "namespaces" / namespace / "pods"
-      val query = Uri.Query("labelSelector" -> labelSelector)
+      val query = Uri.Query("labelSelector" -> labelSelector, "fieldSelection" -> "status.phase==Running")
       val uri = Uri.from(scheme = "https", host = host, port = port).withPath(path).withQuery(query)
 
       HttpRequest(uri = uri, headers = List(Authorization(OAuth2BearerToken(token))))


### PR DESCRIPTION
It seems like we'd be most interested in the pods which are currently running (cc: @girdharshubham ).  Without this filter, especially in environments where rollouts are frequent (e.g. dev/test environments), there's a chance that getting so many pods could cause HTTP responses which akka http rejects.

Can hide this behind a config setting if needed, but I'm not sure why one would want to discover pods which used to be there.