### PR TITLE
fix: reload tokens in kubernetes lease

### DIFF
--- a/discovery-kubernetes-api/src/main/resources/reference.conf
+++ b/discovery-kubernetes-api/src/main/resources/reference.conf
@@ -32,6 +32,12 @@ akka.discovery {
     api-service-host-env-name = "KUBERNETES_SERVICE_HOST"
     api-service-port-env-name = "KUBERNETES_SERVICE_PORT"
 
+    # The maximum amount of time to cache a token for.
+    # Service account tokens are by default in Kubernetes issued with a 1 hour expiry, and are rotated by the kubelet
+    # when they reach 80% of it's total TTL. That means, if at any given time a read of a token is done, the token may
+    # expire in 12 minutes, so this must be less than that.
+    api-token-reload-interval = 10m
+
     # Namespace discovery path
     #
     # If this path doesn't exist, the namespace will default to "default".

--- a/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/Settings.scala
+++ b/discovery-kubernetes-api/src/main/scala/akka/discovery/kubernetes/Settings.scala
@@ -5,10 +5,11 @@
 package akka.discovery.kubernetes
 
 import java.util.Optional
-
 import akka.actor._
 import com.typesafe.config.Config
 
+import scala.concurrent.duration.FiniteDuration
+import scala.jdk.DurationConverters._
 import scala.jdk.OptionConverters._
 
 final class Settings(system: ExtendedActorSystem) extends Extension {
@@ -39,6 +40,9 @@ final class Settings(system: ExtendedActorSystem) extends Extension {
 
   val apiServicePortEnvName: String =
     kubernetesApi.getString("api-service-port-env-name")
+
+  val apiTokenTtl: FiniteDuration =
+    kubernetesApi.getDuration("api-token-reload-interval").toScala
 
   val podNamespacePath: String =
     kubernetesApi.getString("pod-namespace-path")

--- a/integration-test/lease-kubernetes/src/test/scala/akka/coordination/lease/kubernetes/KubernetesApiIntegrationTest.scala
+++ b/integration-test/lease-kubernetes/src/test/scala/akka/coordination/lease/kubernetes/KubernetesApiIntegrationTest.scala
@@ -14,7 +14,7 @@ import org.scalatest.concurrent.{ Eventually, ScalaFutures }
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
-import scala.concurrent.Await
+import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration._
 
 /**
@@ -48,13 +48,14 @@ class KubernetesApiIntegrationTest
     "",
     "localhost",
     8080,
+    10.minutes,
     namespace = Some("lease"),
     "",
     apiServerRequestTimeout = 1.second,
     false
   )
 
-  val underTest = new KubernetesApiImpl(system, settings, "lease", "token", None)
+  val underTest = new KubernetesApiImpl(system, settings, "lease", () => Future.successful("token"), None)
   val leaseName = "lease-1"
   val client1 = "client-1"
   val client2 = "client-2"

--- a/integration-test/lease-kubernetes/src/test/scala/akka/coordination/lease/kubernetes/LeaseContentionSpec.scala
+++ b/integration-test/lease-kubernetes/src/test/scala/akka/coordination/lease/kubernetes/LeaseContentionSpec.scala
@@ -58,7 +58,7 @@ class LeaseContentionSpec
     system,
     KubernetesSettings(system, TimeoutSettings(system.settings.config.getConfig("akka.coordination.lease.kubernetes"))),
     "lease",
-    "token",
+    () => Future.successful("token"),
     None)
 
   val lease1 = "contended-lease"

--- a/integration-test/rolling-update-kubernetes/src/test/scala/akka/rollingupdate/kubernetes/KubernetesApiIntegrationTest.scala
+++ b/integration-test/rolling-update-kubernetes/src/test/scala/akka/rollingupdate/kubernetes/KubernetesApiIntegrationTest.scala
@@ -4,9 +4,8 @@
 
 package akka.rollingupdate.kubernetes
 
-import scala.concurrent.Await
+import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration._
-
 import akka.Done
 import akka.actor.ActorSystem
 import akka.cluster.Cluster
@@ -54,6 +53,7 @@ class KubernetesApiIntegrationTest
     "",
     "localhost",
     8080,
+    10.minutes,
     namespace = Some("rolling"),
     "",
     podName = "pod1",
@@ -68,7 +68,12 @@ class KubernetesApiIntegrationTest
   )
 
   private val underTest =
-    new KubernetesApiImpl(system, settings, settings.namespace.get, apiToken = "", clientHttpsConnectionContext = None)
+    new KubernetesApiImpl(
+      system,
+      settings,
+      settings.namespace.get,
+      () => Future.successful(""),
+      clientHttpsConnectionContext = None)
   private val crName = KubernetesApi.makeDNS1039Compatible(system.name)
   private val podName1 = "pod1"
   private val podName2 = "pod2"

--- a/lease-kubernetes/src/main/resources/reference.conf
+++ b/lease-kubernetes/src/main/resources/reference.conf
@@ -51,4 +51,10 @@ akka.coordination.lease.kubernetes {
     # For backwards compatibility to support rolling update. Truncation of lease name may cause conflicting names
     # of different lease resources.
     allow-lease-name-truncation = off
+
+    # The maximum amount of time to cache a token for.
+    # Service account tokens are by default in Kubernetes issued with a 1 hour expiry, and are rotated by the kubelet
+    # when they reach 80% of it's total TTL. That means, if at any given time a read of a token is done, the token may
+    # expire in 12 minutes, so this must be less than that.
+    api-token-reload-interval = 10m
 }

--- a/lease-kubernetes/src/main/scala/akka/coordination/lease/kubernetes/KubernetesSettings.scala
+++ b/lease-kubernetes/src/main/scala/akka/coordination/lease/kubernetes/KubernetesSettings.scala
@@ -48,10 +48,12 @@ private[akka] object KubernetesSettings {
       config.getString("api-token-path"),
       config.getString("api-service-host"),
       config.getInt("api-service-port"),
+      config.getDuration("api-token-reload-interval").toScala,
       config.optDefinedValue("namespace"),
       config.getString("namespace-path"),
       apiServerRequestTimeout,
       secure = config.getBoolean("secure-api-server"),
+      insecureTokens = false,
       apiServerRequestTimeout / 2,
       config.getBoolean("allow-lease-name-truncation"))
 
@@ -67,9 +69,12 @@ private[akka] class KubernetesSettings(
     val apiTokenPath: String,
     val apiServerHost: String,
     val apiServerPort: Int,
+    val apiTokenTtl: FiniteDuration,
     val namespace: Option[String],
     val namespacePath: String,
     val apiServerRequestTimeout: FiniteDuration,
     val secure: Boolean = true,
+    // Note: for token testability
+    val insecureTokens: Boolean = false,
     val bodyReadTimeout: FiniteDuration = 1.second,
     val allowLeaseNameTruncation: Boolean = false)

--- a/rolling-update-kubernetes/src/main/resources/reference.conf
+++ b/rolling-update-kubernetes/src/main/resources/reference.conf
@@ -19,6 +19,12 @@ akka.rollingupdate.kubernetes {
 
     api-service-request-timeout = 2s
 
+    # The maximum amount of time to cache a token for.
+    # Service account tokens are by default in Kubernetes issued with a 1 hour expiry, and are rotated by the kubelet
+    # when they reach 80% of it's total TTL. That means, if at any given time a read of a token is done, the token may
+    # expire in 12 minutes, so this must be less than that.
+    api-token-reload-interval = 10m
+
     # Namespace file path. The namespace is to create the lock in. Can be overridden by "namespace"
     #
     # If this path doesn't exist, the namespace will default to "default".

--- a/rolling-update-kubernetes/src/main/scala/akka/rollingupdate/kubernetes/KubernetesSettings.scala
+++ b/rolling-update-kubernetes/src/main/scala/akka/rollingupdate/kubernetes/KubernetesSettings.scala
@@ -8,7 +8,6 @@ import akka.annotation.InternalApi
 import com.typesafe.config.Config
 
 import scala.concurrent.duration._
-import scala.jdk.CollectionConverters.ListHasAsScala
 import scala.jdk.DurationConverters._
 
 /**
@@ -44,6 +43,7 @@ private[kubernetes] object KubernetesSettings {
       config.getString("api-token-path"),
       config.getString("api-service-host"),
       config.getInt("api-service-port"),
+      config.getDuration("api-token-reload-interval").toScala,
       config.optDefinedValue("namespace"),
       config.getString("namespace-path"),
       config.getString("pod-name"),
@@ -64,6 +64,7 @@ private[kubernetes] class KubernetesSettings(
     val apiTokenPath: String,
     val apiServiceHost: String,
     val apiServicePort: Int,
+    val apiTokenTtl: FiniteDuration,
     val namespace: Option[String],
     val namespacePath: String,
     val podName: String,
@@ -71,7 +72,9 @@ private[kubernetes] class KubernetesSettings(
     val apiServiceRequestTimeout: FiniteDuration,
     val customResourceSettings: CustomResourceSettings,
     val revisionAnnotation: String,
-    val bodyReadTimeout: FiniteDuration = 1.second
+    val bodyReadTimeout: FiniteDuration = 1.second,
+    // Note: for token testability
+    val insecureTokens: Boolean = false
 )
 
 /**

--- a/rolling-update-kubernetes/src/test/scala/akka/rollingupdate/kubernetes/PodDeletionCostAnnotatorCrSpec.scala
+++ b/rolling-update-kubernetes/src/test/scala/akka/rollingupdate/kubernetes/PodDeletionCostAnnotatorCrSpec.scala
@@ -110,6 +110,7 @@ class PodDeletionCostAnnotatorCrSpec
       apiTokenPath = "",
       apiServiceHost = "localhost",
       apiServicePort = 0,
+      apiTokenTtl = 500.millis,
       namespace = Some(namespace),
       namespacePath = "",
       podName = podName,

--- a/rolling-update-kubernetes/src/test/scala/akka/rollingupdate/kubernetes/PodDeletionCostAnnotatorSpec.scala
+++ b/rolling-update-kubernetes/src/test/scala/akka/rollingupdate/kubernetes/PodDeletionCostAnnotatorSpec.scala
@@ -6,7 +6,6 @@ package akka.rollingupdate.kubernetes
 
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
-
 import akka.actor.ActorSystem
 import akka.actor.Address
 import akka.cluster.Cluster
@@ -39,6 +38,8 @@ import org.scalatest.time.Millis
 import org.scalatest.time.Seconds
 import org.scalatest.time.Span
 import org.scalatest.wordspec.AnyWordSpecLike
+
+import scala.concurrent.Future
 
 object PodDeletionCostAnnotatorSpec {
   val config = ConfigFactory.parseString("""
@@ -84,6 +85,7 @@ class PodDeletionCostAnnotatorSpec
       apiTokenPath = "",
       apiServiceHost = "localhost",
       apiServicePort = wireMockServer.port(),
+      apiTokenTtl = 500.millis,
       namespace = Some(namespace),
       namespacePath = "",
       podName = podName,
@@ -99,7 +101,7 @@ class PodDeletionCostAnnotatorSpec
       system,
       settings(podName1),
       namespace,
-      apiToken = "apiToken",
+      () => Future.successful("apiToken"),
       clientHttpsConnectionContext = None)
 
   private def annotatorProps(pod: String) =


### PR DESCRIPTION
Fixes #1412

This implements token reload for kubernetes lease coordination. The tokens are loaded as required, and cached for 10 minutes.

10 minutes is selected because kubelet token rotation is done when a token, which by default expires in 1 hour, has reached 80% of its time to live, that is, after 48 minutes.