### PR TITLE
feat: Retries for lease acquire

### DIFF
--- a/docs/src/main/paradox/kubernetes-lease.md
+++ b/docs/src/main/paradox/kubernetes-lease.md
@@ -183,7 +183,13 @@ Note that version conflicts during heartbeat (meaning another node has modified 
 
 #### Acquire failure retry
 
-Transient failures during acquire (network timeout, API server unavailability) are retried within the caller's `lease-operation-timeout` budget, spanning both the initial read and the update. A retry is only scheduled while the elapsed time plus the next delay is under half the budget, leaving the rest for the retried call. Backoff starts at `lease-operation-timeout / 20`, doubles each attempt, and is capped at `lease-operation-timeout / 5`.
+When an acquire fails due to a transient error (network timeout, API server unavailability) during the initial read or the update, the lease actor retries within the caller's `lease-operation-timeout` budget rather than failing immediately.
+
+The retry time budget is calculated with safety margins:
+
+* The caller's ask times out at `lease-operation-timeout`, covering both the initial read and the update.
+* A retry is only scheduled while the elapsed time plus the next delay is under half the budget, leaving the rest for the retried call to complete.
+* Retries use exponential backoff: starting at `lease-operation-timeout / 4`, doubling each attempt (`op-timeout/4`, `op-timeout/2`, `op-timeout`), and capped at `lease-operation-timeout`. With the half-budget rule this typically allows a single retry, keeping load on a struggling API server bounded.
 
 If an update was applied server-side but the client missed the response, the retry's update is answered with a conflict naming us as owner — this is treated as a successful acquire. Genuine conflicts (a different owner) are not retried.
 

--- a/docs/src/main/paradox/kubernetes-lease.md
+++ b/docs/src/main/paradox/kubernetes-lease.md
@@ -181,6 +181,12 @@ The retry time budget is calculated with safety margins:
 
 Note that version conflicts during heartbeat (meaning another node has modified the lease resource) are *not* retried — they indicate a genuine lease loss.
 
+#### Acquire failure retry
+
+Transient failures during acquire (network timeout, API server unavailability) are retried within the caller's `lease-operation-timeout` budget, spanning both the initial read and the update. A retry is only scheduled while the elapsed time plus the next delay is under half the budget, leaving the rest for the retried call. Backoff starts at `lease-operation-timeout / 20`, doubles each attempt, and is capped at `lease-operation-timeout / 5`.
+
+If an update was applied server-side but the client missed the response, the retry's update is answered with a conflict naming us as owner — this is treated as a successful acquire. Genuine conflicts (a different owner) are not retried.
+
 #### Example configurations
 
 | Configuration | Ratio | Retry deadline | ~Retries on failure |

--- a/lease-kubernetes/src/main/mima-filters/1.6.5.backwards.excludes
+++ b/lease-kubernetes/src/main/mima-filters/1.6.5.backwards.excludes
@@ -1,0 +1,9 @@
+# internals, acquire retry on transient API failure
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.coordination.lease.kubernetes.LeaseActor#OperationInProgress.copy")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.coordination.lease.kubernetes.LeaseActor#OperationInProgress.this")
+ProblemFilters.exclude[MissingTypesProblem]("akka.coordination.lease.kubernetes.LeaseActor$OperationInProgress$")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.coordination.lease.kubernetes.LeaseActor#OperationInProgress.apply")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.coordination.lease.kubernetes.LeaseActor#PendingReadData.copy")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.coordination.lease.kubernetes.LeaseActor#PendingReadData.this")
+ProblemFilters.exclude[MissingTypesProblem]("akka.coordination.lease.kubernetes.LeaseActor$PendingReadData$")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.coordination.lease.kubernetes.LeaseActor#PendingReadData.apply")

--- a/lease-kubernetes/src/main/scala/akka/coordination/lease/kubernetes/LeaseActor.scala
+++ b/lease-kubernetes/src/main/scala/akka/coordination/lease/kubernetes/LeaseActor.scala
@@ -173,10 +173,10 @@ private[akka] class LeaseActor(
       } else {
         val elapsed = (System.nanoTime() - prd.acquireStartTime).nanos
         log.warning(
-          "Failure during lease read: [{}]. Time since acquire started [{}] exceeds retry budget after [{}] retries.",
+          "Failure during lease read: [{}]. Time since acquire started [{}] exceeds retry budget after [{}] attempts.",
           t.getMessage,
           elapsed.pretty,
-          prd.retryCount
+          prd.retryCount + 1
         )
         prd.replyTo ! Failure(t)
         goto(Idle).using(ReadRequired)
@@ -209,7 +209,14 @@ private[akka] class LeaseActor(
       op.replyTo ! LeaseAcquired
       // Try again as lock version has moved on but is not taken
       pipe(k8sApi.updateLeaseResource(leaseName, ownerName, version).map(r => WriteResponse(r))).to(self)
-      stay()
+      stay().using(op.copy(version = version))
+    case Event(WriteResponse(Left(LeaseResource(Some(currentOwner), version, _))), op: OperationInProgress)
+        if currentOwner == ownerName =>
+      // A previous attempt's write actually succeeded on the server even though we observed a transient
+      // failure (or never received the response). Treat as acquired.
+      granted.set(true)
+      op.replyTo ! LeaseAcquired
+      goto(Granted).using(GrantedVersion(version, op.leaseLostCallback))
     case Event(WriteResponse(Left(LeaseResource(Some(_), _, _))), op: OperationInProgress) =>
       // The audacity, someone else has taken the lease :(
       op.replyTo ! LeaseTaken
@@ -231,10 +238,10 @@ private[akka] class LeaseActor(
       } else {
         val elapsed = (System.nanoTime() - op.acquireStartTime).nanos
         log.warning(
-          "Failure during lease update: [{}]. Time since acquire started [{}] exceeds retry budget after [{}] retries.",
+          "Failure during lease update: [{}]. Time since acquire started [{}] exceeds retry budget after [{}] attempts.",
           t.getMessage,
           elapsed.pretty,
-          op.retryCount
+          op.retryCount + 1
         )
         op.replyTo ! Failure(t)
         goto(Idle).using(ReadRequired)

--- a/lease-kubernetes/src/main/scala/akka/coordination/lease/kubernetes/LeaseActor.scala
+++ b/lease-kubernetes/src/main/scala/akka/coordination/lease/kubernetes/LeaseActor.scala
@@ -404,25 +404,24 @@ private[akka] class LeaseActor(
     goto(Granting).using(OperationInProgress(reply, version, leaseLost, acquireStartTime = acquireStartTime))
   }
 
-  private def acquireRetryDelay(retryCount: Int): FiniteDuration = {
-    val base = settings.timeoutSettings.operationTimeout / 20
-    val cap = settings.timeoutSettings.operationTimeout / 5
-    val delay = base * (1L << math.min(retryCount - 1, 4))
-    delay.min(cap)
+  // Exponential backoff: base/4, base/2, base, base, ... capped at base.
+  // Conservative cadence so a struggling API server is not hammered with retries.
+  private def exponentialRetryDelay(base: FiniteDuration, retryCount: Int): FiniteDuration = {
+    val delay = base / 4 * (1L << math.min(retryCount - 1, 2))
+    delay.min(base)
   }
+
+  private def acquireRetryDelay(retryCount: Int): FiniteDuration =
+    exponentialRetryDelay(settings.timeoutSettings.operationTimeout, retryCount)
+
+  private def heartbeatRetryDelay(retryCount: Int): FiniteDuration =
+    exponentialRetryDelay(settings.timeoutSettings.heartbeatInterval, retryCount)
 
   private def canRetryWithin(acquireStartTime: Long, delay: FiniteDuration): Boolean = {
     // Caller's ask times out at operationTimeout. Only schedule a retry if after the delay
     // we'll still have time for another API call within half of the caller's budget.
     val elapsed = System.nanoTime() - acquireStartTime
     elapsed + delay.toNanos < settings.timeoutSettings.operationTimeout.toNanos / 2
-  }
-
-  private def heartbeatRetryDelay(retryCount: Int): FiniteDuration = {
-    val interval = settings.timeoutSettings.heartbeatInterval
-    // Exponential backoff: interval/4, interval/2, interval, interval, ...
-    val delay = interval / 4 * (1L << math.min(retryCount - 1, 2))
-    delay.min(interval)
   }
 
   private def hasTimeLeftForHeartbeatRetry(lastHeartbeatTime: Long): Boolean = {

--- a/lease-kubernetes/src/main/scala/akka/coordination/lease/kubernetes/LeaseActor.scala
+++ b/lease-kubernetes/src/main/scala/akka/coordination/lease/kubernetes/LeaseActor.scala
@@ -206,8 +206,8 @@ private[akka] class LeaseActor(
 
     case Event(WriteResponse(Left(LeaseResource(None, version, _))), op: OperationInProgress) =>
       require(op.version != version)
-      op.replyTo ! LeaseAcquired
-      // Try again as lock version has moved on but is not taken
+      // Try again as lock version has moved on but is not taken; the follow-up update's
+      // response is the authoritative reply to the caller.
       pipe(k8sApi.updateLeaseResource(leaseName, ownerName, version).map(r => WriteResponse(r))).to(self)
       stay().using(op.copy(version = version))
     case Event(WriteResponse(Left(LeaseResource(Some(currentOwner), version, _))), op: OperationInProgress)

--- a/lease-kubernetes/src/main/scala/akka/coordination/lease/kubernetes/LeaseActor.scala
+++ b/lease-kubernetes/src/main/scala/akka/coordination/lease/kubernetes/LeaseActor.scala
@@ -40,14 +40,20 @@ private[akka] object LeaseActor {
     def replyTo: ActorRef
   }
   // Awaiting a read to try and get the lease
-  case class PendingReadData(replyTo: ActorRef, leaseLostCallback: Option[Throwable] => Unit)
+  case class PendingReadData(
+      replyTo: ActorRef,
+      leaseLostCallback: Option[Throwable] => Unit,
+      acquireStartTime: Long = System.nanoTime(),
+      retryCount: Int = 0)
       extends Data
       with ReplyRequired
   case class OperationInProgress(
       replyTo: ActorRef,
       version: String,
       leaseLostCallback: Option[Throwable] => Unit,
-      operationStartTime: Long = System.nanoTime())
+      operationStartTime: Long = System.nanoTime(),
+      acquireStartTime: Long = System.nanoTime(),
+      retryCount: Int = 0)
       extends Data
       with ReplyRequired
   case class GrantedVersion(
@@ -66,6 +72,7 @@ private[akka] object LeaseActor {
   private case class WriteResponse(response: Either[LeaseResource, LeaseResource]) extends Command
   private case object Heartbeat extends Command
   private case class HeartbeatRetry(retryCount: Int) extends Command
+  private case class AcquireRetry(retryCount: Int) extends Command
 
   sealed trait Response
   case object LeaseAcquired extends Response
@@ -112,9 +119,9 @@ private[akka] class LeaseActor(
 
   when(PendingRead) {
     // Lock not taken
-    case Event(ReadResponse(LeaseResource(None, version, _)), PendingReadData(who, leaseLost)) =>
-      tryGetLease(version, who, leaseLost)
-    case Event(ReadResponse(LeaseResource(Some(currentOwner), version, time)), PendingReadData(who, leaseLost))
+    case Event(ReadResponse(LeaseResource(None, version, _)), prd: PendingReadData) =>
+      tryGetLease(version, prd.replyTo, prd.leaseLostCallback, prd.acquireStartTime)
+    case Event(ReadResponse(LeaseResource(Some(currentOwner), version, time)), prd: PendingReadData)
         if currentOwner == ownerName =>
       // We have the lock from a different incarnation
       if (hasLeaseTimedOut(time)) {
@@ -125,7 +132,7 @@ private[akka] class LeaseActor(
           ownerName,
           time
         )
-        tryGetLease(version, who, leaseLost)
+        tryGetLease(version, prd.replyTo, prd.leaseLostCallback, prd.acquireStartTime)
       } else {
         log.warning(
           "Lease {} requested by client {} is already owned by client. Previous lease was not released due to ungraceful shutdown. " +
@@ -133,53 +140,110 @@ private[akka] class LeaseActor(
           leaseName,
           ownerName
         )
-        who ! LeaseAcquired
-        goto(Granted).using(GrantedVersion(version, leaseLost))
+        prd.replyTo ! LeaseAcquired
+        goto(Granted).using(GrantedVersion(version, prd.leaseLostCallback))
       }
-    case Event(ReadResponse(LeaseResource(Some(currentOwner), version, time)), PendingReadData(who, leaseLost)) =>
+    case Event(ReadResponse(LeaseResource(Some(currentOwner), version, time)), prd: PendingReadData) =>
       if (hasLeaseTimedOut(time)) {
         log.warning(
           "Lease {} has reached TTL. Owner {} has failed to heartbeat, have they crashed?. Allowing {} to try and take lease",
           leaseName,
           currentOwner,
           ownerName)
-        tryGetLease(version, who, leaseLost)
+        tryGetLease(version, prd.replyTo, prd.leaseLostCallback, prd.acquireStartTime)
       } else {
-        who ! LeaseTaken
+        prd.replyTo ! LeaseTaken
         // Even though we have a version there is no benefit to storing it as we can't update a lease that has a client
         goto(Idle).using(ReadRequired)
       }
+    case Event(Failure(t), prd: PendingReadData) =>
+      val nextRetry = prd.retryCount + 1
+      val delay = acquireRetryDelay(nextRetry)
+      if (canRetryWithin(prd.acquireStartTime, delay)) {
+        val elapsed = (System.nanoTime() - prd.acquireStartTime).nanos
+        log.warning(
+          "Failure during lease read: [{}]. Time since acquire started [{}]. Scheduling retry [{}] in [{}].",
+          t.getMessage,
+          elapsed.pretty,
+          nextRetry,
+          delay.pretty
+        )
+        startSingleTimer("acquire-retry", AcquireRetry(nextRetry), delay)
+        stay().using(prd.copy(retryCount = nextRetry))
+      } else {
+        val elapsed = (System.nanoTime() - prd.acquireStartTime).nanos
+        log.warning(
+          "Failure during lease read: [{}]. Time since acquire started [{}] exceeds retry budget after [{}] retries.",
+          t.getMessage,
+          elapsed.pretty,
+          prd.retryCount
+        )
+        prd.replyTo ! Failure(t)
+        goto(Idle).using(ReadRequired)
+      }
+    case Event(AcquireRetry(retryCount), _: PendingReadData) =>
+      log.info("Retrying lease read, attempt [{}]", retryCount)
+      pipe(k8sApi.readOrCreateLeaseResource(leaseName).map(ReadResponse.apply)).to(self)
+      stay()
   }
 
   when(Granting) {
-    case Event(
-        WriteResponse(Right(response)),
-        cc @ OperationInProgress(who, oldVersion, leaseLost, operationStartTime)) =>
+    case Event(WriteResponse(Right(response)), op: OperationInProgress) =>
       require(
-        oldVersion != response.version,
-        s"Update response from Kubernetes API should not return the same version: Response: $response. Client: $cc")
-      val operationDuration = System.nanoTime() - operationStartTime
+        op.version != response.version,
+        s"Update response from Kubernetes API should not return the same version: Response: $response. Client: $op")
+      val operationDuration = System.nanoTime() - op.operationStartTime
       if (operationDuration > (settings.timeoutSettings.heartbeatTimeout.toNanos / 2)) {
         log.warning("API server took too long to respond to update: {}. ", operationDuration.nanos.pretty)
-        who ! Failure(
+        op.replyTo ! Failure(
           new LeaseTimeoutException(s"API server took too long to respond: ${operationDuration.nanos.pretty}"))
         goto(Idle).using(ReadRequired)
       } else {
         granted.set(true)
-        who ! LeaseAcquired
-        goto(Granted).using(GrantedVersion(response.version, leaseLost))
+        op.replyTo ! LeaseAcquired
+        goto(Granted).using(GrantedVersion(response.version, op.leaseLostCallback))
       }
 
-    case Event(WriteResponse(Left(LeaseResource(None, version, _))), OperationInProgress(who, oldVersion, _, _)) =>
-      require(oldVersion != version)
-      who ! LeaseAcquired
+    case Event(WriteResponse(Left(LeaseResource(None, version, _))), op: OperationInProgress) =>
+      require(op.version != version)
+      op.replyTo ! LeaseAcquired
       // Try again as lock version has moved on but is not taken
       pipe(k8sApi.updateLeaseResource(leaseName, ownerName, version).map(r => WriteResponse(r))).to(self)
       stay()
-    case Event(WriteResponse(Left(LeaseResource(Some(_), _, _))), OperationInProgress(who, _, _, _)) =>
+    case Event(WriteResponse(Left(LeaseResource(Some(_), _, _))), op: OperationInProgress) =>
       // The audacity, someone else has taken the lease :(
-      who ! LeaseTaken
+      op.replyTo ! LeaseTaken
       goto(Idle).using(ReadRequired) // can't use version as another owner has the lock
+    case Event(Failure(t), op: OperationInProgress) =>
+      val nextRetry = op.retryCount + 1
+      val delay = acquireRetryDelay(nextRetry)
+      if (canRetryWithin(op.acquireStartTime, delay)) {
+        val elapsed = (System.nanoTime() - op.acquireStartTime).nanos
+        log.warning(
+          "Failure during lease update: [{}]. Time since acquire started [{}]. Scheduling retry [{}] in [{}].",
+          t.getMessage,
+          elapsed.pretty,
+          nextRetry,
+          delay.pretty
+        )
+        startSingleTimer("acquire-retry", AcquireRetry(nextRetry), delay)
+        stay().using(op.copy(retryCount = nextRetry))
+      } else {
+        val elapsed = (System.nanoTime() - op.acquireStartTime).nanos
+        log.warning(
+          "Failure during lease update: [{}]. Time since acquire started [{}] exceeds retry budget after [{}] retries.",
+          t.getMessage,
+          elapsed.pretty,
+          op.retryCount
+        )
+        op.replyTo ! Failure(t)
+        goto(Idle).using(ReadRequired)
+      }
+    case Event(AcquireRetry(retryCount), op: OperationInProgress) =>
+      log.info("Retrying lease update, attempt [{}]. Version [{}]", retryCount, op.version)
+      pipe(k8sApi.updateLeaseResource(leaseName, ownerName, op.version).map(WriteResponse.apply)).to(self)
+      // reset operationStartTime so the "too slow" check in Granting measures only the retried call
+      stay().using(op.copy(operationStartTime = System.nanoTime()))
   }
 
   when(Granted) {
@@ -259,23 +323,23 @@ private[akka] class LeaseActor(
 
   when(Releasing) {
     // FIXME deal with failure from releasing the the lock, currently handled in whenUnhandled but could retry to remove: https://github.com/lightbend/akka-commercial-addons/issues/502
-    case Event(WriteResponse(Right(lr)), OperationInProgress(who, _, _, _)) =>
+    case Event(WriteResponse(Right(lr)), op: OperationInProgress) =>
       require(lr.owner.isEmpty, "Released lease has unexpected owner: " + lr)
-      who ! LeaseReleased
+      op.replyTo ! LeaseReleased
       goto(Idle).using(LeaseCleared(lr.version))
-    case Event(WriteResponse(Left(lr @ LeaseResource(None, _, _))), OperationInProgress(who, _, _, _)) =>
+    case Event(WriteResponse(Left(lr @ LeaseResource(None, _, _))), op: OperationInProgress) =>
       log.warning(
         "Release conflict and owner has been removed: {}. Lease will continue to work but TTL must have been reached to allow another node to remove lease.",
         lr
       )
-      who ! LeaseReleased
+      op.replyTo ! LeaseReleased
       goto(Idle).using(ReadRequired)
-    case Event(WriteResponse(Left(lr @ LeaseResource(Some(_), _, _))), OperationInProgress(who, _, _, _)) =>
+    case Event(WriteResponse(Left(lr @ LeaseResource(Some(_), _, _))), op: OperationInProgress) =>
       log.warning(
         "Release conflict and owner has changed: {}. Lease will continue to work but TTL must have been reached to allow another node to update the lease.",
         lr
       )
-      who ! LeaseReleased
+      op.replyTo ! LeaseReleased
       goto(Idle).using(ReadRequired)
   }
 
@@ -298,6 +362,9 @@ private[akka] class LeaseActor(
     case Event(_: HeartbeatRetry, _) =>
       // stale retry after leaving Granted state, ignore
       stay()
+    case Event(_: AcquireRetry, _) =>
+      // stale retry after leaving PendingRead / Granting states, ignore
+      stay()
     case Event(Failure(t), replyRequired: ReplyRequired) =>
       log.warning(
         "Failure communicating with the API server for owner {} lease {}: [{}]. Current state: {}",
@@ -311,19 +378,37 @@ private[akka] class LeaseActor(
 
   onTransition {
     case _ -> Granted =>
+      cancelTimer("acquire-retry")
       startSingleTimer("heartbeat", Heartbeat, settings.timeoutSettings.heartbeatInterval)
     case Granted -> _ =>
       cancelTimer("heartbeat")
       cancelTimer("heartbeat-retry")
       granted.set(false)
+    case _ -> Idle =>
+      cancelTimer("acquire-retry")
   }
 
   private def tryGetLease(
       version: String,
       reply: ActorRef,
-      leaseLost: Option[Throwable] => Unit): FSM.State[LeaseActor.State, Data] = {
+      leaseLost: Option[Throwable] => Unit,
+      acquireStartTime: Long): FSM.State[LeaseActor.State, Data] = {
     pipe(k8sApi.updateLeaseResource(leaseName, ownerName, version).map(r => WriteResponse(r))).to(self)
-    goto(Granting).using(OperationInProgress(reply, version, leaseLost))
+    goto(Granting).using(OperationInProgress(reply, version, leaseLost, acquireStartTime = acquireStartTime))
+  }
+
+  private def acquireRetryDelay(retryCount: Int): FiniteDuration = {
+    val base = settings.timeoutSettings.operationTimeout / 20
+    val cap = settings.timeoutSettings.operationTimeout / 5
+    val delay = base * (1L << math.min(retryCount - 1, 4))
+    delay.min(cap)
+  }
+
+  private def canRetryWithin(acquireStartTime: Long, delay: FiniteDuration): Boolean = {
+    // Caller's ask times out at operationTimeout. Only schedule a retry if after the delay
+    // we'll still have time for another API call within half of the caller's budget.
+    val elapsed = System.nanoTime() - acquireStartTime
+    elapsed + delay.toNanos < settings.timeoutSettings.operationTimeout.toNanos / 2
   }
 
   private def heartbeatRetryDelay(retryCount: Int): FiniteDuration = {

--- a/lease-kubernetes/src/test/scala/akka/coordination/lease/kubernetes/LeaseActorSpec.scala
+++ b/lease-kubernetes/src/test/scala/akka/coordination/lease/kubernetes/LeaseActorSpec.scala
@@ -254,9 +254,10 @@ class LeaseActorSpec
       // Fail due to cas, version has moved on by 6 but no one owns the lock
       val failedVersion = currentVersionCount + 6
       updateProbe.reply(Left(LeaseResource(None, failedVersion.toString, System.currentTimeMillis())))
-      // Try again
+      // Try again — successful update bumps the version server-side
       updateProbe.expectMsg((ownerName, failedVersion.toString))
-      updateProbe.reply(Right(LeaseResource(Some(ownerName), failedVersion.toString, System.currentTimeMillis())))
+      val grantedVersion = (failedVersion + 1).toString
+      updateProbe.reply(Right(LeaseResource(Some(ownerName), grantedVersion, System.currentTimeMillis())))
       senderProbe.expectMsg(LeaseAcquired)
     }
 

--- a/lease-kubernetes/src/test/scala/akka/coordination/lease/kubernetes/LeaseActorSpec.scala
+++ b/lease-kubernetes/src/test/scala/akka/coordination/lease/kubernetes/LeaseActorSpec.scala
@@ -129,6 +129,21 @@ class LeaseActorSpec
       senderProbe.expectMsg(LeaseAcquired)
     }
 
+    "report lease taken if retried update conflict reports another owner" in new Test {
+      // transient failure during update, on retry the lease has been taken by another client
+      val k8sApiFailure = new LeaseException("Failed to communicate with API server")
+      underTest ! LeaseActor.Acquire()
+      leaseProbe.expectMsg(leaseName)
+      leaseProbe.reply(LeaseResource(None, currentVersion, System.currentTimeMillis()))
+      updateProbe.expectMsg((ownerName, currentVersion))
+      updateProbe.reply(Failure(k8sApiFailure))
+      // retry sees that someone else has taken the lease
+      updateProbe.expectMsg((ownerName, currentVersion))
+      incrementVersion()
+      updateProbe.reply(Left(LeaseResource(Some("a different client"), currentVersion, System.currentTimeMillis())))
+      senderProbe.expectMsg(LeaseTaken)
+    }
+
     "allow acquire after initial failure on rad" in new Test {
       k8sApiFailureDuringRead()
       acquireLease()

--- a/lease-kubernetes/src/test/scala/akka/coordination/lease/kubernetes/LeaseActorSpec.scala
+++ b/lease-kubernetes/src/test/scala/akka/coordination/lease/kubernetes/LeaseActorSpec.scala
@@ -80,7 +80,37 @@ class LeaseActorSpec
       underTest ! LeaseActor.Acquire()
       leaseProbe.expectMsg(leaseName)
       leaseProbe.reply(Failure(k8sApiFailure))
-      senderProbe.expectMsg(Failure(k8sApiFailure))
+      // retries until budget is exhausted, then replies with the last failure
+      readFailureUntilGiveUp(k8sApiFailure)
+      senderProbe.expectMsg(leaseSettings.timeoutSettings.operationTimeout * 2, Failure(k8sApiFailure))
+    }
+
+    "retry read on transient failure and recover" in new Test {
+      val k8sApiFailure = new LeaseException("Failed to communicate with API server")
+      underTest ! LeaseActor.Acquire()
+      leaseProbe.expectMsg(leaseName)
+      leaseProbe.reply(Failure(k8sApiFailure))
+      // retry succeeds
+      leaseProbe.expectMsg(leaseName)
+      leaseProbe.reply(LeaseResource(None, currentVersion, System.currentTimeMillis()))
+      updateProbe.expectMsg((ownerName, currentVersion))
+      incrementVersion()
+      updateProbe.reply(Right(LeaseResource(Some(ownerName), currentVersion, System.currentTimeMillis())))
+      senderProbe.expectMsg(LeaseAcquired)
+    }
+
+    "retry update on transient failure and recover" in new Test {
+      val k8sApiFailure = new LeaseException("Failed to communicate with API server")
+      underTest ! LeaseActor.Acquire()
+      leaseProbe.expectMsg(leaseName)
+      leaseProbe.reply(LeaseResource(None, currentVersion, System.currentTimeMillis()))
+      updateProbe.expectMsg((ownerName, currentVersion))
+      updateProbe.reply(Failure(k8sApiFailure))
+      // retry succeeds
+      updateProbe.expectMsg((ownerName, currentVersion))
+      incrementVersion()
+      updateProbe.reply(Right(LeaseResource(Some(ownerName), currentVersion, System.currentTimeMillis())))
+      senderProbe.expectMsg(LeaseAcquired)
     }
 
     "allow acquire after initial failure on rad" in new Test {
@@ -505,7 +535,21 @@ class LeaseActorSpec
       underTest ! LeaseActor.Acquire()
       leaseProbe.expectMsg(leaseName)
       leaseProbe.reply(Failure(k8sApiFailure))
-      senderProbe.expectMsg(Failure(k8sApiFailure))
+      readFailureUntilGiveUp(k8sApiFailure)
+      senderProbe.expectMsg(leaseSettings.timeoutSettings.operationTimeout * 2, Failure(k8sApiFailure))
+    }
+
+    def readFailureUntilGiveUp(failure: Throwable): Unit = {
+      // keep failing retries until the time budget is exhausted
+      var done = false
+      while (!done) {
+        try {
+          leaseProbe.expectMsg(leaseSettings.timeoutSettings.operationTimeout, leaseName)
+          leaseProbe.reply(Failure(failure))
+        } catch {
+          case _: AssertionError => done = true
+        }
+      }
     }
 
     def heartBeatConflict(): Unit = {

--- a/lease-kubernetes/src/test/scala/akka/coordination/lease/kubernetes/LeaseActorSpec.scala
+++ b/lease-kubernetes/src/test/scala/akka/coordination/lease/kubernetes/LeaseActorSpec.scala
@@ -113,6 +113,22 @@ class LeaseActorSpec
       senderProbe.expectMsg(LeaseAcquired)
     }
 
+    "treat retried update conflict reporting self as owner as acquired" in new Test {
+      // simulates the case where a previous update attempt actually succeeded on the server
+      // even though we observed a transient failure (or never received the response)
+      val k8sApiFailure = new LeaseException("Failed to communicate with API server")
+      underTest ! LeaseActor.Acquire()
+      leaseProbe.expectMsg(leaseName)
+      leaseProbe.reply(LeaseResource(None, currentVersion, System.currentTimeMillis()))
+      updateProbe.expectMsg((ownerName, currentVersion))
+      updateProbe.reply(Failure(k8sApiFailure))
+      // retry sees the lease is already owned by us
+      updateProbe.expectMsg((ownerName, currentVersion))
+      incrementVersion()
+      updateProbe.reply(Left(LeaseResource(Some(ownerName), currentVersion, System.currentTimeMillis())))
+      senderProbe.expectMsg(LeaseAcquired)
+    }
+
     "allow acquire after initial failure on rad" in new Test {
       k8sApiFailureDuringRead()
       acquireLease()


### PR DESCRIPTION
Follow-up to #1441: applies the same retry-with-backoff pattern to the lease acquisition path (PendingRead / Granting), so transient kube-API failures during Acquire no longer immediately fail the caller.

  - Budget is the caller's operationTimeout (vs. the heartbeat timeout used in #1441); retry scheduled only if elapsed + delay < operationTimeout / 2, else the original failure is returned.
  - Exponential backoff from operationTimeout / 20, capped at / 5.
  - acquireStartTime is threaded from PendingRead into Granting so the budget spans both phases.