### PR TITLE
fix: retry lease heartbeat if timeout far enough off (#1441)

### DIFF
--- a/docs/src/main/paradox/kubernetes-lease.md
+++ b/docs/src/main/paradox/kubernetes-lease.md
@@ -149,10 +149,59 @@ akka {
 
 @@snip [reference.conf](/lease-kubernetes/src/main/resources/reference.conf)
 
+### Tuning timeouts
+
+Each lease holder periodically writes to the Kubernetes API server to maintain its lease. The default `heartbeat-interval` of `heartbeat-timeout / 10` (12s with the default 120s timeout) is very conservative. In clusters with many leases — especially when using Cluster Sharding where there is one lease per shard — this can put significant load on the Kubernetes API server. Increasing the `heartbeat-interval` reduces this load.
+
+The lease uses three related timeout settings:
+
+* `heartbeat-interval` — How often the lease holder writes a new timestamp to the lease resource. Default: `heartbeat-timeout / 10`.
+* `heartbeat-timeout` — How long a lease can go without being updated before another node may take it over. Default: `120s`.
+* `lease-operation-timeout` — The total time allowed for a single lease API operation (acquire, release, or heartbeat update). Default: `5s`.
+
+#### Heartbeat interval to timeout ratio
+
+The ratio between `heartbeat-interval` and `heartbeat-timeout` determines how many heartbeat attempts fit within the timeout window and how quickly a crashed node's lease can be taken over. The default ratio of 1:10 is very conservative. A ratio of 1:5 is a good balance between API server load and safety.
+
+@@@ warning
+
+Do not set the ratio below 1:4. At 1:4 there is only room for approximately one heartbeat retry on transient failures, and below that the retry mechanism provides no benefit. During a retry window the local node continues to believe it holds the lease while writes to the API server are failing. If other nodes can still reach the API server they may observe the lease as expired and acquire it. With the safety margins built in, this overlap is brief and bounded, but reducing the ratio shrinks those margins. This is especially important for Split Brain Resolver, Cluster Singleton, and Cluster Sharding where holding a stale lease can cause split-brain scenarios.
+
+@@@
+
+#### Heartbeat failure retry
+
+When a heartbeat fails due to a transient error (network timeout, API server unavailability), the lease holder does not immediately give up the lease. Instead, it retries the heartbeat as long as there is sufficient time remaining before the `heartbeat-timeout` deadline.
+
+The retry time budget is calculated with safety margins:
+
+* Other nodes consider the lease expired at `heartbeat-timeout - 2 * heartbeat-interval` after the last successful heartbeat.
+* The lease holder stops retrying before that, subtracting `lease-operation-timeout` (time for the retry itself) and an additional `heartbeat-interval` (buffer for clock skew between nodes).
+* Retries use exponential backoff: starting at `heartbeat-interval / 4`, doubling each attempt (`interval/4`, `interval/2`, `interval`), and capped at `heartbeat-interval`.
+
+Note that version conflicts during heartbeat (meaning another node has modified the lease resource) are *not* retried — they indicate a genuine lease loss.
+
+#### Example configurations
+
+| Configuration | Ratio | Retry deadline | ~Retries on failure |
+|---------------|-------|----------------|---------------------|
+| interval=12s, timeout=120s, op-timeout=5s (default) | 1:10 | 79s | ~7 |
+| interval=24s, timeout=120s, op-timeout=10s | 1:5 | 38s | ~2 |
+| interval=30s, timeout=120s, op-timeout=10s | 1:4 | 20s | ~1 |
+
+A recommended configuration for tighter timing:
+
+```
+akka.coordination.lease.kubernetes {
+  heartbeat-interval = 24s
+  heartbeat-timeout = 120s
+  lease-operation-timeout = 10s
+}
+```
+
 ### F.A.Q
 
 Q. What happens if the node that holds the lease crashes?
 
-A. Each lease has a Time To Live (TTL) that is set `akka.coordination.lease.kubernetes.heartbeat-timeout` which defaults to 120s. A lease holder updates the lease every `1/10` of the timeout to keep the lease. If the TTL passes without
-   the lease being updated another node is allowed to take the lease. For ultimate safety this timeout can be set very high but then an operator would need to come and clear the lease if a lease owner crashes with the lease taken.
+A. Each lease has a Time To Live (TTL) that is set via `akka.coordination.lease.kubernetes.heartbeat-timeout` which defaults to 120s. A lease holder updates the lease periodically to keep the lease (by default every `1/10` of the timeout). If the TTL passes without the lease being updated another node is allowed to take the lease. If a heartbeat fails due to a transient error, the lease holder retries the heartbeat as long as there is sufficient time remaining before the TTL deadline (see @ref:[Tuning timeouts](#tuning-timeouts)). For ultimate safety the heartbeat timeout can be set very high but then an operator would need to come and clear the lease if a lease owner crashes with the lease taken.
    

--- a/lease-kubernetes/src/main/mima-filters/1.6.4.backwards.excludes
+++ b/lease-kubernetes/src/main/mima-filters/1.6.4.backwards.excludes
@@ -1,0 +1,5 @@
+# internals, heartbeat retry on transient API failure
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.coordination.lease.kubernetes.LeaseActor#GrantedVersion.copy")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.coordination.lease.kubernetes.LeaseActor#GrantedVersion.this")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.coordination.lease.kubernetes.LeaseActor#GrantedVersion.apply")
+ProblemFilters.exclude[MissingTypesProblem]("akka.coordination.lease.kubernetes.LeaseActor$GrantedVersion$")

--- a/lease-kubernetes/src/main/scala/akka/coordination/lease/kubernetes/LeaseActor.scala
+++ b/lease-kubernetes/src/main/scala/akka/coordination/lease/kubernetes/LeaseActor.scala
@@ -50,7 +50,12 @@ private[akka] object LeaseActor {
       operationStartTime: Long = System.nanoTime())
       extends Data
       with ReplyRequired
-  case class GrantedVersion(version: String, leaseLostCallback: Option[Throwable] => Unit) extends Data
+  case class GrantedVersion(
+      version: String,
+      leaseLostCallback: Option[Throwable] => Unit,
+      lastHeartbeatTime: Long = System.nanoTime(),
+      retryCount: Int = 0)
+      extends Data
 
   sealed trait Command
   case class Acquire(leaseLostCallback: Option[Throwable] => Unit = ConstantFun.scalaAnyToUnit) extends Command
@@ -60,6 +65,7 @@ private[akka] object LeaseActor {
   private case class ReadResponse(response: LeaseResource) extends Command
   private case class WriteResponse(response: Either[LeaseResource, LeaseResource]) extends Command
   private case object Heartbeat extends Command
+  private case class HeartbeatRetry(retryCount: Int) extends Command
 
   sealed trait Response
   case object LeaseAcquired extends Response
@@ -177,7 +183,7 @@ private[akka] class LeaseActor(
   }
 
   when(Granted) {
-    case Event(Heartbeat, GrantedVersion(version, _)) =>
+    case Event(Heartbeat, GrantedVersion(version, _, _, _)) =>
       log.debug("Heartbeat: updating lease time. Version {}", version)
       pipe(k8sApi.updateLeaseResource(leaseName, ownerName, version).map(WriteResponse.apply)).to(self)
       stay()
@@ -187,19 +193,55 @@ private[akka] class LeaseActor(
         "response from API server has different owner for success: " + resource)
       log.debug("Heartbeat: lease time updated: Version {}", resource.version)
       startSingleTimer("heartbeat", Heartbeat, settings.timeoutSettings.heartbeatInterval)
-      stay().using(gv.copy(version = resource.version))
-    case Event(WriteResponse(Left(lr @ _)), GrantedVersion(_, leaseLost)) =>
+      stay().using(gv.copy(version = resource.version, lastHeartbeatTime = System.nanoTime(), retryCount = 0))
+    case Event(WriteResponse(Left(lr @ _)), GrantedVersion(_, leaseLost, _, _)) =>
       log.warning("Conflict during heartbeat to lease {}. Lease assumed to be released.", lr)
       granted.set(false)
       executeLeaseLockCallback(leaseLost, None)
       goto(Idle).using(ReadRequired)
-    case Event(Failure(t), GrantedVersion(_, leaseLost)) =>
-      // FIXME, retry if timeout far enough off: https://github.com/lightbend/akka-commercial-addons/issues/501
-      log.warning("Failure during heartbeat to lease: [{}]. Lease assumed to be released.", t.getMessage)
-      granted.set(false)
-      executeLeaseLockCallback(leaseLost, Some(t))
-      goto(Idle).using(ReadRequired)
-    case Event(Release(), GrantedVersion(version, leaseLost)) =>
+    case Event(Failure(t), gv @ GrantedVersion(_, leaseLost, lastHeartbeatTime, retryCount)) =>
+      if (hasTimeLeftForHeartbeatRetry(lastHeartbeatTime)) {
+        val elapsed = (System.nanoTime() - lastHeartbeatTime).nanos
+        val nextRetry = retryCount + 1
+        val delay = heartbeatRetryDelay(nextRetry)
+        log.warning(
+          "Failure during heartbeat to lease: [{}]. Time since last successful heartbeat [{}]. Scheduling retry [{}] in [{}].",
+          t.getMessage,
+          elapsed.pretty,
+          nextRetry,
+          delay.pretty
+        )
+        startSingleTimer("heartbeat-retry", HeartbeatRetry(nextRetry), delay)
+        stay().using(gv.copy(retryCount = nextRetry))
+      } else {
+        val elapsed = (System.nanoTime() - lastHeartbeatTime).nanos
+        log.warning(
+          "Failure during heartbeat to lease: [{}]. Time since last successful heartbeat [{}] exceeds safe retry window after [{}] retries. Lease assumed lost.",
+          t.getMessage,
+          elapsed.pretty,
+          retryCount
+        )
+        granted.set(false)
+        executeLeaseLockCallback(leaseLost, Some(t))
+        goto(Idle).using(ReadRequired)
+      }
+    case Event(HeartbeatRetry(retryCount), GrantedVersion(version, leaseLost, lastHeartbeatTime, _)) =>
+      if (hasTimeLeftForHeartbeatRetry(lastHeartbeatTime)) {
+        log.info("Retrying heartbeat, attempt [{}]. Version [{}]", retryCount, version)
+        pipe(k8sApi.updateLeaseResource(leaseName, ownerName, version).map(WriteResponse.apply)).to(self)
+        stay()
+      } else {
+        val elapsed = (System.nanoTime() - lastHeartbeatTime).nanos
+        log.warning(
+          "Heartbeat retry [{}] arrived too late, time since last successful heartbeat [{}] exceeds safe retry window. Lease assumed lost.",
+          retryCount,
+          elapsed.pretty
+        )
+        granted.set(false)
+        executeLeaseLockCallback(leaseLost, None)
+        goto(Idle).using(ReadRequired)
+      }
+    case Event(Release(), GrantedVersion(version, leaseLost, _, _)) =>
       pipe(k8sApi.updateLeaseResource(leaseName, "", version).map(WriteResponse.apply)).to(self)
       goto(Releasing).using(OperationInProgress(sender(), version, leaseLost))
     case Event(Acquire(leaseLostCallback), gv: GrantedVersion) =>
@@ -253,6 +295,9 @@ private[akka] class LeaseActor(
         stateName)
       sender() ! InvalidRequest("Tried to release a lease that is not acquired")
       stay().using(data)
+    case Event(_: HeartbeatRetry, _) =>
+      // stale retry after leaving Granted state, ignore
+      stay()
     case Event(Failure(t), replyRequired: ReplyRequired) =>
       log.warning(
         "Failure communicating with the API server for owner {} lease {}: [{}]. Current state: {}",
@@ -269,6 +314,7 @@ private[akka] class LeaseActor(
       startSingleTimer("heartbeat", Heartbeat, settings.timeoutSettings.heartbeatInterval)
     case Granted -> _ =>
       cancelTimer("heartbeat")
+      cancelTimer("heartbeat-retry")
       granted.set(false)
   }
 
@@ -278,6 +324,24 @@ private[akka] class LeaseActor(
       leaseLost: Option[Throwable] => Unit): FSM.State[LeaseActor.State, Data] = {
     pipe(k8sApi.updateLeaseResource(leaseName, ownerName, version).map(r => WriteResponse(r))).to(self)
     goto(Granting).using(OperationInProgress(reply, version, leaseLost))
+  }
+
+  private def heartbeatRetryDelay(retryCount: Int): FiniteDuration = {
+    val interval = settings.timeoutSettings.heartbeatInterval
+    // Exponential backoff: interval/4, interval/2, interval, interval, ...
+    val delay = interval / 4 * (1L << math.min(retryCount - 1, 2))
+    delay.min(interval)
+  }
+
+  private def hasTimeLeftForHeartbeatRetry(lastHeartbeatTime: Long): Boolean = {
+    val elapsed = (System.nanoTime() - lastHeartbeatTime).nanos
+    // Other nodes consider the lease expired at: heartbeatTimeout - 2*heartbeatInterval.
+    // We must give up before that, subtracting:
+    // - operationTimeout: time needed to complete the retry API call itself
+    // - heartbeatInterval: additional buffer for clock skew between nodes
+    val otherNodeTakeover = settings.timeoutSettings.heartbeatTimeout - (2 * settings.timeoutSettings.heartbeatInterval)
+    val safetyMargin = settings.timeoutSettings.operationTimeout + settings.timeoutSettings.heartbeatInterval
+    elapsed < otherNodeTakeover - safetyMargin
   }
 
   private def hasLeaseTimedOut(leaseTime: Long): Boolean = {

--- a/lease-kubernetes/src/test/scala/akka/coordination/lease/kubernetes/LeaseActorSpec.scala
+++ b/lease-kubernetes/src/test/scala/akka/coordination/lease/kubernetes/LeaseActorSpec.scala
@@ -241,21 +241,44 @@ class LeaseActorSpec
       }
     }
 
-    "heartbeat fail should set granted to false" in new Test {
+    "heartbeat fail should retry and recover" in new RetryTest {
+      val k8sApiFailure = new LeaseException("Failed to communicate with API server")
+      acquireLease()
+      expectHeartBeat()
+      granted.get() shouldEqual true
+
+      // heartbeat fails
+      updateProbe.expectMsg((ownerName, currentVersion))
+      updateProbe.reply(Failure(k8sApiFailure))
+      // should still be granted
+      granted.get() shouldEqual true
+
+      // retry succeeds
+      updateProbe.expectMsg((ownerName, currentVersion))
+      incrementVersion()
+      updateProbe.reply(Right(LeaseResource(Some(ownerName), currentVersion, System.currentTimeMillis())))
+      granted.get() shouldEqual true
+
+      // next regular heartbeat
+      updateProbe.expectMsg((ownerName, currentVersion))
+    }
+
+    "heartbeat fail should set granted to false after retries exhausted" in new RetryTest {
       val k8sApiFailure = new LeaseException("Failed to communicate with API server")
       acquireLease()
       expectHeartBeat()
       granted.get() shouldEqual true
 
       updateProbe.expectMsg((ownerName, currentVersion))
-      incrementVersion()
       updateProbe.reply(Failure(k8sApiFailure))
+      // retry will be attempted, fail that too and keep failing until budget exhausted
+      heartBeatFailureUntilLost()
       awaitAssert {
         granted.get() shouldEqual false
       }
     }
 
-    "heartbeat fail should call lease lost callback" in new Test {
+    "heartbeat fail should call lease lost callback after retries exhausted" in new RetryTest {
       val k8sApiFailure = new LeaseException("Failed to communicate with API server")
       @volatile var callbackCalled: Option[Throwable] = _
       acquireLease(reason => callbackCalled = reason)
@@ -263,11 +286,37 @@ class LeaseActorSpec
       granted.get() shouldEqual true
 
       updateProbe.expectMsg((ownerName, currentVersion))
-      incrementVersion()
       updateProbe.reply(Failure(k8sApiFailure))
+      heartBeatFailureUntilLost()
       awaitAssert {
-        callbackCalled shouldEqual Some(k8sApiFailure)
+        callbackCalled should not be null
       }
+    }
+
+    "multiple heartbeat failures should keep retrying and recover" in new RetryTest {
+      val k8sApiFailure = new LeaseException("Failed to communicate with API server")
+      acquireLease()
+      expectHeartBeat()
+      granted.get() shouldEqual true
+
+      // first heartbeat fails
+      updateProbe.expectMsg((ownerName, currentVersion))
+      updateProbe.reply(Failure(k8sApiFailure))
+      granted.get() shouldEqual true
+
+      // retry also fails
+      updateProbe.expectMsg((ownerName, currentVersion))
+      updateProbe.reply(Failure(k8sApiFailure))
+      granted.get() shouldEqual true
+
+      // third attempt succeeds
+      updateProbe.expectMsg((ownerName, currentVersion))
+      incrementVersion()
+      updateProbe.reply(Right(LeaseResource(Some(ownerName), currentVersion, System.currentTimeMillis())))
+      granted.get() shouldEqual true
+
+      // regular heartbeat continues
+      updateProbe.expectMsg((ownerName, currentVersion))
     }
 
     "lock should be acquireable after heart beat conflict" in new Test {
@@ -386,9 +435,10 @@ class LeaseActorSpec
     def incrementVersion() = currentVersionCount += 1
     val leaseProbe = TestProbe()
     val updateProbe = TestProbe()
-    val mockKubernetesApi = new MockKubernetesApi(system, leaseProbe.ref, updateProbe.ref)
+    lazy val mockKubernetesApi = new MockKubernetesApi(system, leaseProbe.ref, updateProbe.ref)
     val granted = new AtomicBoolean(false)
-    val underTest = system.actorOf(LeaseActor.props(mockKubernetesApi, leaseSettings, leaseSettings.leaseName, granted))
+    lazy val underTest =
+      system.actorOf(LeaseActor.props(mockKubernetesApi, leaseSettings, leaseSettings.leaseName, granted))
     val senderProbe = TestProbe()
     implicit val sender: ActorRef = senderProbe.ref
 
@@ -469,12 +519,38 @@ class LeaseActorSpec
 
     def heartBeatFailure(): Unit = {
       updateProbe.expectMsg((ownerName, currentVersion))
-      incrementVersion()
+      // Note: don't increment version here, the actor retries with the same version on failure
       updateProbe.reply(Failure(new LeaseException("Failed to communicate with API server")))
+      heartBeatFailureUntilLost()
       awaitAssert {
         granted.get() shouldEqual false
       }
     }
 
+    def heartBeatFailureUntilLost(): Unit = {
+      // keep failing retries until the time budget is exhausted
+      while (granted.get()) {
+        try {
+          val msg = updateProbe.expectMsg(leaseSettings.timeoutSettings.heartbeatTimeout, (ownerName, currentVersion))
+          updateProbe.reply(Failure(new LeaseException("Failed to communicate with API server")))
+        } catch {
+          case _: AssertionError => // no more retries, budget exhausted
+        }
+      }
+    }
+
+  }
+
+  // Test trait with realistic timeout ratios where retry budget is positive.
+  // Generous timeouts to avoid flaky failures in CI where pauses of 500ms+ can occur.
+  // heartbeatInterval=1s, heartbeatTimeout=20s, operationTimeout=2s (1:20 ratio)
+  // Retry budget: (20s - 2s) - (2s + 1s) = 15s
+  // Retry delay: 500ms (heartbeatInterval / 2)
+  trait RetryTest extends Test {
+    override val leaseSettings: LeaseSettings = new LeaseSettings(
+      leaseName,
+      ownerName,
+      new TimeoutSettings(1.second, 20.seconds, 2.seconds),
+      ConfigFactory.empty())
   }
 }


### PR DESCRIPTION
Backport of https://github.com/akka/akka-management/pull/1441 into `1.5.x`