### PR TITLE
build: Don't email about build failures from PRs

### DIFF
--- a/.github/actions/email-on-failure/action.yml
+++ b/.github/actions/email-on-failure/action.yml
@@ -1,0 +1,29 @@
+name: Email on failure
+description: Send a notification email when a workflow job fails.
+inputs:
+  username:
+    description: SMTP username
+    required: true
+  password:
+    description: SMTP password
+    required: true
+  to:
+    description: Recipient address
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Send email
+      uses: dawidd6/action-send-mail@v12
+      with:
+        server_address: smtp.gmail.com
+        server_port: 465
+        secure: true
+        username: ${{ inputs.username }}
+        password: ${{ inputs.password }}
+        subject: "Failed: ${{ github.workflow }} / ${{ github.job }}"
+        to: ${{ inputs.to }}
+        from: Akka CI
+        body: |
+          Job ${{ github.job }} in workflow ${{ github.workflow }} of ${{ github.repository }} failed!
+          https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -43,16 +43,8 @@ jobs:
 
       - name: Email on failure
         if: ${{ failure() }}
-        uses: dawidd6/action-send-mail@v12
+        uses: ./.github/actions/email-on-failure
         with:
-          server_address: smtp.gmail.com
-          server_port: 465
-          secure: true
-          username: ${{secrets.MAIL_USERNAME}}
-          password: ${{secrets.MAIL_PASSWORD}}
-          subject: "Failed: ${{ github.workflow }} / ${{ github.job }}"
-          to: ${{secrets.MAIL_SEND_TO}}
-          from: Akka CI
-          body: |
-            Job ${{ github.job }} in workflow ${{ github.workflow }} of ${{github.repository}} failed!
-            https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+          username: ${{ secrets.MAIL_USERNAME }}
+          password: ${{ secrets.MAIL_PASSWORD }}
+          to: ${{ secrets.MAIL_SEND_TO }}

--- a/.github/workflows/integration-tests-app-version-revision.yml
+++ b/.github/workflows/integration-tests-app-version-revision.yml
@@ -62,17 +62,9 @@ jobs:
         run: find . -name "*.log" -exec ./scripts/cat-log.sh {} \;
 
       - name: Email on failure
-        if: ${{ failure() }}
-        uses: dawidd6/action-send-mail@v12
+        if: ${{ failure() && github.event_name != 'pull_request' }}
+        uses: ./.github/actions/email-on-failure
         with:
-          server_address: smtp.gmail.com
-          server_port: 465
-          secure: true
-          username: ${{secrets.MAIL_USERNAME}}
-          password: ${{secrets.MAIL_PASSWORD}}
-          subject: "Failed: ${{ github.workflow }} / ${{ github.job }}"
-          to: ${{secrets.MAIL_SEND_TO}}
-          from: Akka CI
-          body: |
-            Job ${{ github.job }} in workflow ${{ github.workflow }} of ${{github.repository}} failed!
-            https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+          username: ${{ secrets.MAIL_USERNAME }}
+          password: ${{ secrets.MAIL_PASSWORD }}
+          to: ${{ secrets.MAIL_SEND_TO }}

--- a/.github/workflows/integration-tests-kube-api.yml
+++ b/.github/workflows/integration-tests-kube-api.yml
@@ -61,17 +61,9 @@ jobs:
         run: find . -name "*.log" -exec ./scripts/cat-log.sh {} \;
 
       - name: Email on failure
-        if: ${{ failure() }}
-        uses: dawidd6/action-send-mail@v12
+        if: ${{ failure() && github.event_name != 'pull_request' }}
+        uses: ./.github/actions/email-on-failure
         with:
-          server_address: smtp.gmail.com
-          server_port: 465
-          secure: true
-          username: ${{secrets.MAIL_USERNAME}}
-          password: ${{secrets.MAIL_PASSWORD}}
-          subject: "Failed: ${{ github.workflow }} / ${{ github.job }}"
-          to: ${{secrets.MAIL_SEND_TO}}
-          from: Akka CI
-          body: |
-            Job ${{ github.job }} in workflow ${{ github.workflow }} of ${{github.repository}} failed!
-            https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+          username: ${{ secrets.MAIL_USERNAME }}
+          password: ${{ secrets.MAIL_PASSWORD }}
+          to: ${{ secrets.MAIL_SEND_TO }}

--- a/.github/workflows/integration-tests-kube-dns.yml
+++ b/.github/workflows/integration-tests-kube-dns.yml
@@ -61,17 +61,9 @@ jobs:
         run: find . -name "*.log" -exec ./scripts/cat-log.sh {} \;
 
       - name: Email on failure
-        if: ${{ failure() }}
-        uses: dawidd6/action-send-mail@v12
+        if: ${{ failure() && github.event_name != 'pull_request' }}
+        uses: ./.github/actions/email-on-failure
         with:
-          server_address: smtp.gmail.com
-          server_port: 465
-          secure: true
-          username: ${{secrets.MAIL_USERNAME}}
-          password: ${{secrets.MAIL_PASSWORD}}
-          subject: "Failed: ${{ github.workflow }} / ${{ github.job }}"
-          to: ${{secrets.MAIL_SEND_TO}}
-          from: Akka CI
-          body: |
-            Job ${{ github.job }} in workflow ${{ github.workflow }} of ${{github.repository}} failed!
-            https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+          username: ${{ secrets.MAIL_USERNAME }}
+          password: ${{ secrets.MAIL_PASSWORD }}
+          to: ${{ secrets.MAIL_SEND_TO }}

--- a/.github/workflows/integration-tests-lease.yml
+++ b/.github/workflows/integration-tests-lease.yml
@@ -70,17 +70,9 @@ jobs:
         run: find . -name "*.log" -exec ./scripts/cat-log.sh {} \;
 
       - name: Email on failure
-        if: ${{ failure() }}
-        uses: dawidd6/action-send-mail@v12
+        if: ${{ failure() && github.event_name != 'pull_request' }}
+        uses: ./.github/actions/email-on-failure
         with:
-          server_address: smtp.gmail.com
-          server_port: 465
-          secure: true
-          username: ${{secrets.MAIL_USERNAME}}
-          password: ${{secrets.MAIL_PASSWORD}}
-          subject: "Failed: ${{ github.workflow }} / ${{ github.job }}"
-          to: ${{secrets.MAIL_SEND_TO}}
-          from: Akka CI
-          body: |
-            Job ${{ github.job }} in workflow ${{ github.workflow }} of ${{github.repository}} failed!
-            https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+          username: ${{ secrets.MAIL_USERNAME }}
+          password: ${{ secrets.MAIL_PASSWORD }}
+          to: ${{ secrets.MAIL_SEND_TO }}

--- a/.github/workflows/integration-tests-rolling-update-cr.yml
+++ b/.github/workflows/integration-tests-rolling-update-cr.yml
@@ -71,17 +71,9 @@ jobs:
         run: find . -name "*.log" -exec ./scripts/cat-log.sh {} \;
 
       - name: Email on failure
-        if: ${{ failure() }}
-        uses: dawidd6/action-send-mail@v12
+        if: ${{ failure() && github.event_name != 'pull_request' }}
+        uses: ./.github/actions/email-on-failure
         with:
-          server_address: smtp.gmail.com
-          server_port: 465
-          secure: true
-          username: ${{secrets.MAIL_USERNAME}}
-          password: ${{secrets.MAIL_PASSWORD}}
-          subject: "Failed: ${{ github.workflow }} / ${{ github.job }}"
-          to: ${{secrets.MAIL_SEND_TO}}
-          from: Akka CI
-          body: |
-            Job ${{ github.job }} in workflow ${{ github.workflow }} of ${{github.repository}} failed!
-            https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+          username: ${{ secrets.MAIL_USERNAME }}
+          password: ${{ secrets.MAIL_PASSWORD }}
+          to: ${{ secrets.MAIL_SEND_TO }}

--- a/.github/workflows/integration-tests-rolling-update.yml
+++ b/.github/workflows/integration-tests-rolling-update.yml
@@ -62,17 +62,9 @@ jobs:
         run: find . -name "*.log" -exec ./scripts/cat-log.sh {} \;
 
       - name: Email on failure
-        if: ${{ failure() }}
-        uses: dawidd6/action-send-mail@v12
+        if: ${{ failure() && github.event_name != 'pull_request' }}
+        uses: ./.github/actions/email-on-failure
         with:
-          server_address: smtp.gmail.com
-          server_port: 465
-          secure: true
-          username: ${{secrets.MAIL_USERNAME}}
-          password: ${{secrets.MAIL_PASSWORD}}
-          subject: "Failed: ${{ github.workflow }} / ${{ github.job }}"
-          to: ${{secrets.MAIL_SEND_TO}}
-          from: Akka CI
-          body: |
-            Job ${{ github.job }} in workflow ${{ github.workflow }} of ${{github.repository}} failed!
-            https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+          username: ${{ secrets.MAIL_USERNAME }}
+          password: ${{ secrets.MAIL_PASSWORD }}
+          to: ${{ secrets.MAIL_SEND_TO }}

--- a/.github/workflows/integration-tests-samples.yml
+++ b/.github/workflows/integration-tests-samples.yml
@@ -61,17 +61,9 @@ jobs:
         run: find . -name "*.log" -exec ./scripts/cat-log.sh {} \;
 
       - name: Email on failure
-        if: ${{ failure() }}
-        uses: dawidd6/action-send-mail@v12
+        if: ${{ failure() && github.event_name != 'pull_request' }}
+        uses: ./.github/actions/email-on-failure
         with:
-          server_address: smtp.gmail.com
-          server_port: 465
-          secure: true
-          username: ${{secrets.MAIL_USERNAME}}
-          password: ${{secrets.MAIL_PASSWORD}}
-          subject: "Failed: ${{ github.workflow }} / ${{ github.job }}"
-          to: ${{secrets.MAIL_SEND_TO}}
-          from: Akka CI
-          body: |
-            Job ${{ github.job }} in workflow ${{ github.workflow }} of ${{github.repository}} failed!
-            https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+          username: ${{ secrets.MAIL_USERNAME }}
+          password: ${{ secrets.MAIL_PASSWORD }}
+          to: ${{ secrets.MAIL_SEND_TO }}

--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -46,17 +46,9 @@ jobs:
         run: cs launch net.runne::site-link-validator:0.2.5 -- scripts/link-validator.conf
 
       - name: Email on failure
-        if: ${{ failure() }}
-        uses: dawidd6/action-send-mail@v12
+        if: ${{ failure() && github.event_name != 'pull_request' }}
+        uses: ./.github/actions/email-on-failure
         with:
-          server_address: smtp.gmail.com
-          server_port: 465
-          secure: true
-          username: ${{secrets.MAIL_USERNAME}}
-          password: ${{secrets.MAIL_PASSWORD}}
-          subject: "Failed: ${{ github.workflow }} / ${{ github.job }}"
-          to: ${{secrets.MAIL_SEND_TO}}
-          from: Akka CI
-          body: |
-            Job ${{ github.job }} in workflow ${{ github.workflow }} of ${{github.repository}} failed!
-            https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+          username: ${{ secrets.MAIL_USERNAME }}
+          password: ${{ secrets.MAIL_PASSWORD }}
+          to: ${{ secrets.MAIL_SEND_TO }}

--- a/.github/workflows/native-image-tests.yml
+++ b/.github/workflows/native-image-tests.yml
@@ -58,16 +58,8 @@ jobs:
 
       - name: Email on failure
         if: ${{ failure() }}
-        uses: dawidd6/action-send-mail@v12
+        uses: ./.github/actions/email-on-failure
         with:
-          server_address: smtp.gmail.com
-          server_port: 465
-          secure: true
-          username: ${{secrets.MAIL_USERNAME}}
-          password: ${{secrets.MAIL_PASSWORD}}
-          subject: "Failed: ${{ github.workflow }} / ${{ github.job }}"
-          to: ${{secrets.MAIL_SEND_TO}}
-          from: Akka CI
-          body: |
-            Job ${{ github.job }} in workflow ${{ github.workflow }} of ${{github.repository}} failed!
-            https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+          username: ${{ secrets.MAIL_USERNAME }}
+          password: ${{ secrets.MAIL_PASSWORD }}
+          to: ${{ secrets.MAIL_SEND_TO }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -64,17 +64,9 @@ jobs:
         run: find . -name "*.log" -exec ./scripts/cat-log.sh {} \;
 
       - name: Email on failure
-        if: ${{ failure() }}
-        uses: dawidd6/action-send-mail@v12
+        if: ${{ failure() && github.event_name != 'pull_request' }}
+        uses: ./.github/actions/email-on-failure
         with:
-          server_address: smtp.gmail.com
-          server_port: 465
-          secure: true
-          username: ${{secrets.MAIL_USERNAME}}
-          password: ${{secrets.MAIL_PASSWORD}}
-          subject: "Failed: ${{ github.workflow }} / ${{ github.job }}"
-          to: ${{secrets.MAIL_SEND_TO}}
-          from: Akka CI
-          body: |
-            Job ${{ github.job }} in workflow ${{ github.workflow }} of ${{github.repository}} failed!
-            https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+          username: ${{ secrets.MAIL_USERNAME }}
+          password: ${{ secrets.MAIL_PASSWORD }}
+          to: ${{ secrets.MAIL_SEND_TO }}


### PR DESCRIPTION
We only want nightlies and fails in main sent there. PR failures are seen right away by PR author and reviewers anyway

Also, pull email on fail into a shared action to repeat a bit less stuff
