### PR TITLE
bump: Azure API uses Jackson Databind

### DIFF
--- a/artifact-bom/akka-discovery-azure-api/pom.xml
+++ b/artifact-bom/akka-discovery-azure-api/pom.xml
@@ -34,17 +34,17 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>2.18.7</version>
+                <version>2.18.8</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
-                <version>2.18.7</version>
+                <version>2.18.8</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.18.7</version>
+                <version>2.18.8</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.datatype</groupId>
@@ -297,17 +297,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.18.7</version>
+            <version>2.18.8</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.18.7</version>
+            <version>2.18.8</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.18.7</version>
+            <version>2.18.8</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -51,7 +51,7 @@ object Dependencies {
     "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
     "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
     "org.scalatest" %% "scalatest" % ScalaTestVersion % Test
-  )
+  ) ++ JacksonDatabind
 
   val DiscoveryMarathonApi = Seq(
     "com.typesafe.akka" %% "akka-actor" % AkkaVersion,


### PR DESCRIPTION
As some of the other cloud provider libraries, the Azure API also uses Jackson Databind internally. This makes sure its version aligns with the exact Jackson version used across Akka.

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References
- https://github.com/akka/akka-management/pull/1454#pullrequestreview-4626815297